### PR TITLE
fix(tray): handle JNA version conflict on Windows (#crash-jna) closes #109

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Aura Launcher will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+## [2.0.6] - 2026-03-17
+
+### Fixed
+- **Launcher crash on Windows when JNA version conflict is present**: dorkbox
+  SystemTray throws `java.lang.Error` (not `Exception`) when it detects an
+  incompatible JNA native library cached in `%TEMP%`. Added `jna.nosys=true`
+  system property in `main()` and jvmArgs so JNA always uses its bundled native.
+  Widened `TrayManager.init` catch to `Throwable` as a second line of defence.
+  With `startInTray=true` on affected Windows machines the launcher would silently
+  die before the window ever appeared — now it gracefully falls back to showing
+  the window when tray init fails.
+
 ## [2.0.5] - 2026-03-17
 
 ### Added

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -194,7 +194,10 @@ compose.desktop {
             "-XX:ReservedCodeCacheSize=128m",
 
             // Security
-            "--enable-native-access=ALL-UNNAMED"
+            "--enable-native-access=ALL-UNNAMED",
+
+            // prevent JNA native lib version conflict
+            "-Djna.nosys=true"
         )
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -92,6 +92,7 @@ sealed class Screen {
 
 @OptIn(ExperimentalResourceApi::class, DelicateCoroutinesApi::class)
 fun main() {
+    System.setProperty("jna.nosys", "true")
     System.setProperty("skiko.fps.limit", "60")
     Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
         val logger = LoggerFactory.getLogger("CrashHandler")

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
@@ -58,8 +58,8 @@ object TrayManager {
             t.setImage(iconStream)
             buildMenu(t.menu, strings)
             logger.info("TrayManager initialized ({})", t.javaClass.simpleName)
-        } catch (e: Exception) {
-            logger.error("Failed to initialize TrayManager", e)
+        } catch (t: Exception) {
+            logger.error("Failed to initialize TrayManager", t)
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Infrastructure
 kotlinVersion=2.3.20-RC3
-appVersion=2.0.5
+appVersion=2.0.6
 
 # Core Dependencies
 ktorVersion=3.4.1


### PR DESCRIPTION
dorkbox SystemTray throws java.lang.Error (not Exception) when it finds an incompatible JNA native library already loaded from %TEMP%. The old catch(Exception) let it propagate and kill the main thread.

- Set jna.nosys=true in main() and jvmArgs so JNA always uses its own bundled native instead of whatever is on the system
- Widen TrayManager.init catch to Throwable so a tray failure never crashes the launcher — it degrades gracefully (isSupported = false)