### PR TITLE
fix(auth): add register button next to login (closes #105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Aura Launcher will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+## [2.0.5] - 2026-03-17
+
+### Added
+- **Register button in login panel** (#105): added "Create an account" `OutlinedButton`
+  below the login button; opens `BASE_URL/register` in the system browser so users
+  can immediately tell which account type they need.
+- `loginRegister` i18n key added to `AppStrings`, `RussianStrings`, `EnglishStrings`,
+  `GermanStrings`.
+
 ## [2.0.4] - 2026-03-15
 
 ### Changed

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
@@ -1,6 +1,7 @@
 package hivens.ui
 
 import androidx.compose.animation.core.*
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -232,6 +233,34 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
             } else {
                 Text(s.loginButton, color = Color.White, fontWeight = FontWeight.Bold)
             }
+        }
+
+        // ── Button "Register" — issue #105 ─────────────────────────────────
+        OutlinedButton(
+            onClick  = {
+                runCatching {
+                    val url = "${AppConfig.BASE_URL}/register"
+                    if (Desktop.isDesktopSupported() &&
+                        Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)
+                    ) {
+                        Desktop.getDesktop().browse(URI(url))
+                    }
+                }
+            },
+            modifier  = Modifier.fillMaxWidth().height(42.dp),
+            shape     = RoundedCornerShape(8.dp),
+            border    = BorderStroke(
+                width = 1.dp,
+                color = CelestiaTheme.colors.primary.copy(alpha = 0.45f)
+            ),
+            colors    = ButtonDefaults.outlinedButtonColors(
+                contentColor = CelestiaTheme.colors.primary
+            )
+        ) {
+            Text(
+                text       = s.loginRegister,
+                fontWeight = FontWeight.Medium
+            )
         }
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -16,6 +16,7 @@ interface AppStrings {
     val loginLoading: String
     val loginErrorEmpty: String
     val loginErrorGeneric: String
+    val loginRegister: String
 
     // --- Navigation ---
     val navHome: String

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -16,6 +16,7 @@ object EnglishStrings : AppStrings {
     override val loginLoading      = "LOADING"
     override val loginErrorEmpty   = "Enter your username and password"
     override val loginErrorGeneric = "Login error"
+    override val loginRegister     = "Create an account"
 
     // Navigation
     override val navHome     = "Home"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -16,6 +16,7 @@ object GermanStrings : AppStrings {
     override val loginLoading      = "LADEN"
     override val loginErrorEmpty   = "Benutzername und Passwort eingeben"
     override val loginErrorGeneric = "Anmeldefehler"
+    override val loginRegister     = "Konto erstellen"
 
     // Navigation
     override val navHome     = "Startseite"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -16,6 +16,7 @@ object RussianStrings : AppStrings {
     override val loginLoading      = "ЗАГРУЗКА"
     override val loginErrorEmpty   = "Введите логин и пароль"
     override val loginErrorGeneric = "Ошибка входа"
+    override val loginRegister     = "Зарегистрироваться"
 
     // Navigation
     override val navHome     = "Главная"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Infrastructure
 kotlinVersion=2.3.20-RC3
-appVersion=2.0.3
+appVersion=2.0.5
 
 # Core Dependencies
 ktorVersion=3.4.1


### PR DESCRIPTION
Users had no way to tell which account they needed from the launcher UI. Added an outlined "Create an account" button below the login button in LoginPanel that opens BASE_URL/register in the system browser.

- New loginRegister i18n key (ru/en/de)
- OutlinedButton styled as secondary action to keep visual hierarchy