### PR TITLE
fix(update): skip releases with empty changelog in fetchChangelogBetween

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/update/UpdateService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/update/UpdateService.kt
@@ -302,11 +302,12 @@ class UpdateService(
                         compareVersions(v, latestVersion)  <= 0
             }
             .sortedByDescending { it.tagName }
-            .joinToString("\n\n---\n\n") { release ->
-                val version = release.tagName
+            .mapNotNull { release ->
                 val section = extractWhatsChanged(release.body)
-                "## $version\n\n$section"
+                if (section.isBlank()) null  // skip releases with no parseable changelog
+                else "## ${release.tagName}\n\n$section"
             }
+            .joinToString("\n\n---\n\n")
             .ifBlank { "No changelog available" }
     }
 

--- a/client-launcher/src/test/kotlin/hivens/launcher/update/UpdateServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/update/UpdateServiceTest.kt
@@ -32,7 +32,10 @@ class UpdateServiceTest {
         val tempDir = Files.createTempDirectory("update-test")
         tempDir.toFile().deleteOnExit()
         return UpdateService(
-            httpClient = buildMockClient(body = body, status = status),
+            httpClient = buildMockClient(
+                MockResponse(urlContains = "releases/latest", body = body,    status = status),
+                MockResponse(urlContains = "releases",        body = "[$body]", status = status)
+            ),
             json = json,
             dataDirectory = tempDir
         )


### PR DESCRIPTION
extractWhatsChanged(null) returns "" but joinToString still produced "## v99.0.0\n\n" which is not blank — ifBlank fallback never triggered. Replaced joinToString with mapNotNull that drops blank sections first.