### PR TITLE
fix(memory): partial native Skia leak fix in CustomBackground and SkinManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Aura Launcher will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+## [2.0.3] - 2026-03-15
+
+### ⚠️ Known Issue - Custom Background
+> **It is highly recommended not to use the Custom Background feature in this version.**
+> Despite the partial fix for the native memory leak, enabling/disabling the background
+> does not release resources completely, but animated GIFs/WebPs continue to accumulate
+> native Skia objects. The function will be redesigned in the next release.
+> Use at your own risk.
+
+### Fixed
+- **Partial native memory leak fix in `CustomBackground`**: replaced `toImageBitmapSafe()`
+  (shallow `Bitmap.asComposeImageBitmap()` wrapper) with `Image.makeFromBitmap` +
+  `toComposeImageBitmap()` + `img.close()` in both static and animated paths.
+  `toImageBitmapSafe()` extension removed entirely. `ManagedSCleanerThunk` count reduced
+  from 645 to 468 in VisualVM heap dump.
+- **Partial native memory leak fix in `SkinManager`**: `Canvas` in `skiaImageToBitmap`
+  now closed via `try/finally`; all `Image.makeFromEncoded` call sites in
+  `getSkinFront`/`getSkinBack` close the Skia `Image` immediately after
+  `toComposeImageBitmap()`; `saveBitmapToDisk` closes intermediate `Image` after encode.
+
+### Known Remaining Issues
+- Toggle off/on of custom background does not fully release native Skia resources
+- Animated GIF/WebP frames continue to accumulate `SkiaBackedImageBitmap` instances
+  until GC decides to collect them — JVM does not account for native memory pressure
+- Root cause: `Image.toComposeImageBitmap()` on Compose Multiplatform desktop wraps
+  rather than deep-copies pixel data; closing the source `Image` may invalidate the
+  returned `ImageBitmap`. Full fix requires rewrite using a proper image-loading
+  library with desktop GIF support (Coil 3 does not support animated GIF on desktop).
+
 ## [2.0.2] - 2026-03-14
 
 ### Fixed

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/background/CustomBackground.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/background/CustomBackground.kt
@@ -15,10 +15,10 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.asComposeImageBitmap
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -26,12 +26,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.withContext
-import org.jetbrains.skia.Bitmap
-import org.jetbrains.skia.Canvas
 import org.jetbrains.skia.Codec
-import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.Data
-import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.makeFromFileName
 import java.io.File
 
@@ -171,30 +167,6 @@ private fun AnimatedParallaxImage(
     }
 }
 
