### PR TITLE
fix: handle expired SSL certificate with user-facing warning (#ssl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Aura Launcher will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+## [2.2.3] - 2026-03-25
+
+### Fixed
+- **SSL certificate expired on smartycraft.ru**: raw `CertPathValidatorException` stack
+  trace replaced with a human-readable orange warning banner. Users can now make an
+  informed decision — "Connect anyway" retries the login with SSL verification disabled,
+  while "Cancel" keeps them on the login screen. The bypass is entirely opt-in.
+
 ## [2.2.2] - 2026-03-25
 
 ### Fixed

--- a/client-core/src/main/kotlin/hivens/core/api/AuthException.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/AuthException.kt
@@ -7,5 +7,7 @@ import hivens.core.data.AuthStatus
  */
 class AuthException(
     val status: AuthStatus,
-    message: String
+    message: String,
+    /** True when failure is caused by an expired/invalid SSL certificate. */
+    val isSslError: Boolean = false
 ) : Exception(message)

--- a/client-core/src/main/kotlin/hivens/core/api/AuthService.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/AuthService.kt
@@ -99,6 +99,13 @@ class AuthService(
         } catch (e: Exception) {
             if (e is AuthException) throw e
             logger.error("Authorization error", e)
+            if (e.isSslCertificateError()) {
+                throw AuthException(
+                    status     = AuthStatus.INTERNAL_ERROR,
+                    message    = "SSL certificate error: ${e.message}",
+                    isSslError = true
+                )
+            }
             throw AuthException(AuthStatus.INTERNAL_ERROR, "Network Error: ${e.message}")
         }
 
@@ -165,5 +172,18 @@ class AuthService(
         rand.nextBytes(mac)
         mac[0] = (mac[0].toInt() and 254).toByte()
         return mac.joinToString("-") { "%02X".format(it) }
+    }
+
+    private fun Throwable.isSslCertificateError(): Boolean {
+        var cause: Throwable? = this
+        while (cause != null) {
+            if (cause is javax.net.ssl.SSLHandshakeException ||
+                cause is java.security.cert.CertPathValidatorException ||
+                cause.message?.contains("certificate_expired") == true ||
+                cause.message?.contains("CertPathValidatorException") == true
+            ) return true
+            cause = cause.cause
+        }
+        return false
     }
 }

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -19,6 +19,7 @@ import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import java.net.InetSocketAddress
 import java.net.Proxy
@@ -64,37 +65,32 @@ val networkModule = module {
         builder.build()
     }
 
-    single<HttpClient> {
-        val okHttpInstance = get<OkHttpClient>()
-
-        HttpClient(OkHttp) {
-            engine {
-                preconfigured = okHttpInstance
-            }
-
-            // Ktor plugins
-            install(ContentNegotiation) {
-                json(get())
-            }
-
-            install(HttpTimeout) {
-                requestTimeoutMillis = 600_000 // 10 minutes
-                connectTimeoutMillis = 30_000 // 30 seconds to connect
-                socketTimeoutMillis = 600_000 // 10 minutes to wait for packets
-            }
-
-            defaultRequest {
-                // User-Agent strictly according to the config
-                header("User-Agent", "SMARTYlauncher/${AppConfig.LAUNCHER_VERSION}")
-                contentType(ContentType.Application.Json)
-            }
-        }
-    }
+    single<HttpClient> { buildHttpClient(get(), get()) }
 
     // Repositories
     single { ServerRepository(get(), get(), get<java.nio.file.Path>().toFile()) }
     singleOf(::SkinRepository)
     singleOf(::PlayerRepository)
