### PR TITLE
fix(build): add java.management module to bundled JRE

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -193,7 +193,7 @@ jobs:
           # 1. Build the minimal JRE first — jlink refuses to write into an existing dir
           jlink \
             --output "$APPDIR/usr" \
-            --add-modules java.base,java.desktop,java.logging,java.naming,java.net.http,java.prefs,java.sql,jdk.crypto.ec,jdk.unsupported,jdk.zipfs \
+            --add-modules java.base,java.desktop,java.logging,java.management,java.naming,java.net.http,java.prefs,java.sql,jdk.crypto.ec,jdk.unsupported,jdk.zipfs \
             --no-header-files \
             --no-man-pages \
             --strip-debug \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Aura Launcher will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+## [2.0.1] - 2026-03-14
+
+### Fixed
+- About screen crash on packaged builds (`java.management` missing from bundled JRE)
 
 ## [2.0.0] - 2026-03-14
 

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -131,6 +131,7 @@ compose.desktop {
                 "java.base",
                 "java.desktop",
                 "java.logging",
+                "java.management",
                 "java.naming",
                 "java.net.http",
                 "java.prefs",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Infrastructure
 kotlinVersion=2.3.20-RC3
-appVersion=2.0.0
+appVersion=2.0.1
 
 # Core Dependencies
 ktorVersion=3.4.1


### PR DESCRIPTION
ManagementFactory (used in AboutScreen and RamSelector for system RAM and heap info) was missing from jlink module list, causing NoClassDefFoundError at runtime in packaged builds.