### PR TITLE
fix(background): disable animated GIF/WebP, add GC hint on settings change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to Aura Launcher will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+## [2.0.4] - 2026-03-15
+
+### Changed
+- **Animated GIF/WebP background disabled**: animated paths in `CustomBackground`
+  removed until 2.1.0 (Kamel rewrite). GIF/WebP files now show the first frame
+  as a static image. This eliminates the primary source of native Skia memory
+  accumulation (`BG.gif.frame` objects growing to 200+ between GC cycles,
+  causing RSS to reach 6–8 GB). Static image backgrounds are unaffected.
+
+### Fixed
+- **`CustomBackground` GC hint on settings change**: `System.gc()` called when
+  background is disabled or image path changes, prompting JVM to collect
+  orphaned `SkiaBackedImageBitmap` finalizers sooner. Previously RSS would
+  hold at 8+ GB until JVM decided to GC on its own.
+
+### Added
+- `SkiaDebugOverlay` — internal debug composable showing live RSS, JVM heap,
+  and tracked Skia object counts with Force GC buttons. Used to diagnose
+  and confirm memory fixes. Not included in release builds.
+- `SkiaTracker` — lightweight weak-reference tracker for `ImageBitmap` objects.
+
+### Known Issues
+- Animated GIF/WebP backgrounds show first frame only — full animation
+  support returns in 2.1.0 via Kamel
+- Static background `BG.static` count may reach 3–4 between GC cycles
+  when rapidly switching images; clears on next GC cycle
 ## [2.0.3] - 2026-03-15
 
 ### ⚠️ Known Issue - Custom Background

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -2,7 +2,9 @@ package hivens.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -10,6 +12,7 @@ import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.*
 import coil3.ImageLoader
 import coil3.compose.setSingletonImageLoaderFactory
@@ -27,6 +30,7 @@ import hivens.launcher.di.networkModule
 import hivens.ui.background.BackgroundManager
 import hivens.ui.background.CustomBackground
 import hivens.ui.components.UpdateManager
+import hivens.ui.debug.SkiaDebugOverlay
 import hivens.ui.generated.resources.Res
 import hivens.ui.generated.resources.favicon
 import hivens.ui.i18n.AppLocale