-/**
- * Converts a Skia Bitmap to ImageBitmap without leaking a Canvas.
- *
- * The standard toComposeImageBitmap() creates a Canvas internally and never
- * closes it, causing native memory to accumulate over time. This function
- * explicitly closes the Canvas after use.
- */
-private fun Bitmap.toImageBitmapSafe(): ImageBitmap {
-    val dst = Bitmap()
-    dst.allocPixels(ImageInfo.makeS32(width, height, ColorAlphaType.PREMUL))
-    val canvas = Canvas(dst)
-    try {
-        val image = org.jetbrains.skia.Image.makeFromBitmap(this)
-        try {
-            canvas.drawImage(image, 0f, 0f)
-        } finally {
-            image.close()
-        }
-    } finally {
-        canvas.close()
-    }
-    return dst.asComposeImageBitmap()
-}
-
 @Composable
 private fun rememberSkiaImage(file: File): ImageBitmap? {
     var bitmap by remember(file) { mutableStateOf<ImageBitmap?>(null) }
@@ -203,19 +175,24 @@ private fun rememberSkiaImage(file: File): ImageBitmap? {
         if (!file.exists()) return@LaunchedEffect
 
         withContext(Dispatchers.IO) {
-            var data:  Data?   = null
-            var codec: Codec?  = null
-            var bmp:   Bitmap? = null
+            var data:  Data?                      = null
+            var codec: Codec?                     = null
+            var bmp:   org.jetbrains.skia.Bitmap? = null
 
             try {
                 data  = Data.makeFromFileName(file.absolutePath)
                 codec = Codec.makeFromData(data)
-                bmp   = Bitmap().apply { allocPixels(codec.imageInfo) }
+                bmp   = org.jetbrains.skia.Bitmap().apply { allocPixels(codec.imageInfo) }
 
                 if (codec.frameCount <= 1) {
-                    // Static image — decode once, convert safely, done
+                    // Static image — decode once, convert via full pixel copy, done
                     codec.readPixels(bmp, 0)
-                    bitmap = bmp.toImageBitmapSafe()
+                    val img = org.jetbrains.skia.Image.makeFromBitmap(bmp)
+                    try {
+                        bitmap = img.toComposeImageBitmap()
+                    } finally {
+                        img.close()
+                    }
                 } else {
                     // Animated GIF/WebP — decode frame by frame
                     var frame      = 0
@@ -225,8 +202,15 @@ private fun rememberSkiaImage(file: File): ImageBitmap? {
                         if (frame == 0) { bmp.erase(0); priorFrame = -1 }
 
                         codec.readPixels(bmp, frame, priorFrame)
-                        // Use safe conversion to avoid Canvas leak on every frame
-                        bitmap = bmp.toImageBitmapSafe()
+
+                        // Full pixel copy into JVM heap — Skia Image is closed immediately,
+                        // no native memory accumulation between frames.
+                        val img = org.jetbrains.skia.Image.makeFromBitmap(bmp)
+                        try {
+                            bitmap = img.toComposeImageBitmap()
+                        } finally {
+                            img.close()
+                        }
 
                         var duration = codec.framesInfo[frame].duration
                         if (duration < 30) duration = 100

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/utils/SkinManager.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/utils/SkinManager.kt
@@ -2,6 +2,7 @@ package hivens.ui.utils
 
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
 import hivens.config.AppConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -73,8 +74,11 @@ object SkinManager {
         if (diskFile.exists() && !isExpired(diskFile)) {
             try {
                 val skiaImage = org.jetbrains.skia.Image.makeFromEncoded(diskFile.readBytes())
-                val bitmap = skiaImageToBitmap(skiaImage)
-                val result = bitmap.asComposeImageBitmap()
+                val result = try {
+                    skiaImage.toComposeImageBitmap()
+                } finally {
+                    skiaImage.close()
+                }
                 frontCache[nickname] = result
                 logger.debug("Front skin loaded from disk cache: {}", nickname)
                 return@withContext result
@@ -87,7 +91,10 @@ object SkinManager {
         // 3. Download and render
         val rawSkin = getOrDownloadRawSkin(nickname) ?: return@withContext null
         val processed = assembleSkin(rawSkin, isFront = true, cloak = null)
-        val result = processed.asComposeImageBitmap()
+        val result = run {
+            val img = org.jetbrains.skia.Image.makeFromBitmap(processed)
+            try { img.toComposeImageBitmap() } finally { img.close() }
+        }
 
         // Save to caches
         frontCache[nickname] = result
@@ -103,8 +110,11 @@ object SkinManager {
         if (diskFile.exists() && !isExpired(diskFile)) {
             try {
                 val skiaImage = org.jetbrains.skia.Image.makeFromEncoded(diskFile.readBytes())
-                val bitmap = skiaImageToBitmap(skiaImage)
-                val result = bitmap.asComposeImageBitmap()
+                val result = try {
+                    skiaImage.toComposeImageBitmap()
+                } finally {
+                    skiaImage.close()
+                }
                 backCache[nickname] = result
                 logger.debug("Back skin loaded from disk cache: {}", nickname)
                 return@withContext result
@@ -124,7 +134,10 @@ object SkinManager {
         val rawCloak = downloadTexture(cloakUrl)
 
         val processed = assembleSkin(rawSkin, isFront = false, cloak = rawCloak)
-        val result = processed.asComposeImageBitmap()
+        val result = run {
+            val img = org.jetbrains.skia.Image.makeFromBitmap(processed)
+            try { img.toComposeImageBitmap() } finally { img.close() }
+        }
 
         backCache[nickname] = result
         saveBitmapToDisk(processed, diskFile)
@@ -185,7 +198,11 @@ object SkinManager {
         val bitmap = org.jetbrains.skia.Bitmap()
         bitmap.allocPixels(ImageInfo.makeS32(image.width, image.height, ColorAlphaType.PREMUL))
         val canvas = org.jetbrains.skia.Canvas(bitmap)
-        canvas.drawImage(image, 0f, 0f)
+        try {
+            canvas.drawImage(image, 0f, 0f)
+        } finally {
+            canvas.close()
+        }
         return bitmap
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Infrastructure
 kotlinVersion=2.3.20-RC3
-appVersion=2.0.2
+appVersion=2.0.3
 
 # Core Dependencies
 ktorVersion=3.4.1


### PR DESCRIPTION


- Replace toImageBitmapSafe() with Image.makeFromBitmap + toComposeImageBitmap()
  + img.close() in both static and animated paths in CustomBackground; toImageBitmapSafe() extension removed entirely
- Wrap Canvas in skiaImageToBitmap (SkinManager) with try/finally to ensure close
- Close Skia Image immediately after toComposeImageBitmap() in getSkinFront, getSkinBack (both disk cache and network paths) and saveBitmapToDisk
- ManagedSCleanerThunk count reduced 645 → 468 per VisualVM heap dump

Known remaining: toggle off/on does not fully release native resources; animated GIF/WebP frames still accumulate until GC. Full rewrite planned (Kamel or similar) — custom background use discouraged until then.