### PR TITLE
feat(update): aggregate changelog across all versions between current and latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Aura Launcher will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
+## [2.0.7] - 2026-03-17
+
+### Changed
+- **Update dialog changelog**: instead of showing raw release body (including
+  Downloads table and SHA256 checksums), now aggregates "What's Changed"
+  sections across all versions between the installed and latest release.
+
 ## [2.0.6] - 2026-03-17
 
 ### Fixed

--- a/client-launcher/src/main/kotlin/hivens/launcher/update/UpdateService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/update/UpdateService.kt
@@ -30,7 +30,8 @@ class UpdateService(
     private val lastCheckFile = updateDir.resolve(".last_check")
 
     companion object {
-        private const val GITHUB_API = "https://api.github.com/repos/Kitty-Hivens/Aura-Launcher/releases/latest"
+        private const val GITHUB_API_LATEST   = "https://api.github.com/repos/Kitty-Hivens/Aura-Launcher/releases/latest"
+        private const val GITHUB_API_RELEASES = "https://api.github.com/repos/Kitty-Hivens/Aura-Launcher/releases"
         private const val CHECK_INTERVAL_HOURS = 12L
     }
 
@@ -52,7 +53,7 @@ class UpdateService(
 
             logger.info("Checking for launcher updates...")
 
-            val response = httpClient.get(GITHUB_API) {
+            val response = httpClient.get(GITHUB_API_LATEST) {
                 header("Accept", "application/vnd.github.v3+json")
             }
 
@@ -87,7 +88,7 @@ class UpdateService(
                 version = release.tagName,
                 downloadUrl = asset.browserDownloadUrl,
                 checksum = checksum,
-                changelog = release.body ?: "No changelog available",
+                changelog = fetchChangelogBetween(currentVersion, latestVersion),
                 isCritical = isCritical
             )
 
@@ -281,6 +282,47 @@ class UpdateService(
         }
 
         return 0
+    }
+
+    private suspend fun fetchChangelogBetween(
+        currentVersion: String,
+        latestVersion: String
+    ): String {
+        val response = httpClient.get(GITHUB_API_RELEASES) {
+            header("Accept", "application/vnd.github.v3+json")
+        }
+        if (response.status.value != 200) return ""
+
+        val releases = json.decodeFromString<List<GitHubRelease>>(response.bodyAsText())
+
+        return releases
+            .filter { release ->
+                val v = release.tagName.removePrefix("v")
+                compareVersions(v, currentVersion) > 0 &&
+                        compareVersions(v, latestVersion)  <= 0
+            }
+            .sortedByDescending { it.tagName }
+            .joinToString("\n\n---\n\n") { release ->
+                val version = release.tagName
+                val section = extractWhatsChanged(release.body)
+                "## $version\n\n$section"
+            }
+            .ifBlank { "No changelog available" }
+    }
+
+    private fun extractWhatsChanged(body: String?): String {
+        if (body == null) return ""
+
+        // Slice between "## What's Changed" and the next "---" or "##"
+        val start = body.indexOf("## What's Changed")
+        if (start == -1) return body.substringBefore("---").trim()
+
+        val afterHeader = body.substring(start + "## What's Changed".length)
+        return afterHeader
+            .substringBefore("\n---")
+            .substringBefore("\n## ")
+            .trim()
+            .ifBlank { "" }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Infrastructure
 kotlinVersion=2.3.20-RC3
-appVersion=2.0.6
+appVersion=2.0.7
 
 # Core Dependencies
 ktorVersion=3.4.1


### PR DESCRIPTION
Previously showed raw release.body including Downloads table and SHA256 checksums — noise unrelated to what actually changed.

Now fetches all releases, filters to range (currentVersion, latestVersion], extracts only the "What's Changed" section from each, and joins them with version headers. User updating from 2.0.6 to 2.1.5 sees all intermediate changes in one readable markdown block.