+
+
+    // ── Insecure client (SSL verification disabled) ───────────────────────
+    // Registered only for the explicit "connect anyway" user flow.
+    // Never injected by default — must be requested by named("insecure").
+
+    single(named("insecure")) {
+        val (socketFactory, trustManager) = buildTrustAllSsl()
+
+        val builder = OkHttpClient.Builder()
+            .connectTimeout(AppConfig.TIMEOUT_CONNECT, TimeUnit.MILLISECONDS)
+            .readTimeout(AppConfig.TIMEOUT_READ, TimeUnit.MILLISECONDS)
+            .sslSocketFactory(socketFactory, trustManager)
+            .hostnameVerifier { _, _ -> true }
+            .proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress(AppConfig.Proxy.HOST, AppConfig.Proxy.PORT)))
+
+        builder.build()
+    }
+
+    single<HttpClient>(named("insecure")) { buildHttpClient(get(named("insecure")), get()) }
 }
 
 /**
@@ -149,4 +145,45 @@ val appModule = module {
             dataDirectory = get()
         )
     }
+
+    single<IAuthService>(named("insecure")) {
+        AuthService(get(named("insecure")), get())
+    }
 }
+
+private fun buildTrustAllSsl(): Pair<javax.net.ssl.SSLSocketFactory, javax.net.ssl.X509TrustManager> {
+    val trustManager = object : javax.net.ssl.X509TrustManager {
+        override fun checkClientTrusted(
+            chain: Array<java.security.cert.X509Certificate>, authType: String
+        ) = Unit
+        override fun checkServerTrusted(
+            chain: Array<java.security.cert.X509Certificate>, authType: String
+        ) = Unit
+        override fun getAcceptedIssuers(): Array<java.security.cert.X509Certificate> = emptyArray()
+    }
+    val ctx = javax.net.ssl.SSLContext.getInstance("TLS")
+    ctx.init(null, arrayOf(trustManager), java.security.SecureRandom())
+    return ctx.socketFactory to trustManager
+}
+
+private fun buildHttpClient(okHttpInstance: OkHttpClient, json: Json): HttpClient =
+    HttpClient(OkHttp) {
+        engine {
+            preconfigured = okHttpInstance
+        }
+
+        // Ktor plugins
+        install(ContentNegotiation) { json(json) }
+
+        install(HttpTimeout) {
+            requestTimeoutMillis = 600_000 // 10 minutes
+            connectTimeoutMillis = 30_000 // 30 seconds to connect
+            socketTimeoutMillis = 600_000 // 10 minutes to wait for packets
+        }
+
+        defaultRequest {
+            // User-Agent strictly according to the config
+            header("User-Agent", "SMARTYlauncher/${AppConfig.LAUNCHER_VERSION}")
+            contentType(ContentType.Application.Json)
+        }
+    }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
@@ -3,6 +3,7 @@ package hivens.ui
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -34,6 +35,7 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import hivens.config.AppConfig
+import hivens.core.api.AuthException
 import hivens.core.api.interfaces.IAuthService
 import hivens.core.api.interfaces.IServerListService
 import hivens.core.data.NewsItem
@@ -48,6 +50,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
 import java.awt.Desktop
 import java.net.URI
 
@@ -90,6 +93,7 @@ fun RightPanel(
 @Composable
 fun LoginPanel(onLogin: (SessionData) -> Unit) {
     val authService: IAuthService              = koinInject()
+    val insecureAuthService: IAuthService      = koinInject(named("insecure"))
     val credentialsManager: CredentialsManager = koinInject()
     val profileManager: ProfileManager         = koinInject()
     val s            = LocalStrings.current
@@ -101,6 +105,7 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
     var rememberMe   by remember { mutableStateOf(true) }
     var isLoading    by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
+    var sslWarning   by remember { mutableStateOf(false) }
 
     val fieldColors = OutlinedTextFieldDefaults.colors(
         focusedTextColor        = CelestiaTheme.colors.textPrimary,
@@ -114,26 +119,33 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
         unfocusedContainerColor = Color.Transparent
     )
 
-    fun doLogin() {
+    fun doLogin(service: IAuthService = authService) {
         if (login.isBlank() || password.isBlank()) { errorMessage = s.loginErrorEmpty; return }
         focusManager.clearFocus()
-        isLoading = true
+        isLoading    = true
+        sslWarning   = false
         errorMessage = null
         scope.launch {
             try {
                 val session = withContext(Dispatchers.IO) {
                     val lastServer = profileManager.lastServerId ?: AppConfig.DEFAULT_SERVER_ID
-                    val sess = authService.login(login, password, lastServer)
+                    val sess = service.login(login, password, lastServer)
                     if (rememberMe) credentialsManager.save(sess)
                     sess
                 }
                 onLogin(session)
-            } catch (e: Exception) {
+            } catch (e: AuthException) {
                 isLoading = false
-                errorMessage = e.message
-                    ?.replace("java.lang.Exception: ", "")
-                    ?.substringAfter("API: ")
-                    ?: s.loginErrorGeneric
+                when {
+                    e.isSslError -> sslWarning = true
+                    else         -> errorMessage = e.message
+                        ?.replace("java.lang.Exception: ", "")
+                        ?.substringAfter("API: ")
+                        ?: s.loginErrorGeneric
+                }
+            } catch (e: Exception) {
+                isLoading    = false
+                errorMessage = e.message ?: s.loginErrorGeneric
             }
         }
     }
@@ -151,6 +163,60 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
             color      = CelestiaTheme.colors.textPrimary
         )
 
+        // ── SSL warning banner ────────────────────────────────────────────
+        if (sslWarning) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        color = Color(0xFFF59E0B).copy(alpha = 0.12f),
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                    .border(
+                        width = 1.dp,
+                        color = Color(0xFFF59E0B).copy(alpha = 0.5f),
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                    .padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text       = "⚠ ${s.sslWarningTitle}",
+                    style      = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    color      = Color(0xFFF59E0B)
+                )
+                Text(
+                    text  = s.sslWarningBody,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = CelestiaTheme.colors.textPrimary.copy(alpha = 0.85f)
+                )
+                Row(
+                    modifier              = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    OutlinedButton(
+                        onClick  = { sslWarning = false },
+                        modifier = Modifier.weight(1f),
+                        shape    = RoundedCornerShape(6.dp)
+                    ) {
+                        Text(s.sslWarningCancel, color = CelestiaTheme.colors.textSecondary)
+                    }
+                    Button(
+                        onClick = { doLogin(insecureAuthService) },
+                        modifier = Modifier.weight(1f),
+                        shape    = RoundedCornerShape(6.dp),
+                        colors   = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFFF59E0B)
+                        )
+                    ) {
+                        Text(s.sslWarningConnectAnyway, color = Color.Black)
+                    }
+                }
+            }
+        }
+
+        // ── Regular error ─────────────────────────────────────────────────
         if (errorMessage != null) {
             Text(
                 text     = errorMessage ?: "",
@@ -166,9 +232,10 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
             )
         }
 
+        // ── Fields ────────────────────────────────────────────────────────
         OutlinedTextField(
             value         = login,
-            onValueChange = { login = it; errorMessage = null },
+            onValueChange = { login = it; errorMessage = null; sslWarning = false },
             label         = { Text(s.loginUsername) },
             modifier      = Modifier.fillMaxWidth(),
             singleLine    = true,
@@ -180,7 +247,7 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
 
         OutlinedTextField(
             value                = password,
-            onValueChange        = { password = it; errorMessage = null },
+            onValueChange        = { password = it; errorMessage = null; sslWarning = false },
             label                = { Text(s.loginPassword) },
             modifier             = Modifier.fillMaxWidth(),
             singleLine           = true,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -311,4 +311,10 @@ interface AppStrings {
     val aprilCloseSurrender: String
     val aprilCloseHideTray: String
     fun aprilCloseEscapeCount(current: Int, max: Int): String
+
+    // --- SSL Warning ---
+    val sslWarningTitle: String
+    val sslWarningBody: String
+    val sslWarningConnectAnyway: String
+    val sslWarningCancel: String
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -317,4 +317,10 @@ object EnglishStrings : AppStrings {
     override val aprilCloseHideTray  = "Hide to tray"
     override fun aprilCloseEscapeCount(current: Int, max: Int) =
         "The close button has fled $current / $max times"
+
+    // --- SSL Warning ---
+    override val sslWarningTitle        = "Server certificate expired"
+    override val sslWarningBody         = "The server's SSL certificate has expired. Your connection may be insecure — server identity cannot be verified. Proceed at your own risk?"
+    override val sslWarningConnectAnyway = "Connect anyway"
+    override val sslWarningCancel       = "Cancel"
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -317,4 +317,10 @@ object GermanStrings : AppStrings {
     override val aprilCloseHideTray  = "Im Tray verstecken"
     override fun aprilCloseEscapeCount(current: Int, max: Int) =
         "Der Schließen-Knopf ist $current / $max Mal geflohen"
+
+    // --- SSL Warning ---
+    override val sslWarningTitle        = "Serverzertifikat abgelaufen"
+    override val sslWarningBody         = "Das SSL-Zertifikat des Servers ist abgelaufen. Die Verbindung ist möglicherweise unsicher — die Identität des Servers kann nicht verifiziert werden. Auf eigenes Risiko fortfahren?"
+    override val sslWarningConnectAnyway = "Trotzdem verbinden"
+    override val sslWarningCancel       = "Abbrechen"
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -317,4 +317,10 @@ object RussianStrings : AppStrings {
     override val aprilCloseHideTray  = "Свернуть в трей"
     override fun aprilCloseEscapeCount(current: Int, max: Int) =
         "Кнопка сбежала $current / $max раз"
+
+    // --- SSL Warning ---
+    override val sslWarningTitle        = "Сертификат безопасности устарел"
+    override val sslWarningBody         = "Сертификат сервера истёк. Соединение может быть небезопасным — данные передаются без проверки подлинности сервера. Продолжить на свой страх и риск?"
+    override val sslWarningConnectAnyway = "Всё равно подключиться"
+    override val sslWarningCancel       = "Отмена"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Infrastructure
 kotlinVersion=2.3.20-RC3
-appVersion=2.2.2
+appVersion=2.2.3
 
 # Core Dependencies
 ktorVersion=3.4.1


### PR DESCRIPTION
smartycraft.ru SSL cert expired. Raw CertPathValidatorException is now detected and surfaced as an opt-in warning banner instead of a cryptic error message.

Changes:
- AuthException: add isSslError flag
- AuthService: detect SSL errors via cause chain traversal
- Modules: add named("insecure") OkHttpClient/HttpClient/IAuthService; extract buildHttpClient() to eliminate 22-line duplication
- RightPanel/LoginPanel: show amber warning banner on SSL error; "Connect anyway" retries with insecure client, "Cancel" dismisses
- AppStrings + all 3 locales: sslWarningTitle/Body/ConnectAnyway/Cancel
- CHANGELOG: 2.2.3 entry