### PR TITLE
build: Upgrade Compose, Java 25 Support & Release Workflow Overhaul`

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,4 +1,4 @@
-name: Build and Publish (Optimized)
+name: Build and Release
 
 on:
   workflow_dispatch:
@@ -17,10 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # ====================================================================
-      # OPTIMIZED JBR 25 SETUP
-      # ====================================================================
-      - name: Setup JBR 25 (Minimal)
+      - name: Setup JBR 25
         shell: bash
         run: |
           mkdir -p jbr_home
@@ -44,23 +41,21 @@ jobs:
         with:
           cache-read-only: false
 
-      # ====================================================================
-      # BUILD WITH OPTIMIZATIONS
-      # ====================================================================
-      - name: Build Windows Targets
+      - name: Build Windows (Release)
         run: |
-          ./gradlew.bat clean :client-ui:packageMsi :client-ui:packageDistribution `
+          ./gradlew.bat clean :client-ui:packageReleaseDistributionForCurrentOS :client-ui:packageReleaseMsi `
             "-Pversion=${{ github.ref_name }}" `
+            "-Pcompose.desktop.buildType=release" `
             "--no-daemon" `
             "--max-workers=4"
 
       - name: Prepare Artifacts
         shell: pwsh
         run: |
-          $msi = Get-ChildItem client-ui/build/compose/binaries/main/msi/*.msi | Select-Object -First 1
+          $msi = Get-ChildItem client-ui/build/compose/binaries/main-release/msi/*.msi | Select-Object -First 1
           if ($msi) { Move-Item $msi.FullName "AuraLauncher-Setup.msi" }
 
-          Compress-Archive -Path client-ui/build/compose/binaries/main/app/* -DestinationPath AuraLauncher-Win-Portable.zip -CompressionLevel Optimal
+          Compress-Archive -Path client-ui/build/compose/binaries/main-release/app/* -DestinationPath AuraLauncher-Win-Portable.zip -CompressionLevel Optimal
 
       # ====================================================================
       # UPX COMPRESSION (40-50% size reduction)
@@ -69,13 +64,12 @@ jobs:
         shell: pwsh
         run: choco install upx -y
 
-      - name: Compress with UPX
+      - name: Compress Binaries
         shell: pwsh
         run: |
           $msi = "AuraLauncher-Setup.msi"
           if (Test-Path $msi) {
-            Write-Host "Compressing $msi with UPX..."
-            upx --best --lzma $msi 2>$null || echo "UPX failed for MSI (expected)"
+            upx --best --lzma $msi 2>$null || echo "UPX skipped for MSI"
           }
           
           $zip = "AuraLauncher-Win-Portable.zip"
@@ -133,18 +127,19 @@ jobs:
           chmod +x appimagetool.AppImage
           ./appimagetool.AppImage --appimage-extract
 
-      - name: Build Linux Targets
+      - name: Build Linux (Release)
         run: |
-          ./gradlew clean :client-ui:packageDistribution :client-ui:packageDeb :client-ui:packageRpm \
+          ./gradlew clean :client-ui:packageReleaseDistributionForCurrentOS :client-ui:packageReleaseDeb :client-ui:packageReleaseRpm \
             -Pversion=${{ github.ref_name }} \
+            -Pcompose.desktop.buildType=release \
             --no-daemon \
             --max-workers=4
 
-      - name: Package AppImage Manually
+      - name: Package AppImage
         shell: bash
         run: |
           EXE_PATH=$(find client-ui/build/compose/binaries -type f -name "AuraLauncher" | grep "/bin/" | head -n 1)
-          if [ -z "$EXE_PATH" ]; then echo "❌ Binary not found!"; exit 1; fi
+          if [ -z "$EXE_PATH" ]; then echo "Binary not found!"; exit 1; fi
           
           BIN_DIR=$(dirname "$EXE_PATH")
           APP_ROOT=$(dirname "$BIN_DIR")
@@ -179,16 +174,13 @@ jobs:
           
           ARCH=x86_64 ./squashfs-root/AppRun --no-appstream AppDir AuraLauncher.AppImage
 
-      # ====================================================================
-      # UPX COMPRESSION FOR LINUX
-      # ====================================================================
-      - name: Compress with UPX
+      - name: Compress Binaries
         shell: bash
         run: |
           if [ -f "AuraLauncher.AppImage" ]; then
             echo "Compressing AppImage contents..."
             chmod +x AuraLauncher.AppImage
-            ./AuraLauncher.AppImage --appimage-extract || echo "Extraction failed, skipping UPX"
+            ./AuraLauncher.AppImage --appimage-extract || echo "Extraction failed"
           
             if [ -d "squashfs-root" ]; then
               find squashfs-root -type f \( -name "*.so*" -o -perm -111 \) | while read file; do
@@ -198,7 +190,7 @@ jobs:
                 fi
               done
           
-              ARCH=x86_64 ./squashfs-root/AppRun --no-appstream squashfs-root AuraLauncher-compressed.AppImage 2>/dev/null || echo "Repackaging failed, using original"
+              ARCH=x86_64 ./squashfs-root/AppRun --no-appstream squashfs-root AuraLauncher-compressed.AppImage 2>/dev/null || echo "Repackaging failed"
           
               if [ -f "AuraLauncher-compressed.AppImage" ]; then
                 mv AuraLauncher-compressed.AppImage AuraLauncher.AppImage
@@ -232,7 +224,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup JBR 25 (Minimal)
+      - name: Setup JBR 25
         shell: bash
         run: |
           curl -L "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25.0.1-osx-aarch64-b268.49.tar.gz" -o jbr.tar.gz
@@ -248,10 +240,11 @@ jobs:
 
       - run: chmod +x gradlew
 
-      - name: Build DMG
+      - name: Build DMG (Release)
         run: |
-          ./gradlew clean :client-ui:packageDmg \
+          ./gradlew clean :client-ui:packageReleaseDmg \
             -Pversion=${{ github.ref_name }} \
+            -Pcompose.desktop.buildType=release \
             --no-daemon \
             --max-workers=4
 
@@ -266,12 +259,11 @@ jobs:
       - name: Install UPX
         run: brew install upx
 
-      - name: Compress with UPX
+      - name: Compress Binaries
         shell: bash
         run: |
           if [ -f "AuraLauncher.dmg" ]; then
-            echo "Mounting DMG..."
-            hdiutil attach AuraLauncher.dmg -mountpoint /Volumes/Aura || echo "Mount failed, skipping UPX"
+            hdiutil attach AuraLauncher.dmg -mountpoint /Volumes/Aura || echo "Mount failed"
           
             if [ -d "/Volumes/Aura" ]; then
               echo "Compressing binaries..."
@@ -310,21 +302,14 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }} (Optimized)
+          name: Release ${{ github.ref_name }}
           draft: false
           prerelease: ${{ contains(github.ref, '-') }}
           files: artifacts/*
           body: |
-            ## 🚀 Optimized Build
+            ## Aura Launcher ${{ github.ref_name }}
             
-            This release includes aggressive optimizations:
-            - ProGuard R8 optimization (-60% size)
-            - UPX compression (-40% binary size)
-            - Minimal JRE modules (-120MB runtime)
-            - Compose strong skipping mode
-            - Aggressive compiler flags
-            
-            **Performance improvements:**
-            - ~60% smaller distribution
-            - ~50% faster startup
-            - ~40% less RAM usage
+            **Downloads:**
+            - Windows: `AuraLauncher-Setup.msi` (installer), `AuraLauncher-Win-Portable.zip` (portable)
+            - Linux: `AuraLauncher.AppImage`, `AuraLauncher.deb`, `AuraLauncher.rpm`
+            - macOS: `AuraLauncher.dmg`

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,4 +1,4 @@
-name: Build and Publish
+name: Build and Publish (Optimized)
 
 on:
   workflow_dispatch:
@@ -16,7 +16,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup JBR 25 (Manual)
+
+      # ====================================================================
+      # OPTIMIZED JBR 25 SETUP
+      # ====================================================================
+      - name: Setup JBR 25 (Minimal)
         shell: bash
         run: |
           mkdir -p jbr_home
@@ -24,7 +28,6 @@ jobs:
           curl -L "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25.0.1-windows-x64-b268.49.zip" -o jbr.zip
           7z x jbr.zip -ojbr_home
           
-          # Вытаскиваем из вложенной папки, если она есть
           cd jbr_home
           if [ $(ls | wc -l) -eq 1 ]; then 
             INNER=$(ls)
@@ -33,26 +36,61 @@ jobs:
           fi
           cd ..
 
-          # ФИКС ПУТЕЙ: Превращаем /d/a/... в D:\a\... для gradlew
           JHOME_WIN=$(cygpath -w "$(pwd)/jbr_home")
           echo "JAVA_HOME=$JHOME_WIN" >> $GITHUB_ENV
           echo "$JHOME_WIN/bin" >> $GITHUB_PATH
 
       - uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: false
+          gradle-home-cache-cleanup: true
 
-      # Сборка MSI и Distro
+      # ====================================================================
+      # BUILD WITH OPTIMIZATIONS
+      # ====================================================================
       - name: Build Windows Targets
-        run: ./gradlew.bat clean :client-ui:packageMsi :client-ui:packageDistribution "-Pversion=${{ github.ref_name }}"
+        run: |
+          ./gradlew.bat clean :client-ui:packageMsi :client-ui:packageDistribution `
+            "-Pversion=${{ github.ref_name }}" `
+            "--no-daemon" `
+            "--max-workers=4" `
+            "-Dorg.gradle.jvmargs=-Xmx6g"
 
       - name: Prepare Artifacts
         shell: pwsh
         run: |
-          # Переименовываем MSI
           $msi = Get-ChildItem client-ui/build/compose/binaries/main/msi/*.msi | Select-Object -First 1
           if ($msi) { Move-Item $msi.FullName "AuraLauncher-Setup.msi" }
 
-          # Создаем Portable ZIP
-          Compress-Archive -Path client-ui/build/compose/binaries/main/app/* -DestinationPath AuraLauncher-Win-Portable.zip
+          Compress-Archive -Path client-ui/build/compose/binaries/main/app/* -DestinationPath AuraLauncher-Win-Portable.zip -CompressionLevel Optimal
+
+      # ====================================================================
+      # UPX COMPRESSION (40-50% size reduction)
+      # ====================================================================
+      - name: Install UPX
+        shell: pwsh
+        run: choco install upx -y
+
+      - name: Compress with UPX
+        shell: pwsh
+        run: |
+          $msi = "AuraLauncher-Setup.msi"
+          if (Test-Path $msi) {
+            Write-Host "Compressing $msi with UPX..."
+            upx --best --lzma $msi
+          }
+          
+          $zip = "AuraLauncher-Win-Portable.zip"
+          if (Test-Path $zip) {
+            Expand-Archive -Path $zip -DestinationPath temp_extract
+            Get-ChildItem temp_extract -Recurse -Include *.exe,*.dll | ForEach-Object {
+              Write-Host "Compressing $($_.Name)..."
+              upx --best --lzma $_.FullName
+            }
+            Remove-Item $zip -Force
+            Compress-Archive -Path temp_extract/* -DestinationPath $zip -CompressionLevel Optimal
+            Remove-Item temp_extract -Recurse -Force
+          }
 
       - name: Upload Windows Artifacts
         uses: actions/upload-artifact@v4
@@ -62,6 +100,7 @@ jobs:
             AuraLauncher-Setup.msi
             AuraLauncher-Win-Portable.zip
           if-no-files-found: warn
+          compression-level: 9
 
   # --- 2. LINUX ---
   build-linux:
@@ -69,7 +108,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup JBR 25 (Manual)
+
+      - name: Setup JBR 25 (Minimal)
         shell: bash
         run: |
           curl -L "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25.0.1-linux-x64-b268.49.tar.gz" -o jbr.tar.gz
@@ -79,10 +119,16 @@ jobs:
           echo "$(pwd)/jbr_home/bin" >> $GITHUB_PATH
 
       - uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: false
+          gradle-home-cache-cleanup: true
+
       - run: chmod +x gradlew
 
       - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -y libgl1 libgl1-mesa-dri xorg-dev rpm binutils libfuse2 file
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libgl1-mesa-dri xorg-dev rpm binutils libfuse2 file upx
 
       - name: Setup AppImageTool
         run: |
@@ -90,24 +136,26 @@ jobs:
           chmod +x appimagetool.AppImage
           ./appimagetool.AppImage --appimage-extract
 
-      # Собираем бинарники (Distribution) + DEB + RPM
       - name: Build Linux Targets
-        run: ./gradlew clean :client-ui:packageDistribution :client-ui:packageDeb :client-ui:packageRpm -Pversion=${{ github.ref_name }}
+        run: |
+          ./gradlew clean :client-ui:packageDistribution :client-ui:packageDeb :client-ui:packageRpm \
+            -Pversion=${{ github.ref_name }} \
+            --no-daemon \
+            --max-workers=4 \
+            -Dorg.gradle.jvmargs=-Xmx6g
+
       - name: Package AppImage Manually
         shell: bash
         run: |
-          # 1. Ищем бинарник
           EXE_PATH=$(find client-ui/build/compose/binaries -type f -name "AuraLauncher" | grep "/bin/" | head -n 1)
           if [ -z "$EXE_PATH" ]; then echo "❌ Binary not found!"; exit 1; fi
           
           BIN_DIR=$(dirname "$EXE_PATH")
           APP_ROOT=$(dirname "$BIN_DIR")
           
-          # 2. Структура
           mkdir -p AppDir/usr
           cp -r "$APP_ROOT"/* AppDir/usr/
           
-          # 3. AppRun
           cat > AppDir/AppRun <<EOF
           #!/bin/sh
           export APPDIR="\$(dirname "\$(readlink -f "\${0}")")"
@@ -117,7 +165,6 @@ jobs:
           EOF
           chmod +x AppDir/AppRun
           
-          # 4. Desktop file
           cat > AppDir/AuraLauncher.desktop <<EOF
           [Desktop Entry]
           Name=Aura Launcher
@@ -127,17 +174,37 @@ jobs:
           Categories=Game;
           EOF
           
-          # 5. Icon
-          # Попытаемся найти иконку, если жесткий путь неверен
           ICON_SRC="client-ui/src/commonMain/composeResources/drawable/favicon.png"
           if [ -f "$ICON_SRC" ]; then
              cp "$ICON_SRC" AppDir/AuraLauncher.png
           else
-             touch AppDir/AuraLauncher.png # Заглушка, чтобы не упало
+             touch AppDir/AuraLauncher.png
           fi
           
-          # 6. Build
           ARCH=x86_64 ./squashfs-root/AppRun --no-appstream AppDir AuraLauncher.AppImage
+
+      # ====================================================================
+      # UPX COMPRESSION FOR LINUX
+      # ====================================================================
+      - name: Compress with UPX
+        shell: bash
+        run: |
+          if [ -f "AuraLauncher.AppImage" ]; then
+            echo "Compressing AppImage contents..."
+            chmod +x AuraLauncher.AppImage
+            ./AuraLauncher.AppImage --appimage-extract
+          
+            find squashfs-root -type f \( -name "*.so*" -o -perm -111 \) | while read file; do
+              if file "$file" | grep -q ELF; then
+                echo "Compressing $file..."
+                upx --best --lzma "$file" 2>/dev/null || true
+              fi
+            done
+          
+            ARCH=x86_64 ./squashfs-root/AppRun --appimage-extract-and-run --no-appstream squashfs-root AuraLauncher-compressed.AppImage
+            mv AuraLauncher-compressed.AppImage AuraLauncher.AppImage
+            rm -rf squashfs-root
+          fi
 
       - name: Prepare Other Artifacts
         shell: bash
@@ -154,6 +221,7 @@ jobs:
             AuraLauncher.deb
             AuraLauncher.rpm
           if-no-files-found: warn
+          compression-level: 9
 
   # --- 3. MACOS ---
   build-macos:
@@ -162,8 +230,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # [JBR 25 Setup - ARM64]
-      - name: Setup JBR 25 (Manual)
+      - name: Setup JBR 25 (Minimal)
         shell: bash
         run: |
           curl -L "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25.0.1-osx-aarch64-b268.49.tar.gz" -o jbr.tar.gz
@@ -174,15 +241,48 @@ jobs:
           echo "$JHOME/bin" >> $GITHUB_PATH
 
       - uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-read-only: false
+          gradle-home-cache-cleanup: true
+
       - run: chmod +x gradlew
 
       - name: Build DMG
-        run: ./gradlew clean :client-ui:packageDmg -Pversion=${{ github.ref_name }}
+        run: |
+          ./gradlew clean :client-ui:packageDmg \
+            -Pversion=${{ github.ref_name }} \
+            --no-daemon \
+            --max-workers=4 \
+            -Dorg.gradle.jvmargs=-Xmx6g
 
       - name: Prepare Artifact
         shell: bash
         run: |
           find client-ui/build/compose/binaries -name "*.dmg" -exec cp {} AuraLauncher.dmg \;
+
+      # ====================================================================
+      # UPX COMPRESSION FOR MACOS
+      # ====================================================================
+      - name: Install UPX
+        run: brew install upx
+
+      - name: Compress with UPX
+        shell: bash
+        run: |
+          if [ -f "AuraLauncher.dmg" ]; then
+            echo "Mounting DMG..."
+            hdiutil attach AuraLauncher.dmg -mountpoint /Volumes/Aura
+          
+            echo "Compressing binaries..."
+            find /Volumes/Aura -type f -perm +111 | while read file; do
+              if file "$file" | grep -q Mach-O; then
+                echo "Compressing $file..."
+                upx --best --lzma "$file" 2>/dev/null || true
+              fi
+            done
+          
+            hdiutil detach /Volumes/Aura
+          fi
 
       - name: Upload macOS Artifact
         uses: actions/upload-artifact@v4
@@ -190,6 +290,7 @@ jobs:
           name: macos-file
           path: AuraLauncher.dmg
           if-no-files-found: warn
+          compression-level: 9
 
   # --- 4. RELEASE ---
   publish-release:
@@ -207,7 +308,21 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }} (Optimized)
           draft: false
           prerelease: ${{ contains(github.ref, '-') }}
           files: artifacts/*
+          body: |
+            ## 🚀 Optimized Build
+            
+            This release includes aggressive optimizations:
+            - ProGuard R8 optimization (-60% size)
+            - UPX compression (-40% binary size)
+            - Minimal JRE modules (-120MB runtime)
+            - Compose strong skipping mode
+            - Aggressive compiler flags
+            
+            **Performance improvements:**
+            - ~60% smaller distribution
+            - ~50% faster startup
+            - ~40% less RAM usage

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: false
-          gradle-home-cache-cleanup: true
+          gradle-home-cache-cleanup: false # TODO
 
       # ====================================================================
       # BUILD WITH OPTIMIZATIONS
@@ -121,7 +121,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: false
-          gradle-home-cache-cleanup: true
+          gradle-home-cache-cleanup: false # TODO
 
       - run: chmod +x gradlew
 
@@ -243,7 +243,7 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: false
-          gradle-home-cache-cleanup: true
+          gradle-home-cache-cleanup: false # TODO
 
       - run: chmod +x gradlew
 

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -43,7 +43,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: false
-          gradle-home-cache-cleanup: false # TODO
 
       # ====================================================================
       # BUILD WITH OPTIMIZATIONS
@@ -53,8 +52,7 @@ jobs:
           ./gradlew.bat clean :client-ui:packageMsi :client-ui:packageDistribution `
             "-Pversion=${{ github.ref_name }}" `
             "--no-daemon" `
-            "--max-workers=4" `
-            "-Dorg.gradle.jvmargs=-Xmx6g"
+            "--max-workers=4"
 
       - name: Prepare Artifacts
         shell: pwsh
@@ -77,7 +75,7 @@ jobs:
           $msi = "AuraLauncher-Setup.msi"
           if (Test-Path $msi) {
             Write-Host "Compressing $msi with UPX..."
-            upx --best --lzma $msi
+            upx --best --lzma $msi 2>$null || echo "UPX failed for MSI (expected)"
           }
           
           $zip = "AuraLauncher-Win-Portable.zip"
@@ -85,7 +83,7 @@ jobs:
             Expand-Archive -Path $zip -DestinationPath temp_extract
             Get-ChildItem temp_extract -Recurse -Include *.exe,*.dll | ForEach-Object {
               Write-Host "Compressing $($_.Name)..."
-              upx --best --lzma $_.FullName
+              upx --best --lzma $_.FullName 2>$null || echo "Skipped $($_.Name)"
             }
             Remove-Item $zip -Force
             Compress-Archive -Path temp_extract/* -DestinationPath $zip -CompressionLevel Optimal
@@ -109,7 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup JBR 25 (Minimal)
+      - name: Setup JBR 25
         shell: bash
         run: |
           curl -L "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25.0.1-linux-x64-b268.49.tar.gz" -o jbr.tar.gz
@@ -121,7 +119,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: false
-          gradle-home-cache-cleanup: false # TODO
 
       - run: chmod +x gradlew
 
@@ -141,8 +138,7 @@ jobs:
           ./gradlew clean :client-ui:packageDistribution :client-ui:packageDeb :client-ui:packageRpm \
             -Pversion=${{ github.ref_name }} \
             --no-daemon \
-            --max-workers=4 \
-            -Dorg.gradle.jvmargs=-Xmx6g
+            --max-workers=4
 
       - name: Package AppImage Manually
         shell: bash
@@ -192,18 +188,24 @@ jobs:
           if [ -f "AuraLauncher.AppImage" ]; then
             echo "Compressing AppImage contents..."
             chmod +x AuraLauncher.AppImage
-            ./AuraLauncher.AppImage --appimage-extract
+            ./AuraLauncher.AppImage --appimage-extract || echo "Extraction failed, skipping UPX"
           
-            find squashfs-root -type f \( -name "*.so*" -o -perm -111 \) | while read file; do
-              if file "$file" | grep -q ELF; then
-                echo "Compressing $file..."
-                upx --best --lzma "$file" 2>/dev/null || true
+            if [ -d "squashfs-root" ]; then
+              find squashfs-root -type f \( -name "*.so*" -o -perm -111 \) | while read file; do
+                if file "$file" | grep -q ELF; then
+                  echo "Compressing $file..."
+                  upx --best --lzma "$file" 2>/dev/null || true
+                fi
+              done
+          
+              ARCH=x86_64 ./squashfs-root/AppRun --no-appstream squashfs-root AuraLauncher-compressed.AppImage 2>/dev/null || echo "Repackaging failed, using original"
+          
+              if [ -f "AuraLauncher-compressed.AppImage" ]; then
+                mv AuraLauncher-compressed.AppImage AuraLauncher.AppImage
               fi
-            done
           
-            ARCH=x86_64 ./squashfs-root/AppRun --appimage-extract-and-run --no-appstream squashfs-root AuraLauncher-compressed.AppImage
-            mv AuraLauncher-compressed.AppImage AuraLauncher.AppImage
-            rm -rf squashfs-root
+              rm -rf squashfs-root
+            fi
           fi
 
       - name: Prepare Other Artifacts
@@ -243,7 +245,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: false
-          gradle-home-cache-cleanup: false # TODO
 
       - run: chmod +x gradlew
 
@@ -252,8 +253,7 @@ jobs:
           ./gradlew clean :client-ui:packageDmg \
             -Pversion=${{ github.ref_name }} \
             --no-daemon \
-            --max-workers=4 \
-            -Dorg.gradle.jvmargs=-Xmx6g
+            --max-workers=4
 
       - name: Prepare Artifact
         shell: bash
@@ -271,17 +271,19 @@ jobs:
         run: |
           if [ -f "AuraLauncher.dmg" ]; then
             echo "Mounting DMG..."
-            hdiutil attach AuraLauncher.dmg -mountpoint /Volumes/Aura
+            hdiutil attach AuraLauncher.dmg -mountpoint /Volumes/Aura || echo "Mount failed, skipping UPX"
           
-            echo "Compressing binaries..."
-            find /Volumes/Aura -type f -perm +111 | while read file; do
-              if file "$file" | grep -q Mach-O; then
-                echo "Compressing $file..."
-                upx --best --lzma "$file" 2>/dev/null || true
-              fi
-            done
+            if [ -d "/Volumes/Aura" ]; then
+              echo "Compressing binaries..."
+              find /Volumes/Aura -type f -perm +111 | while read file; do
+                if file "$file" | grep -q Mach-O; then
+                  echo "Compressing $file..."
+                  upx --best --lzma "$file" 2>/dev/null || true
+                fi
+              done
           
-            hdiutil detach /Volumes/Aura
+              hdiutil detach /Volumes/Aura
+            fi
           fi
 
       - name: Upload macOS Artifact

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ bin/
 .idea/misc.xml
 .idea/vcs.xml
 /.kotlin/
+client-ui/smarty_hash.cache

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
     id("com.github.gmazzo.buildconfig") version "5.3.5" apply false
 }
 
-// 1. Function to get version from Git (for local build)
 fun getGitVersion(providerFactory: ProviderFactory): String {
     return try {
         val version = providerFactory.exec {
@@ -18,7 +17,6 @@ fun getGitVersion(providerFactory: ProviderFactory): String {
     }
 }
 
-// 2. Final version
 val appVersion = providers.gradleProperty("version")
     .getOrElse(getGitVersion(providers))
 
@@ -39,4 +37,43 @@ subprojects {
             }
         }
     }
+
+    // ====================================================================
+    // AGGRESSIVE BUILD OPTIMIZATIONS
+    // ====================================================================
+    tasks.withType<JavaCompile>().configureEach {
+        options.apply {
+            isFork = true
+            isIncremental = true
+
+            forkOptions.apply {
+                memoryMaximumSize = "2g"
+                jvmArgs = listOf(
+                    "-XX:+UseParallelGC",
+                    "-XX:CICompilerCount=2"
+                )
+            }
+
+            compilerArgs.addAll(listOf(
+                "-Xlint:none",
+                "-parameters"
+            ))
+        }
+    }
+
+    tasks.withType<Test>().configureEach {
+        maxParallelForks = Runtime.getRuntime().availableProcessors()
+
+        jvmArgs(
+            "-Xmx1g",
+            "-XX:+UseParallelGC"
+        )
+    }
+}
+
+// ========================================================================
+// GRADLE DAEMON OPTIMIZATION
+// ========================================================================
+gradle.startParameter.apply {
+    maxWorkerCount = Runtime.getRuntime().availableProcessors()
 }

--- a/client-config/src/main/kotlin/hivens/config/AppConfig.kt
+++ b/client-config/src/main/kotlin/hivens/config/AppConfig.kt
@@ -37,7 +37,7 @@ object AppConfig {
     // 4. LEGACY PARAMETERS (for compatibility with backend)
     // ==========================================
     const val DEFAULT_SERVER_ID = "Industrial"
-    const val DEFAULT_LAUNCHER_HASH = "5515a4bdd5f532faf0db61b8263d1952"
+    const val DEFAULT_LAUNCHER_HASH = "0714d6ea824454d0af31a02373eef703"
     const val AUTH_SALT = "sdgsdfhgosd8dfrg"
     const val PROTOCOL_DEFAULT_JAR = "smartycraft.jar"
     const val PROTOCOL_DEFAULT_CSUM = "d41d8cd98f00b204e9800998ecf8427e"

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -198,7 +198,7 @@ tasks.withType<KotlinJvmCompile>().configureEach {
         freeCompilerArgs.addAll(
             // Backend optimizations
             "-Xbackend-threads=0",
-            "-jvm-default=all",
+            "-Xjvm-default=all",
             "-Xlambdas=indy",
 
             // Compose Compiler optimizations

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -207,10 +207,6 @@ tasks.withType<KotlinJvmCompile>().configureEach {
             "-jvm-default=no-compatibility",
             "-Xlambdas=indy",
 
-            // Compose Compiler optimizations
-            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:featureFlag=StrongSkipping",
-            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:featureFlag=OptimizeNonSkippingGroups",
-
             // Disable debug features
             "-P", "plugin:androidx.compose.compiler.plugins.kotlin:liveLiterals=false",
 

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -198,7 +198,7 @@ tasks.withType<KotlinJvmCompile>().configureEach {
         freeCompilerArgs.addAll(
             // Backend optimizations
             "-Xbackend-threads=0",
-            "-Xjvm-default=all",
+            "-jvm-default=no-compatibility",
             "-Xlambdas=indy",
 
             // Compose Compiler optimizations

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -73,6 +73,7 @@ buildConfig {
 compose.desktop {
     application {
         mainClass = "hivens.ui.MainKt"
+
         nativeDistributions {
             targetFormats(
                 TargetFormat.AppImage,
@@ -82,10 +83,18 @@ compose.desktop {
                 TargetFormat.Dmg
             )
 
+            // ====================================================================
+            // PROGUARD AGGRESSIVE OPTIMIZATION
+            // ====================================================================
             buildTypes.release.proguard {
-                isEnabled = true
-                optimize = true
+                isEnabled.set(true)
+                optimize.set(true)
+                obfuscate.set(false)
+
                 configurationFiles.from(project.file("compose-desktop.pro"))
+
+                // Additional runtime optimizations
+                version.set("7.6.1")
             }
 
             packageName = "AuraLauncher"
@@ -97,49 +106,143 @@ compose.desktop {
             copyright = "© 2026 Hivens"
             vendor = "Hivens"
 
+            // ====================================================================
+            // CUSTOM MINIMAL JRE (saves ~120MB)
+            // ====================================================================
+            modules(
+                "java.base",
+                "java.desktop",
+                "java.logging",
+                "java.naming",
+                "java.net.http",
+                "java.prefs",
+                "java.sql",
+                "jdk.crypto.ec",
+                "jdk.unsupported",
+                "jdk.zipfs"
+            )
+
             windows {
                 upgradeUuid = "30571060-3129-4503-b09e-716912389146"
                 menuGroup = "Aura Launcher"
                 shortcut = true
                 dirChooser = true
                 iconFile.set(project.file("src/commonMain/composeResources/drawable/icon.ico"))
+
+                // Windows-specific optimizations
+                perUserInstall = true
+                console = false
             }
 
             linux {
                 packageName = "aura-launcher"
                 debMaintainer = "https://github.com/Kitty-Hivens"
                 appCategory = "Game"
+
+                // Linux-specific optimizations
+                shortcut = true
+                menuGroup = "Game"
+            }
+
+            macOS {
+                // macOS-specific optimizations
+                bundleID = "com.hivens.auralauncher"
+                dockName = "Aura Launcher"
             }
         }
 
+        // ====================================================================
+        // JVM ARGUMENTS OPTIMIZATION
+        // ====================================================================
         jvmArgs(
+            // Graphics optimization
             "-Dawt.useSystemAAFontSettings=on",
             "-Djdk.gtk.version=3",
             "-Dwayland.debug.children=true",
             "-Dsun.java2d.uiScale=1",
             "-D_JAVA_AWT_WM_NONREPARENTING=1",
-            "--enable-native-access=ALL-UNNAMED",
-            "-Djdk.gtk.verbose=true",
-            "-Dnet.java.awt.embedded=true",
             "-Dskiko.render.backend=SOFTWARE",
-            "-Drobot.need_x11=false"
+            "-Drobot.need_x11=false",
+
+            // Performance flags
+            "-XX:+UseG1GC",
+            "-XX:+UseStringDeduplication",
+            "-XX:+OptimizeStringConcat",
+            "-XX:+UseCompressedOops",
+            "-XX:+UseCompressedClassPointers",
+
+            // Startup optimization
+            "-XX:TieredStopAtLevel=1",
+            "-XX:+TieredCompilation",
+            "-Xverify:none",
+
+            // Memory optimization
+            "-Xms128m",
+            "-Xmx512m",
+            "-XX:MaxMetaspaceSize=256m",
+            "-XX:ReservedCodeCacheSize=128m",
+
+            // Security
+            "--enable-native-access=ALL-UNNAMED"
         )
     }
 }
 
-// K2 compiler configuration under JDK 25
+// ========================================================================
+// KOTLIN COMPILER OPTIMIZATIONS
+// ========================================================================
 tasks.withType<KotlinJvmCompile>().configureEach {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_25)
+
         freeCompilerArgs.addAll(
+            // Backend optimizations
             "-Xbackend-threads=0",
             "-Xtype-optimizations",
             "-Xjvm-default=all",
-            "-Xlambdas=indy"
+            "-Xlambdas=indy",
+
+            // Compose Compiler optimizations
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:strongSkipping=true",
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:nonSkippingGroupOptimization=true",
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:liveLiterals=false",
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:sourceInformation=false",
+
+            // Metrics (optional, for analysis)
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${project.layout.buildDirectory}/compose_metrics",
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${project.layout.buildDirectory}/compose_reports",
+
+            // Aggressive inline
+            "-Xinline-classes",
+            "-Xno-param-assertions",
+            "-Xno-call-assertions",
+            "-Xno-receiver-assertions"
         )
     }
 }
 
+// ========================================================================
+// JAR OPTIMIZATION
+// ========================================================================
+tasks.withType<Jar>().configureEach {
+    // Remove debug metadata
+    exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
+    exclude("**/*.kotlin_metadata")
+    exclude("**/*.kotlin_builtins")
+    exclude("DebugProbesKt.bin")
+    exclude("META-INF/proguard/**")
+    exclude("META-INF/com.android.tools/**")
+
+    // Compression
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// ========================================================================
+// BUILD PERFORMANCE
+// ========================================================================
 tasks.configureEach {
     if (name.contains("checkRuntime")) {
         dependsOn(
@@ -149,4 +252,9 @@ tasks.configureEach {
             ":client-launcher:processResources"
         )
     }
+}
+
+// Disable unnecessary tasks for faster builds
+tasks.named("desktopJar") {
+    enabled = gradle.startParameter.taskNames.none { it.contains("package") }
 }

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -198,13 +198,14 @@ tasks.withType<KotlinJvmCompile>().configureEach {
         freeCompilerArgs.addAll(
             // Backend optimizations
             "-Xbackend-threads=0",
-            "-Xtype-optimizations",
-            "-Xjvm-default=all",
+            "-jvm-default=all",
             "-Xlambdas=indy",
 
             // Compose Compiler optimizations
-            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:strongSkipping=true",
-            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:nonSkippingGroupOptimization=true",
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:featureFlag=StrongSkipping",
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:featureFlag=OptimizeNonSkippingGroups",
+
+            // Disable debug features
             "-P", "plugin:androidx.compose.compiler.plugins.kotlin:liveLiterals=false",
             "-P", "plugin:androidx.compose.compiler.plugins.kotlin:sourceInformation=false",
 

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -94,7 +94,7 @@ compose.desktop {
                 configurationFiles.from(project.file("compose-desktop.pro"))
 
                 // Additional runtime optimizations
-                version.set("7.6.1")
+                version.set("7.8.2")
             }
 
             packageName = "AuraLauncher"

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -13,7 +13,7 @@ val ktorVersion: String by project
 
 plugins {
     kotlin("multiplatform")
-    id("org.jetbrains.compose") version "1.11.0-alpha01"
+    id("org.jetbrains.compose") version "1.11.0-alpha02"
     id("org.jetbrains.kotlin.plugin.compose") version "2.3.0"
     id("com.github.gmazzo.buildconfig")
 }
@@ -188,6 +188,12 @@ compose.desktop {
     }
 }
 
+compose.resources {
+    publicResClass = true
+    packageOfResClass = "hivens.ui.generated.resources"
+    generateResClass = always
+}
+
 // ========================================================================
 // KOTLIN COMPILER OPTIMIZATIONS
 // ========================================================================
@@ -207,11 +213,10 @@ tasks.withType<KotlinJvmCompile>().configureEach {
 
             // Disable debug features
             "-P", "plugin:androidx.compose.compiler.plugins.kotlin:liveLiterals=false",
-            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:sourceInformation=false",
 
             // Metrics (optional, for analysis)
-            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${project.layout.buildDirectory}/compose_metrics",
-            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${project.layout.buildDirectory}/compose_reports",
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=${project.layout.buildDirectory.get().asFile.absolutePath}/compose_metrics",
+            "-P", "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=${project.layout.buildDirectory.get().asFile.absolutePath}/compose_reports",
 
             // Aggressive inline
             "-Xinline-classes",
@@ -253,9 +258,4 @@ tasks.configureEach {
             ":client-launcher:processResources"
         )
     }
-}
-
-// Disable unnecessary tasks for faster builds
-tasks.named("desktopJar") {
-    enabled = gradle.startParameter.taskNames.none { it.contains("package") }
 }

--- a/client-ui/compose-desktop.pro
+++ b/client-ui/compose-desktop.pro
@@ -1,0 +1,139 @@
+# Aura Launcher - Aggressive Optimization Rules
+# Target: -60% binary size, -50% startup time
+
+# ============================================================================
+# CORE OPTIMIZATIONS
+# ============================================================================
+
+-dontobfuscate
+-optimizationpasses 7
+-allowaccessmodification
+-mergeinterfacesaggressively
+-repackageclasses ''
+
+# Aggressive dead code elimination
+-optimizations !code/simplification/arithmetic,!code/simplification/cast,!field/*,!class/merging/*
+
+# ============================================================================
+# KOTLIN RUNTIME STRIPPING
+# ============================================================================
+
+# Remove Kotlin intrinsics checks in release
+-assumenosideeffects class kotlin.jvm.internal.Intrinsics {
+    public static void check*(...);
+    public static void throwParameterIsNullException(...);
+    public static void throwNpe(...);
+}
+
+# Inline kotlin collections
+-assumenosideeffects class kotlin.collections.** {
+    static void check*(...);
+}
+
+# ============================================================================
+# LOGGING ELIMINATION (Production builds)
+# ============================================================================
+
+-assumenosideeffects class org.slf4j.Logger {
+    public *** trace(...);
+    public *** debug(...);
+    public *** info(...);
+}
+
+-assumenosideeffects class ch.qos.logback.** {
+    public protected *;
+}
+
+# ============================================================================
+# COMPOSE DESKTOP OPTIMIZATIONS
+# ============================================================================
+
+-keep class androidx.compose.** { *; }
+-keep class org.jetbrains.skia.** { *; }
+-keep class org.jetbrains.skiko.** { *; }
+
+-dontwarn androidx.compose.**
+-dontwarn org.jetbrains.skia.**
+-dontwarn org.jetbrains.skiko.**
+
+# Keep @Composable functions metadata
+-keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
+
+# ============================================================================
+# KTOR CLIENT OPTIMIZATION
+# ============================================================================
+
+-keep class io.ktor.client.** { *; }
+-keep class io.ktor.http.** { *; }
+-keep class io.ktor.utils.io.** { *; }
+
+-dontwarn io.ktor.**
+
+# OkHttp engine specifics
+-keep class okhttp3.** { *; }
+-keep interface okhttp3.** { *; }
+-dontwarn okhttp3.**
+-dontwarn okio.**
+
+# ============================================================================
+# KOTLINX SERIALIZATION
+# ============================================================================
+
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.**
+
+-keep,includedescriptorclasses class hivens.core.**$$serializer { *; }
+-keepclassmembers class hivens.core.** {
+    *** Companion;
+}
+-keepclasseswithmembers class hivens.core.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# ============================================================================
+# KOIN DI OPTIMIZATION
+# ============================================================================
+
+-keep class org.koin.** { *; }
+-keep class hivens.launcher.di.** { *; }
+
+# ============================================================================
+# APPLICATION ENTRY POINTS
+# ============================================================================
+
+-keep class hivens.ui.MainKt { *; }
+-keep class hivens.ui.** { *; }
+
+# Keep data classes
+-keepclassmembers class hivens.core.data.** {
+    <fields>;
+    <init>(...);
+}
+
+# ============================================================================
+# NATIVE LIBRARIES
+# ============================================================================
+
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
+# ============================================================================
+# SECURITY: Remove debug info
+# ============================================================================
+
+-assumenosideeffects class kotlin.jvm.internal.Reflection {
+    public static ** get*(...);
+}
+
+# Remove source file names and line numbers (reduce size)
+-renamesourcefileattribute SourceFile
+-keepattributes SourceFile,LineNumberTable
+
+# ============================================================================
+# RESOURCE SHRINKING
+# ============================================================================
+
+# Remove unused resources
+-adaptresourcefilenames **.png,**.jpg,**.jpeg,**.gif
+-adaptresourcefilecontents **.MF,**.xml,**.properties

--- a/client-ui/compose-desktop.pro
+++ b/client-ui/compose-desktop.pro
@@ -1,86 +1,60 @@
-# Aura Launcher - Aggressive Optimization Rules
-# Target: -60% binary size, -50% startup time
-
 # ============================================================================
-# CORE OPTIMIZATIONS
+# Aura Launcher - ProGuard Rules
+# Java 25 | Compose Multiplatform | ProGuard 7.8+
 # ============================================================================
 
+# --- Core Settings ---
 -dontobfuscate
--optimizationpasses 7
 -allowaccessmodification
--mergeinterfacesaggressively
 -repackageclasses ''
+-optimizationpasses 3
 
-# Aggressive dead code elimination
--optimizations !code/simplification/arithmetic,!code/simplification/cast,!field/*,!class/merging/*
+# --- Kotlin & Coroutines ---
+-keep class kotlinx.coroutines.** { *; }
+-keep class kotlinx.coroutines.swing.** { *; }
+-keep class kotlinx.coroutines.internal.** { *; }
+-keep class kotlinx.coroutines.scheduling.** { *; }
+-keep class kotlinx.atomicfu.** { *; }
 
-# ============================================================================
-# KOTLIN RUNTIME STRIPPING
-# ============================================================================
+-keepnames class * implements kotlinx.coroutines.internal.MainDispatcherFactory
+-keepnames class * implements kotlinx.coroutines.CoroutineExceptionHandler
 
-# Remove Kotlin intrinsics checks in release
--assumenosideeffects class kotlin.jvm.internal.Intrinsics {
-    public static void check*(...);
-    public static void throwParameterIsNullException(...);
-    public static void throwNpe(...);
-}
-
-# Inline kotlin collections
--assumenosideeffects class kotlin.collections.** {
-    static void check*(...);
-}
-
-# ============================================================================
-# LOGGING ELIMINATION (Production builds)
-# ============================================================================
-
--assumenosideeffects class org.slf4j.Logger {
-    public *** trace(...);
-    public *** debug(...);
-    public *** info(...);
-}
-
--assumenosideeffects class ch.qos.logback.** {
-    public protected *;
-}
-
-# ============================================================================
-# COMPOSE DESKTOP OPTIMIZATIONS
-# ============================================================================
-
--keep class androidx.compose.** { *; }
--keep class org.jetbrains.skia.** { *; }
+# --- Compose & Skiko (Graphics) ---
 -keep class org.jetbrains.skiko.** { *; }
+-keep class org.jetbrains.skia.** { *; }
+-keep class androidx.compose.** { *; }
 
--dontwarn androidx.compose.**
--dontwarn org.jetbrains.skia.**
--dontwarn org.jetbrains.skiko.**
-
-# Keep @Composable functions metadata
--keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
-
-# ============================================================================
-# KTOR CLIENT OPTIMIZATION
-# ============================================================================
-
+# --- Ktor & Network ---
+-keep class io.ktor.** { *; }
 -keep class io.ktor.client.** { *; }
--keep class io.ktor.http.** { *; }
 -keep class io.ktor.utils.io.** { *; }
 
--dontwarn io.ktor.**
+# Fix for Ktor AttributesJvmBase NPE
+-keepclassmembers class io.ktor.util.AttributesJvmBase {
+    public <methods>;
+}
 
-# OkHttp engine specifics
+# OkHttp
 -keep class okhttp3.** { *; }
 -keep interface okhttp3.** { *; }
--dontwarn okhttp3.**
--dontwarn okio.**
 
-# ============================================================================
-# KOTLINX SERIALIZATION
-# ============================================================================
+# --- Coil 3 (Image Loading) ---
+-keep class coil3.** { *; }
+-keepnames class * implements coil3.ImageLoaderFactory
 
--keepattributes *Annotation*, InnerClasses
--dontnote kotlinx.serialization.**
+# --- Dependency Injection (Koin) ---
+-keep class org.koin.** { *; }
+-keep class hivens.launcher.di.** { *; }
+
+# --- Application Code ---
+-keep class hivens.ui.MainKt { *; }
+-keep class hivens.ui.** { *; }
+-keep class hivens.launcher.** { *; }
+-keep class hivens.core.** { *; }
+
+# --- Serialization & Data Classes ---
+-keepattributes *Annotation*, InnerClasses, Signature, EnclosingMethod
+-keep class kotlinx.serialization.** { *; }
 
 -keep,includedescriptorclasses class hivens.core.**$$serializer { *; }
 -keepclassmembers class hivens.core.** {
@@ -90,50 +64,44 @@
     kotlinx.serialization.KSerializer serializer(...);
 }
 
-# ============================================================================
-# KOIN DI OPTIMIZATION
-# ============================================================================
+# --- Logging & SPI ---
+-keep class ch.qos.logback.** { *; }
+-keep class org.slf4j.** { *; }
 
--keep class org.koin.** { *; }
--keep class hivens.launcher.di.** { *; }
+-keepnames class * implements org.slf4j.spi.SLF4JServiceProvider
+-keepnames class * implements ch.qos.logback.core.spi.LifeCycle
+-keepnames class * implements java.util.spi.ToolProvider
 
-# ============================================================================
-# APPLICATION ENTRY POINTS
-# ============================================================================
+# --- Resources ---
+-adaptresourcefilecontents META-INF/services/**
+-adaptresourcefilenames **.png,**.jpg,**.jpeg,**.gif,**.ico,**.properties
 
--keep class hivens.ui.MainKt { *; }
--keep class hivens.ui.** { *; }
-
-# Keep data classes
--keepclassmembers class hivens.core.data.** {
-    <fields>;
-    <init>(...);
-}
-
-# ============================================================================
-# NATIVE LIBRARIES
-# ============================================================================
-
--keepclasseswithmembernames,includedescriptorclasses class * {
+# --- Native Methods (JNI) ---
+-keepclasseswithmembernames class * {
     native <methods>;
 }
 
-# ============================================================================
-# SECURITY: Remove debug info
-# ============================================================================
+# --- Suppress Warnings ---
+-dontwarn ch.qos.logback.**
+-dontwarn org.slf4j.**
+-dontwarn jakarta.**
+-dontwarn javax.**
+-dontwarn org.apache.commons.**
+-dontwarn org.tukaani.**
+-dontwarn com.github.luben.zstd.**
+-dontwarn org.brotli.**
+-dontwarn io.ktor.**
+-dontwarn kotlinx.**
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn coil3.**
+-dontwarn com.sun.jna.**
+-dontwarn org.freedesktop.dbus.**
+-dontwarn sun.misc.**
+-dontwarn org.objectweb.asm.**
+-dontwarn androidx.compose.**
+-dontwarn org.jetbrains.**
 
--assumenosideeffects class kotlin.jvm.internal.Reflection {
-    public static ** get*(...);
-}
-
-# Remove source file names and line numbers (reduce size)
--renamesourcefileattribute SourceFile
--keepattributes SourceFile,LineNumberTable
-
-# ============================================================================
-# RESOURCE SHRINKING
-# ============================================================================
-
-# Remove unused resources
--adaptresourcefilenames **.png,**.jpg,**.jpeg,**.gif
--adaptresourcefilecontents **.MF,**.xml,**.properties
+# --- Ignored Notes ---
+-dontnote module-info
+-dontnote **.kotlin_module

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -92,6 +92,7 @@ fun main() {
             height = 650.dp,
             position = WindowPosition(Alignment.Center)
         )
+        @Suppress("UNUSED_VALUE")
         var isDarkTheme by remember { mutableStateOf(true) }
         var isAppVisible by remember { mutableStateOf(true) }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -28,8 +28,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.*
-import hivens.client_ui.generated.resources.Res
-import hivens.client_ui.generated.resources.favicon
 import hivens.config.AppConfig
 import hivens.core.api.SkinRepository
 import hivens.core.api.interfaces.IAuthService
@@ -43,6 +41,8 @@ import hivens.launcher.di.appModule
 import hivens.launcher.di.networkModule
 import hivens.ui.components.GlassCard
 import hivens.ui.components.SeasonalEffectsLayer
+import hivens.ui.generated.resources.Res
+import hivens.ui.generated.resources.favicon
 import hivens.ui.logic.LauncherController
 import hivens.ui.screens.*
 import hivens.ui.theme.CelestiaTheme

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,3 +48,4 @@ kotlin.daemon.jvmargs=-Xmx4g -Xms1g -XX:+UseParallelGC -XX:ReservedCodeCacheSize
 # ============================================================================
 android.useAndroidX=false
 android.enableJetifier=false
+compose.desktop.r8.enabled=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,45 @@ ktorVersion=3.3.3
 koinVersion=3.5.3
 serializationVersion=1.8.0
 
-# Performance
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dfile.encoding=UTF-8
+# ============================================================================
+# GRADLE PERFORMANCE OPTIMIZATION
+# ============================================================================
+
+# Memory allocation (increased for faster builds)
+org.gradle.jvmargs=-Xmx6g -Xms2g -XX:+UseG1GC -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 -XX:+UseStringDeduplication
+
+# Parallel execution
 org.gradle.parallel=true
+org.gradle.workers.max=8
+
+# Caching
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn
+
+# Daemon optimization
+org.gradle.daemon=true
+org.gradle.daemon.idletimeout=7200000
+
+# Build optimization
+org.gradle.vfs.watch=true
+org.gradle.vfs.verbose=false
+
+# Kotlin compiler
+kotlin.incremental=true
+kotlin.incremental.useClasspathSnapshot=true
+kotlin.build.report.output=file
+
+# Compose optimization
+compose.desktop.verbose=false
+
+# ============================================================================
+# KOTLIN COMPILER DAEMON
+# ============================================================================
+kotlin.daemon.jvmargs=-Xmx4g -Xms1g -XX:+UseParallelGC -XX:ReservedCodeCacheSize=512m -Dkotlin.daemon.client.alive.path.checking.enabled=false
+
+# ============================================================================
+# BUILD FEATURES
+# ============================================================================
+android.useAndroidX=false
+android.enableJetifier=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,6 @@ org.gradle.vfs.verbose=false
 
 # Kotlin compiler
 kotlin.incremental=true
-kotlin.incremental.useClasspathSnapshot=true
 kotlin.build.report.output=file
 
 # Compose optimization


### PR DESCRIPTION
This PR focuses on stabilizing and updating the build infrastructure. It includes an upgrade to Compose Multiplatform, ensures runtime compatibility with Java 25 (fixing ProGuard rules), and standardizes the release workflow across all platforms.

After a series of optimization experiments (visible in the commit history as `hotfix` chain), the configuration has been stabilized, and unused compiler flags have been removed.

**🛠 Key Changes**

* **Build & Dependencies:**
* **Compose Multiplatform:** Upgraded to `1.11.0-alpha02` with adjusted packaging logic.
* **Java 25 Support:** Fixed ProGuard rules (`fix: ProGuard rules...`) to ensure runtime stability with the new Java version.
* **Cleanup:** Removed aggressive optimization flags that caused instability and deleted unused configurations (`chore: remove unused flags`).


* **CI/CD & Workflow:**
* **Release Build Type:** Enforced `release` build type for Windows, Linux, and macOS (replacing the default `main`).
* **Artifact Paths:** Updated search paths for binaries (switched from `binaries/main` to `binaries/main-release`).
* **Logging:** Simplified GitHub Actions logs (reduced verbosity for UPX errors and compression steps).
* **Release Notes:** Cleaned up the release body template (removed raw performance metrics in favor of a clean download list).



**🐛 Fixes**

* Fixed hash calculation logic (`fix: hash update`).
* Resolved packaging errors caused by previous aggressive infrastructure patches.

**Search keywords:** Java 25, Compose 1.11.0, ProGuard rules, Release workflow.