@@ -385,6 +389,11 @@ fun AppRoot(
             }
     ) {
         CustomBackground(settings = backgroundSettings, mousePosProvider = { mousePos.value })
+        /*
+        SkiaDebugOverlay(
+            modifier = Modifier.align(Alignment.TopCenter).padding(top = 8.dp)
+        )
+         */
 
         AppLayout(
             appState             = appState,
@@ -403,6 +412,9 @@ fun AppRoot(
             onBackgroundSettingsChanged = { newSettings ->
                 backgroundSettings = newSettings
                 backgroundManager.save(newSettings)
+                if (!newSettings.enabled || newSettings.imagePath != backgroundSettings.imagePath) {
+                    System.gc()
+                }
             }
         )
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/background/CustomBackground.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/background/CustomBackground.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import hivens.ui.debug.SkiaTracker
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -49,8 +50,8 @@ fun CustomBackground(
 
     Box(modifier = modifier.fillMaxSize()) {
         AnimatedParallaxImage(
-            file = file,
-            settings = settings,
+            file             = file,
+            settings         = settings,
             mousePosProvider = mousePosProvider
         )
 
@@ -77,7 +78,7 @@ fun CustomBackground(
                     drawIntoCanvas {
                         val centerX = size.width / 2
                         val centerY = size.height / 2
-                        val radius = maxOf(size.width, size.height) * 0.7f
+                        val radius  = maxOf(size.width, size.height) * 0.7f
                         drawCircle(
                             brush = Brush.radialGradient(
                                 colors = listOf(
@@ -132,36 +133,30 @@ private fun AnimatedParallaxImage(
 
         if (useParallax) {
             val mousePos = mousePosProvider()
-            val targetX = (0.5f - mousePos.x) * settings.parallaxIntensity * 80f
-            val targetY = (0.5f - mousePos.y) * settings.parallaxIntensity * 80f
-            val parallaxX by animateFloatAsState(
-                targetValue = targetX,
-                animationSpec = spring(stiffness = 50f, dampingRatio = 0.8f)
-            )
-            val parallaxY by animateFloatAsState(
-                targetValue = targetY,
-                animationSpec = spring(stiffness = 50f, dampingRatio = 0.8f)
-            )
+            val targetX  = (0.5f - mousePos.x) * settings.parallaxIntensity * 80f
+            val targetY  = (0.5f - mousePos.y) * settings.parallaxIntensity * 80f
+            val parallaxX by animateFloatAsState(targetX, spring(stiffness = 50f, dampingRatio = 0.8f))
+            val parallaxY by animateFloatAsState(targetY, spring(stiffness = 50f, dampingRatio = 0.8f))
             Image(
-                painter = BitmapPainter(imageBitmap),
+                painter            = BitmapPainter(imageBitmap),
                 contentDescription = null,
-                contentScale = contentScale,
-                alignment = alignment,
-                modifier = baseModifier.graphicsLayer {
+                contentScale       = contentScale,
+                alignment          = alignment,
+                modifier           = baseModifier.graphicsLayer {
                     val extraScale = 1f + settings.parallaxIntensity * 0.15f
-                    scaleX = extraScale
-                    scaleY = extraScale
+                    scaleX       = extraScale
+                    scaleY       = extraScale
                     translationX = parallaxX
                     translationY = parallaxY
                 }
             )
         } else {
             Image(
-                painter = BitmapPainter(imageBitmap),
+                painter            = BitmapPainter(imageBitmap),
                 contentDescription = null,
-                contentScale = contentScale,
-                alignment = alignment,
-                modifier = baseModifier
+                contentScale       = contentScale,
+                alignment          = alignment,
+                modifier           = baseModifier
             )
         }
     }
@@ -184,43 +179,17 @@ private fun rememberSkiaImage(file: File): ImageBitmap? {
                 codec = Codec.makeFromData(data)
                 bmp   = org.jetbrains.skia.Bitmap().apply { allocPixels(codec.imageInfo) }
 
-                if (codec.frameCount <= 1) {
-                    // Static image — decode once, convert via full pixel copy, done
-                    codec.readPixels(bmp, 0)
-                    val img = org.jetbrains.skia.Image.makeFromBitmap(bmp)
-                    try {
-                        bitmap = img.toComposeImageBitmap()
-                    } finally {
-                        img.close()
+                // Decode first frame only — animated GIF/WebP disabled until 2.1.0 (Kamel)
+                codec.readPixels(bmp, 0)
+                val img = org.jetbrains.skia.Image.makeFromBitmap(bmp)
+                try {
+                    bitmap = img.toComposeImageBitmap().also {
+                        SkiaTracker.track("BG.static", it)
                     }
-                } else {
-                    // Animated GIF/WebP — decode frame by frame
-                    var frame      = 0
-                    var priorFrame = -1
-
-                    while (isActive) {
-                        if (frame == 0) { bmp.erase(0); priorFrame = -1 }
-
-                        codec.readPixels(bmp, frame, priorFrame)
-
-                        // Full pixel copy into JVM heap — Skia Image is closed immediately,
-                        // no native memory accumulation between frames.
-                        val img = org.jetbrains.skia.Image.makeFromBitmap(bmp)
-                        try {
-                            bitmap = img.toComposeImageBitmap()
-                        } finally {
-                            img.close()
-                        }
-
-                        var duration = codec.framesInfo[frame].duration
-                        if (duration < 30) duration = 100
-
-                        delay(duration.toLong())
-
-                        priorFrame = frame
-                        frame = (frame + 1) % codec.frameCount
-                    }
+                } finally {
+                    img.close()
                 }
+
             } catch (e: Exception) {
                 e.printStackTrace()
             } finally {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/SquareServerCard.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/SquareServerCard.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import hivens.config.AppConfig
 import hivens.core.api.model.ServerProfile
+import hivens.ui.debug.SkiaTracker
 import hivens.ui.effects.neonBorder
 import hivens.ui.effects.shimmerOverlay
 import hivens.ui.theme.CelestiaTheme
@@ -96,7 +97,11 @@ fun SquareServerCard(
             // Looking for icon.png file
             val iconFile = File(baseDir, "clients/${profile.assetDir}/icon.png")
             if (iconFile.exists()) {
-                runCatching { serverIcon = ImageIO.read(iconFile)?.toComposeImageBitmap() }
+                runCatching {
+                    serverIcon = ImageIO.read(iconFile)?.toComposeImageBitmap()?.also {
+                        SkiaTracker.track("Card.icon[${profile.assetDir}]", it)
+                    }
+                }
             }
         }
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/debug/SkiaTracker.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/debug/SkiaTracker.kt
@@ -1,0 +1,201 @@
+package hivens.ui.debug
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.material3.Text
+import kotlinx.coroutines.delay
+import java.io.File
+import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentLinkedQueue
+
+// ─── Global tracker — register Skia objects from anywhere ────────────────────
+
+object SkiaTracker {
+    private val refs = ConcurrentLinkedQueue<Pair<String, WeakReference<Any>>>()
+
+    fun track(label: String, obj: Any) {
+        refs.add(label to WeakReference(obj))
+    }
+
+    fun snapshot(): Map<String, Int> {
+        // Prune dead refs
+        refs.removeIf { it.second.get() == null }
+        return refs.groupingBy { it.first }.eachCount()
+    }
+
+    fun total() = refs.count { it.second.get() != null }
+}
+
+// ─── Overlay composable ───────────────────────────────────────────────────────
+
+/**
+ * Debug overlay — shows:
+ *  - JVM heap used / max
+ *  - Process RSS from /proc/self/status (actual native + heap)
+ *  - Tracked Skia objects via [SkiaTracker]
+ *  - Force GC button
+ *
+ * Toggle visibility with [visible]. Keep out of release builds.
+ */
+@Composable
+fun SkiaDebugOverlay(
+    visible: Boolean = true,
+    modifier: Modifier = Modifier
+) {
+    if (!visible) return
+
+    var heapUsed   by remember { mutableStateOf(0L) }
+    var heapMax    by remember { mutableStateOf(0L) }
+    var rss        by remember { mutableStateOf(0L) }
+    var skiaTotal  by remember { mutableStateOf(0) }
+    var skiaByType by remember { mutableStateOf(emptyMap<String, Int>()) }
+    var expanded   by remember { mutableStateOf(true) }
+    var gcCount    by remember { mutableStateOf(0) }
+
+    LaunchedEffect(gcCount) {
+        while (true) {
+            val rt = Runtime.getRuntime()
+            heapUsed  = (rt.totalMemory() - rt.freeMemory()) / (1024 * 1024)
+            heapMax   = rt.maxMemory() / (1024 * 1024)
+            rss       = readRssMb()
+            skiaByType = SkiaTracker.snapshot()
+            skiaTotal  = SkiaTracker.total()
+            delay(2000)
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(8.dp))
+            .background(Color(0xDD000000))
+            .clickable { expanded = !expanded }
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Column {
+            // ── Header ────────────────────────────────────────────────────────
+            Row(
+                verticalAlignment     = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                val rssColor = when {
+                    rss > 1500 -> Color(0xFFEF5350)
+                    rss > 800  -> Color(0xFFFFD54F)
+                    else       -> Color(0xFF4CAF50)
+                }
+                Text(
+                    "⬤ MEM  RSS: ${rss} MB   Heap: ${heapUsed}/${heapMax} MB   ${if (expanded) "▲" else "▼"}",
+                    color      = rssColor,
+                    fontSize   = 11.sp,
+                    fontWeight = FontWeight.Bold,
+                    fontFamily = FontFamily.Monospace
+                )
+            }
+
+            AnimatedVisibility(visible = expanded) {
+                Column(
+                    Modifier.padding(top = 6.dp),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    // ── Skia tracked objects ──────────────────────────────────
+                    if (skiaByType.isEmpty()) {
+                        Text(
+                            "No tracked objects  (add SkiaTracker.track() calls)",
+                            color      = Color.Gray,
+                            fontSize   = 10.sp,
+                            fontFamily = FontFamily.Monospace
+                        )
+                    } else {
+                        Text(
+                            "Tracked Skia objects: $skiaTotal",
+                            color      = Color.White,
+                            fontSize   = 10.sp,
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = FontFamily.Monospace
+                        )
+                        skiaByType.forEach { (label, count) ->
+                            val color = when {
+                                count > 50 -> Color(0xFFEF5350)
+                                count > 20 -> Color(0xFFFFD54F)
+                                else       -> Color(0xFF4CAF50)
+                            }
+                            Text(
+                                "  %-20s %d".format(label, count),
+                                color      = color,
+                                fontSize   = 10.sp,
+                                fontFamily = FontFamily.Monospace
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(4.dp))
+
+                    // ── RSS trend hint ────────────────────────────────────────
+                    val nativeEst = rss - heapUsed
+                    if (nativeEst > 0) {
+                        Text(
+                            "Native est. ${nativeEst} MB  (RSS − heap)",
+                            color      = if (nativeEst > 500) Color(0xFFFFD54F) else Color.Gray,
+                            fontSize   = 10.sp,
+                            fontFamily = FontFamily.Monospace
+                        )
+                    }
+
+                    Spacer(Modifier.height(4.dp))
+
+                    // ── Buttons ───────────────────────────────────────────────
+                    Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                        DebugButton("Force GC") {
+                            System.gc()
+                            System.runFinalization()
+                            System.gc()
+                            gcCount++
+                        }
+                        DebugButton("GC + wait") {
+                            System.gc()
+                            System.runFinalization()
+                            Thread.sleep(500)
+                            System.gc()
+                            gcCount++
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DebugButton(label: String, onClick: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(4.dp))
+            .background(Color.White.copy(alpha = 0.12f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 3.dp)
+    ) {
+        Text(label, color = Color.White, fontSize = 10.sp, fontFamily = FontFamily.Monospace)
+    }
+}
+
+// ─── /proc/self/status RSS reader ────────────────────────────────────────────
+
+private fun readRssMb(): Long = try {
+    File("/proc/self/status").readLines()
+        .firstOrNull { it.startsWith("VmRSS:") }
+        ?.replace(Regex("[^0-9]"), "")
+        ?.toLongOrNull()
+        ?.div(1024) // kB → MB
+        ?: 0L
+} catch (_: Exception) { 0L }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerDetailScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import hivens.config.AppConfig
 import hivens.core.api.model.ServerProfile
 import hivens.ui.components.GlassCard
+import hivens.ui.debug.SkiaTracker
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
 import kotlinx.coroutines.Dispatchers
@@ -60,7 +61,11 @@ fun ServerDetailScreen(
 
             val imgFile = File(assetsPath, "banner.png")
             if (imgFile.exists()) {
-                runCatching { bannerImage = ImageIO.read(imgFile)?.toComposeImageBitmap() }
+                runCatching {
+                    bannerImage = ImageIO.read(imgFile)?.toComposeImageBitmap()?.also {
+                        SkiaTracker.track("Detail.banner[${server.assetDir}]", it)
+                    }
+                }
             }
             isLoading = false
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerSettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerSettingsScreen.kt
@@ -35,6 +35,7 @@ import hivens.ui.components.CelestiaButton
 import hivens.ui.components.GlassCard
 import hivens.ui.components.ModItemCard
 import hivens.ui.components.RamSelector
+import hivens.ui.debug.SkiaTracker
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
 import io.github.vinceglb.filekit.FileKit
@@ -172,7 +173,9 @@ fun ServerSettingsScreen(server: ServerProfile, onBack: () -> Unit) {
                                         StandardCopyOption.REPLACE_EXISTING
                                     )
                                     runCatching {
-                                        serverIcon = ImageIO.read(targetFile)?.toComposeImageBitmap()
+                                        serverIcon = ImageIO.read(targetFile)?.toComposeImageBitmap()?.also {
+                                            SkiaTracker.track("Settings.icon[${server.assetDir}]", it)
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
- Remove animated frame loop from rememberSkiaImage; GIF/WebP now shows first frame only until 2.1.0 Kamel rewrite eliminates native Skia leak
- Add System.gc() hint when background disabled or image path changes
- Add SkiaDebugOverlay + SkiaTracker for live RSS/heap/object monitoring