### PR TITLE
Release 2.2.9 — Stability + Performance + DX (cold-start, orphan pruning, retry, resume)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,40 @@
+# EditorConfig — see https://editorconfig.org/ for spec.
+# Pinned defaults so contributors don't have to discover ours by accident.
+
+root = true
+
+[*]
+charset                  = utf-8
+end_of_line              = lf
+insert_final_newline     = true
+trim_trailing_whitespace = true
+indent_style             = space
+indent_size              = 4
+
+# Kotlin / Java / Gradle
+[*.{kt,kts,java}]
+indent_size                              = 4
+max_line_length                          = 120
+ij_kotlin_continuation_indent_size       = 4
+ij_kotlin_allow_trailing_comma           = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_imports_layout                 = *
+# We use ※ ◆ ❖ ── ━━ in code comments; don't normalise these.
+ij_visual_guides                         = 120
+
+# YAML / JSON / TOML — 2 spaces is the community default
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+# Markdown — trailing whitespace is a linebreak in MD; don't trim.
+[*.md]
+trim_trailing_whitespace = false
+indent_size              = 2
+
+# Shell — POSIX recommends 4-space indent
+[*.sh]
+indent_size = 4
+
+# Makefiles MUST use tabs
+[Makefile]
+indent_style = tab

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -11,6 +11,14 @@ on:
         required: true
         default: '1.3.0'
 
+# Two simultaneous tag pushes (e.g. accidentally pushing v2.2.9 twice or
+# pushing tag + retry) would otherwise race the GitHub release publish
+# step. cancel-in-progress=false because we don't want a second tag push
+# to *abort* an in-flight release that may already have uploaded artifacts.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   JAVA_VERSION: '25'
   JAVA_DISTRIBUTION: 'jetbrains'
@@ -20,8 +28,19 @@ jobs:
   # Tests - must pass BEFORE any build
   # ─────────────────────────────────────────────────────────────────────────
   test:
-    name: Run Tests
-    runs-on: ubuntu-latest
+    name: Run Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    # fail-fast: false — one OS failing shouldn't kill the others; we want
+    # to see ALL platform-specific failures in one run, not race-of-the-first.
+    # shell: bash so steps work identically on Windows runners (PowerShell's
+    # default shell would mangle the gradlew invocation).
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +58,7 @@ jobs:
         if: always()   # we publish it even if it falls, so we can see what’s broken
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.os }}
           path: |
             client-core/build/reports/tests/
             client-launcher/build/reports/tests/
@@ -161,13 +180,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # appimagetool is the heaviest single download in the Linux build leg
+      # (~30 MB from a `continuous` release tag that doesn't change between
+      # most of our builds). Cache hit makes the assembly leg ~20s faster
+      # and survives upstream availability blips. Bump the key suffix when
+      # you want to force a refresh against a new continuous build.
+      - name: Cache appimagetool
+        id: cache-appimagetool
+        uses: actions/cache@v4
+        with:
+          path: appimagetool
+          key: appimagetool-continuous-x86_64-2026-05
+
       - name: Install AppImage tools
         run: |
           sudo apt-get update -q
           sudo apt-get install -y fuse libfuse2 desktop-file-utils appstream xmlstarlet
-          wget -qO /usr/local/bin/appimagetool \
-            "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
-          chmod +x /usr/local/bin/appimagetool
+          if [ -f appimagetool ]; then
+            sudo install -m 0755 appimagetool /usr/local/bin/appimagetool
+          else
+            wget -qO appimagetool \
+              "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+            chmod +x appimagetool
+            sudo install -m 0755 appimagetool /usr/local/bin/appimagetool
+          fi
 
       - name: Build JAR
         run: ./gradlew :client-ui:packageReleaseUberJarForCurrentOS -Pversion="$APP_VERSION"
@@ -298,48 +334,10 @@ jobs:
         env:
           CHANGELOG_NOTES: ${{ needs.changelog.outputs.notes }}
         run: |
-          REPO_BASE="https://github.com/Kitty-Hivens/Aura-Launcher/releases/download/v${APP_VERSION}"
-
-          # Highlights extracted the same way as for the manifest
-          HIGHLIGHTS=$(printf '%s' "$CHANGELOG_NOTES" \
-            | awk '/^### Highlights/ {flag=1; next} /^### / {flag=0} flag' \
-            | sed '/^[[:space:]]*$/d')
-
-          CHECKSUMS=""
-          while IFS= read -r line; do
-            hash=$(echo "$line" | awk '{print $1}')
-            file=$(echo "$line" | awk '{print $2}' | sed 's|^\./||')
-            [ -z "$file" ] && continue
-            CHECKSUMS="${CHECKSUMS}| \`${file}\` | \`${hash}\` |\n"
-          done < dist/SHA256SUMS.txt
-
           EOF_DELIM=$(openssl rand -hex 8)
           {
             echo "body<<$EOF_DELIM"
-
-            printf '> [!NOTE]\n'
-            printf '> **Aura Launcher** is an unofficial third-party launcher and is not affiliated with or endorsed by the original game developers.\n\n'
-
-            if [ -n "$HIGHLIGHTS" ]; then
-              printf "## What's New\n\n"
-              printf '%s\n\n' "$HIGHLIGHTS"
-            fi
-
-            printf '## Downloads\n\n'
-            printf '| Platform | File |\n|---|---|\n'
-            printf '| Windows Installer | [`AuraLauncher-%s-Setup.exe`](%s/AuraLauncher-%s-Setup.exe) |\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
-            printf '| Windows Portable  | [`AuraLauncher-%s-Windows-Portable.zip`](%s/AuraLauncher-%s-Windows-Portable.zip) |\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
-            printf '| Linux AppImage    | [`AuraLauncher-%s-x86_64.AppImage`](%s/AuraLauncher-%s-x86_64.AppImage) |\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
-            printf '| macOS             | [`AuraLauncher-%s.dmg`](%s/AuraLauncher-%s.dmg) |\n\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
-
-            printf '<details>\n<summary>SHA256 Checksums</summary>\n\n'
-            printf '| File | SHA256 |\n|---|---|\n'
-            echo -e "$CHECKSUMS"
-            printf '\n</details>\n\n'
-
-            printf "## What's Changed\n\n"
-            printf '%s\n' "$CHANGELOG_NOTES"
-
+            ./scripts/compose-release-body.sh
             echo "$EOF_DELIM"
           } >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ launchers ignore prereleases by GitHub API contract.
   so when an emergency upgrade is published the user sees the blocking
   dialog within ~5 minutes — no need to restart the launcher to pick it up.
   Routine release checks stay on the existing 12 h cadence.
+- **Network resilience on the SMARTYcraft channel**: pinned to HTTP/1.1
+  (h2 over SOCKS was dropping mid-stream); auth and asset downloads now
+  retry up to 3 times with 1 s / 3 s / 9 s backoff on transient resets.
+  File downloads resume from where they left off via `Range:` instead of
+  restarting from byte 0.
+- **Single-instance gate hardened**: lock file now stores the holder PID
+  for diagnostics; second-launch attempts also actually raise the existing
+  window (was previously just `visible = true`, leaving it minimised /
+  buried under other windows on KDE / Hyprland / GNOME).
 - Strict version comparison in the update flow: `1.3.0 > 1.3.0-rc3`,
   `rc1 < rc2 < rc3`, `alpha < beta < rc`. Without this the prerelease channel
   would consider RC bumps within the same base "the same version".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Aura Launcher will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-Each released entry should open with a short `### Highlights` block —
+※ Each released entry opens with a short `### Highlights` block —
 2-5 plain-English bullets summarizing what the user actually notices.
 The launcher's in-app update dialog renders just the Highlights; the
 detailed `### Added`/`### Changed`/`### Fixed`/`### Removed` sections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ single-instance gate failing to actually raise the existing window on
 KDE / Hyprland / GNOME.
 
 ### Highlights
+- **Cold-start much faster after a clean session**: when the server
+  manifest hasn't changed since the last successful sync (TTL 7 days),
+  the launcher skips the per-file MD5 integrity walk. On a 1000-file
+  modpack this collapses multi-second checks into a single hash compare.
+- **Orphan files now actually leave**: when the upstream modpack
+  removes a mod, the corresponding local file is pruned on next sync
+  (was: lingered forever, often causing mismatch crashes on join).
+- **User-extendable protected-paths list**: drop a mod into
+  `dataDir/protected-paths.json` and the launcher will never overwrite
+  configs under that directory, even when the manifest says they're
+  stale. Defaults shipped with the file on first run.
 - **SMARTYcraft channel pinned to HTTP/1.1**: h2 multiplexing over the
   upstream SOCKS proxy was dropping mid-stream on long bodies. 1.1 with
   parallel connections trades multiplexing for resilience. Direct channel
@@ -73,6 +84,21 @@ KDE / Hyprland / GNOME.
   ignores housekeeping files (`.lock`, `.show`, `.migrated`) — a
   follow-up to the lock-before-migration order so first-run still triggers
   when the lock file already exists in the target dir.
+- `UpdateApplicator` (320-line `object`) split into `IUpdateApplicator`
+  interface + `Windows`/`Mac`/`Linux`/`NoOp` implementations selected by
+  `OS` at startup. Per-platform shutdown hooks register exactly once via
+  Koin singleton. `UpdateDialog` switched from static call to injected
+  interface.
+- `extra.zip` unpacking now snapshots the extracted file list into
+  `.extra_unpacked_index.json`. On the next sync, files in the old
+  snapshot but not in the new one are pruned (orphans removed by the
+  upstream modpack). Protected paths are never touched even if they
+  appeared in the previous index.
+- `FileDownloadService.processSession` short-circuits the per-file MD5
+  walk when the manifest hash matches the last successful sync (TTL
+  7 days). Cache lives at `dataDir/manifest-cache/<server>.json`. On
+  a 1000-file modpack this turns multi-second cold-start integrity
+  checks into a single hash comparison.
 
 ## [2.2.8] - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,69 @@ below are for the GitHub release page and CHANGELOG readers.
 
 ## [Unreleased]
 
+## [2.2.9] - 2026-05-10
+
+Stability sweep — four user-visible reliability fixes that ride on the
+infrastructure shipped in 2.2.8. Targeted at the failure classes observed
+in production logs: mid-stream HTTP/2 resets on the SOCKS-proxied
+SMARTYcraft channel, downloads restarting from byte 0 on every flake,
+duplicate auth requests on the dashboard → Play flow, and the
+single-instance gate failing to actually raise the existing window on
+KDE / Hyprland / GNOME.
+
+### Highlights
+- **SMARTYcraft channel pinned to HTTP/1.1**: h2 multiplexing over the
+  upstream SOCKS proxy was dropping mid-stream on long bodies. 1.1 with
+  parallel connections trades multiplexing for resilience. Direct channel
+  (GitHub releases, BellSoft JDKs, Maven Central) is unaffected.
+- **Auth and downloads now retry on transient resets** (3 attempts, 1 s /
+  3 s / 9 s backoff). Auth-rejection responses and SSL cert errors are
+  explicitly *not* retried — those need user attention, not a silent loop.
+- **Downloads resume via `Range:`** instead of restarting from byte 0.
+  A 100 MB asset that drops at 70 % now costs seconds to recover instead
+  of restarting the whole transfer.
+- **Per-server session cache** in `AuthService`: dashboard list refresh
+  and the actual server-launch auth used to fire two back-to-back logins
+  for the same server. The second one now returns the 30-second-cached
+  session without hitting the network — fewer requests, fewer chances to
+  trip the upstream's "sessions don't dedup" race.
+- **Single-instance gate raises the existing window**: second-launch
+  attempts previously only flipped `visible = true`, leaving the window
+  minimised or buried under other windows on KDE / Hyprland / GNOME.
+  Now un-minimises and pulses `isAlwaysOnTop` to force a true raise.
+  Lock file also stores the holder PID for diagnostics
+  (`cat ~/.local/share/aura-launcher/.lock`).
+
+### Added
+- `RetryWithBackoff` utility in `client-core/util/`. Generic suspend
+  wrapper with caller-supplied retry predicate; deliberately narrow.
+  5 unit tests cover the predicate contract.
+- `Network.FORCE_HTTP1_FOR_SMARTYCRAFT` knob (default true). Wired via
+  an `OkHttpClient.Builder` extension in `Modules.kt` so secure and
+  insecure smartycraft clients pick it up identically.
+- `SingleInstance` helper in `client-launcher/.../platform/`. Holds the
+  channel + lock on a static field, registers a shutdown hook with audit
+  log line, writes the holder PID into the lock file. 4 unit tests.
+- `.show` watcher in `Main.kt` raises the window via `windowState.isMinimized = false`,
+  `toFront()`, and the `isAlwaysOnTop` pulse trick (the only cross-WM way
+  to force a focus-steal-like raise on X11/Wayland).
+- Per-server session cache in `AuthService` with 30 s TTL. Dashboard load
+  and Play within the same server are deduplicated to one network request.
+
+### Changed
+- `AuthService.login` and `FileDownloadService.downloadFileInternal`
+  wrapped in `retryWithBackoff` with predicates that walk the full
+  cause chain looking for `ConnectException` / `SocketException` /
+  `ClosedByteChannelException` / `SocketTimeoutException` and "Connection
+  reset" `IOException`s. `CancellationException` is explicitly excluded.
+- `FileDownloadService` sends `Range: bytes=N-` when a partial file is on
+  disk; handles 206 (append), 200 (server ignored Range, overwrite),
+  416 (clear bad partial and refetch) explicitly.
+- `DataDirMigration.run` defers to a new `Path.hasUserData()` probe that
+  ignores housekeeping files (`.lock`, `.show`, `.migrated`) — a
+  follow-up to the lock-before-migration order so first-run still triggers
+  when the lock file already exists in the target dir.
+
 ## [2.2.8] - 2026-05-10
 
 Update Channels chunk — gives the launcher two new tools for surviving the
@@ -36,15 +99,6 @@ launchers ignore prereleases by GitHub API contract.
   so when an emergency upgrade is published the user sees the blocking
   dialog within ~5 minutes — no need to restart the launcher to pick it up.
   Routine release checks stay on the existing 12 h cadence.
-- **Network resilience on the SMARTYcraft channel**: pinned to HTTP/1.1
-  (h2 over SOCKS was dropping mid-stream); auth and asset downloads now
-  retry up to 3 times with 1 s / 3 s / 9 s backoff on transient resets.
-  File downloads resume from where they left off via `Range:` instead of
-  restarting from byte 0.
-- **Single-instance gate hardened**: lock file now stores the holder PID
-  for diagnostics; second-launch attempts also actually raise the existing
-  window (was previously just `visible = true`, leaving it minimised /
-  buried under other windows on KDE / Hyprland / GNOME).
 - Strict version comparison in the update flow: `1.3.0 > 1.3.0-rc3`,
   `rc1 < rc2 < rc3`, `alpha < beta < rc`. Without this the prerelease channel
   would consider RC bumps within the same base "the same version".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ PRs and forks are welcome. Code is GPL-3.0 — take it and do whatever.
 
 ---
 
-## Branch model
+## ── Branch model ──
 
 ```
 dev  →  (PR + Qodana CI)  →  stable
@@ -13,7 +13,7 @@ dev  →  (PR + Qodana CI)  →  stable
 All changes go through PRs against `dev`. Direct pushes to `stable` are not allowed.  
 Releases are tagged from `stable` via `build_release.yml`.
 
-## Changelog
+## ── Changelog ──
 
 Each released version's entry in `CHANGELOG.md` should open with a short
 `### Highlights` section — 2-5 user-facing bullets explaining what the user
@@ -26,7 +26,7 @@ alongside the binaries, and `UpdateService` shows it in the in-app update
 dialog. Releases without a Highlights block fall back to rendering the full
 changelog there.
 
-## Commit style
+## ── Commit style ──
 
 Scoped, minimal commits. No squash-merging noise.
 
@@ -36,12 +36,12 @@ feat(update): add isCritical flag detection from release title
 chore(deps): pin JNA to 5.18.1 on Windows
 ```
 
-## Code quality
+## ── Code quality ──
 
 Every PR is scanned by [Qodana](https://www.jetbrains.com/qodana/) (`qodana_code_quality.yml`).  
 The scan runs in full mode (`pr-mode: false`) — all files, not just changed ones.
 
-## Testing
+## ── Testing ──
 
 ```bash
 ./gradlew :client-core:test :client-launcher:test
@@ -53,7 +53,7 @@ Tests live in:
 
 Shared test fixtures are in `client-core/src/testFixtures/` via `java-test-fixtures`.
 
-## Module structure
+## ── Module structure ──
 
 | Module            | Purpose                                        |
 |-------------------|------------------------------------------------|
@@ -62,11 +62,11 @@ Shared test fixtures are in `client-core/src/testFixtures/` via `java-test-fixtu
 | `client-launcher` | DI wiring, file download, update, launch logic |
 | `client-ui`       | Compose Multiplatform desktop UI               |
 
-## Stack
+## ── Stack ──
 
 Kotlin · Compose Multiplatform · Ktor · Koin · Skiko · dorkbox/SystemTray · Logback
 
-## Platform notes
+## ── Platform notes ──
 
 - **Windows**: JNA must stay pinned to `5.18.1` in `client-ui` and forced to `6.1.6` globally via `resolutionStrategy` — dorkbox/SystemTray 4.4 has a hardcoded version check.
 - **Linux**: AppImage is assembled manually in CI (`build_release.yml`), not via Compose packaging.
@@ -74,6 +74,6 @@ Kotlin · Compose Multiplatform · Ktor · Koin · Skiko · dorkbox/SystemTray �
 
 ---
 
-## License
+## ── License ──
 
 By contributing, you agree that your work will be licensed under [GPL-3.0](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,17 @@ Tests live in:
 
 Shared test fixtures are in `client-core/src/testFixtures/` via `java-test-fixtures`.
 
+After cloning, install the pre-push hook so failing tests block your push
+before they hit CI:
+
+```bash
+./scripts/install-hooks.sh
+```
+
+Symlinks `hooks/pre-push` into `.git/hooks/pre-push`; future updates to the
+hook script reach you automatically. Bypass with `git push --no-verify` if
+you really need to push WIP, but please don't make a habit of it.
+
 ## ── Module structure ──
 
 | Module            | Purpose                                        |

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ---
 
-> Not affiliated with or endorsed by SMARTYcraft.  
-> Protocol constants reverse-engineered from [`Kitty-Hivens/smrt-deco`](https://github.com/Kitty-Hivens/smrt-deco).
+> ※ Not affiliated with or endorsed by SMARTYcraft.  
+> ※ Protocol constants reverse-engineered from [`Kitty-Hivens/smrt-deco`](https://github.com/Kitty-Hivens/smrt-deco).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,6 @@ subprojects {
             }
 
             compilerArgs.addAll(listOf(
-                "-Xlint:none",
                 "-parameters"
             ))
         }

--- a/client-config/src/main/kotlin/hivens/config/Network.kt
+++ b/client-config/src/main/kotlin/hivens/config/Network.kt
@@ -42,6 +42,22 @@ object Network {
     const val TIMEOUT_READ    = 300_000L
 
     /**
+     * Force HTTP/1.1 on the smartycraft channel.
+     *
+     * okhttp negotiates HTTP/2 by default when the server advertises ALPN
+     * support. h2 multiplexing over a SOCKS proxy with long-running response
+     * bodies (auth payloads, file manifest sync) periodically dies with
+     * `Connection reset` mid-stream — observed in the wild on the SMARTYcraft
+     * channel. HTTP/1.1 with parallel connections trades multiplexing for
+     * resilience to mid-stream resets and is the safer default while we
+     * don't control the proxy or the upstream server.
+     *
+     * The direct channel (GitHub, BellSoft, Maven Central) is unaffected —
+     * those endpoints have rock-solid h2 stacks and no SOCKS hop.
+     */
+    const val FORCE_HTTP1_FOR_SMARTYCRAFT = true
+
+    /**
      * Hardcoded SOCKS proxy that the upstream service expects every client
      * to tunnel through. The credentials are part of the protocol (recovered
      * from the decompiled official launcher) — they are public by definition,

--- a/client-config/src/main/kotlin/hivens/config/Storage.kt
+++ b/client-config/src/main/kotlin/hivens/config/Storage.kt
@@ -8,7 +8,8 @@ package hivens.config
  * leaf names so callers don't sprinkle "settings.json" string literals.
  */
 object Storage {
-    const val SETTINGS_FILE   = "settings.json"
-    const val PROFILES_FILE   = "profiles.json"
-    const val HASH_CACHE_FILE = "smarty_hash.cache"
+    const val SETTINGS_FILE         = "settings.json"
+    const val PROFILES_FILE         = "profiles.json"
+    const val HASH_CACHE_FILE       = "smarty_hash.cache"
+    const val PROTECTED_PATHS_FILE  = "protected-paths.json"
 }

--- a/client-core/src/main/kotlin/hivens/core/api/AuthService.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/AuthService.kt
@@ -29,16 +29,29 @@ class AuthService(
     private val client get() = clientProvider.current
 
     /**
-     * Diagnostic-only state for the "double login" issue observed in
-     * production: see CHANGELOG note next to the fix that consumes this.
-     * Per-server timestamp of the most recent login attempt; if a second
-     * call lands within 5s on the same server, we log a warn-level stack
-     * trace so the offending caller surfaces in the next user log paste.
-     * This does NOT block the second call — diagnose first, fix in a
-     * follow-up once the offender is known.
+     * Per-server session cache. The dashboard renders server cards by
+     * doing a "list servers" auth, then the Play button does a "launch
+     * server" auth — historically two consecutive logins for the same
+     * serverId within ~3 seconds. Both call sites are legitimate; they
+     * just don't share state. Caching here deduplicates them down to
+     * one network request as long as the user clicks Play within the
+     * TTL window.
+     *
+     * Username is part of the cache key because in principle the user
+     * could re-auth as a different account between the two calls (rare,
+     * but not impossible). Password is not part of the key — when the
+     * user is the same the password is the same; if they differ we don't
+     * hit the cache anyway because of the username mismatch.
+     *
+     * 30 s TTL: long enough for "open launcher → pick server → click Play",
+     * short enough that the upstream server still considers the session
+     * fresh. Cache is in-memory only — process restart re-auths.
      */
-    private val lastLoginNanos = java.util.concurrent.ConcurrentHashMap<String, Long>()
-    private val duplicateLoginWindowNs = 5_000_000_000L  // 5 seconds
+    private data class CacheKey(val username: String, val serverId: String)
+    private data class CachedSession(val session: SessionData, val expiresAt: Long)
+
+    private val sessionCache = java.util.concurrent.ConcurrentHashMap<CacheKey, CachedSession>()
+    private val sessionTtlMs = 30_000L
 
     @Serializable
     private data class AuthRequest(
@@ -68,7 +81,10 @@ class AuthService(
     )
 
     override suspend fun login(username: String, password: String, serverId: String): SessionData {
-        warnIfDuplicate(serverId)
+        cachedFor(username, serverId)?.let {
+            logger.info("Login via API V3 (server: {}) — cache hit, skipping network", serverId)
+            return it
+        }
         logger.info("Login via API V3 (server: {})...", serverId)
 
         val passwordEncoded = HashUtils.md5(password)
@@ -159,23 +175,22 @@ class AuthService(
             serverId = serverId,
             cachedPassword = password,
             balance = response.money
-        )
+        ).also { cacheSession(username, serverId, it) }
     }
 
-    private fun warnIfDuplicate(serverId: String) {
-        val now = System.nanoTime()
-        val previous = lastLoginNanos.put(serverId, now) ?: return
-        val deltaNs = now - previous
-        if (deltaNs < duplicateLoginWindowNs) {
-            val deltaMs = deltaNs / 1_000_000
-            // Synthetic exception captures the stack so the duplicate caller
-            // is visible in logs. Throwable construction is cheap relative
-            // to a network call and only fires inside the 5s window.
-            logger.warn(
-                "Duplicate login attempt for server '{}' within {}ms — possible UI re-fire or unintended re-auth before launch",
-                serverId, deltaMs, Throwable("duplicate-login stack").also { it.stackTrace = it.stackTrace.drop(1).toTypedArray() },
-            )
+    private fun cachedFor(username: String, serverId: String): SessionData? {
+        val key = CacheKey(username, serverId)
+        val cached = sessionCache[key] ?: return null
+        if (System.currentTimeMillis() >= cached.expiresAt) {
+            sessionCache.remove(key, cached)
+            return null
         }
+        return cached.session
+    }
+
+    private fun cacheSession(username: String, serverId: String, session: SessionData) {
+        sessionCache[CacheKey(username, serverId)] =
+            CachedSession(session, System.currentTimeMillis() + sessionTtlMs)
     }
 
     private fun generateGameToken(uid: String?, sessionV3: String?): String? {

--- a/client-core/src/main/kotlin/hivens/core/api/AuthService.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/AuthService.kt
@@ -7,6 +7,7 @@ import hivens.core.data.AuthStatus
 import hivens.core.data.FileManifest
 import hivens.core.data.SessionData
 import hivens.core.util.HashUtils
+import hivens.core.util.retryWithBackoff
 import io.ktor.client.call.*
 import io.ktor.client.request.forms.*
 import io.ktor.http.*
@@ -26,6 +27,18 @@ class AuthService(
 
     private val logger = LoggerFactory.getLogger(AuthService::class.java)
     private val client get() = clientProvider.current
+
+    /**
+     * Diagnostic-only state for the "double login" issue observed in
+     * production: see CHANGELOG note next to the fix that consumes this.
+     * Per-server timestamp of the most recent login attempt; if a second
+     * call lands within 5s on the same server, we log a warn-level stack
+     * trace so the offending caller surfaces in the next user log paste.
+     * This does NOT block the second call — diagnose first, fix in a
+     * follow-up once the offender is known.
+     */
+    private val lastLoginNanos = java.util.concurrent.ConcurrentHashMap<String, Long>()
+    private val duplicateLoginWindowNs = 5_000_000_000L  // 5 seconds
 
     @Serializable
     private data class AuthRequest(
@@ -55,6 +68,7 @@ class AuthService(
     )
 
     override suspend fun login(username: String, password: String, serverId: String): SessionData {
+        warnIfDuplicate(serverId)
         logger.info("Login via API V3 (server: {})...", serverId)
 
         val passwordEncoded = HashUtils.md5(password)
@@ -79,23 +93,27 @@ class AuthService(
         val jsonString = json.encodeToString(requestPayload)
 
         val response: AuthResponse = try {
-            val call = client.submitForm(
-                url = Network.AUTH_URL,
-                formParameters = Parameters.build {
-                    append("action", "login")
-                    append("json", jsonString)
-                }
-            )
-            // Reading the response body as a string for manual error handling
-            val rawBody = call.body<String>().trim()
+            retryWithBackoff(operation = "auth login", shouldRetry = ::isTransientNetworkError) {
+                val call = client.submitForm(
+                    url = Network.AUTH_URL,
+                    formParameters = Parameters.build {
+                        append("action", "login")
+                        append("json", jsonString)
+                    }
+                )
+                // Reading the response body as a string for manual error handling
+                val rawBody = call.body<String>().trim()
 
-            // Handling text server errors
-            if (rawBody.contains("Bad login", ignoreCase = true)) throw AuthException(AuthStatus.BAD_LOGIN, "Invalid login or password")
-            if (rawBody.contains("User not found", ignoreCase = true)) throw AuthException(AuthStatus.BAD_LOGIN, "User not found")
+                // Handling text server errors. These are deliberate auth
+                // rejections from the server, never retryable; isTransientNetworkError
+                // returns false for AuthException so retryWithBackoff bubbles them
+                // out on the first attempt.
+                if (rawBody.contains("Bad login", ignoreCase = true)) throw AuthException(AuthStatus.BAD_LOGIN, "Invalid login or password")
+                if (rawBody.contains("User not found", ignoreCase = true)) throw AuthException(AuthStatus.BAD_LOGIN, "User not found")
 
-            // Parse JSON
-            json.decodeFromString(rawBody)
-
+                // Parse JSON
+                json.decodeFromString<AuthResponse>(rawBody)
+            }
         } catch (e: Exception) {
             if (e is AuthException) throw e
             logger.error("Authorization error", e)
@@ -144,6 +162,22 @@ class AuthService(
         )
     }
 
+    private fun warnIfDuplicate(serverId: String) {
+        val now = System.nanoTime()
+        val previous = lastLoginNanos.put(serverId, now) ?: return
+        val deltaNs = now - previous
+        if (deltaNs < duplicateLoginWindowNs) {
+            val deltaMs = deltaNs / 1_000_000
+            // Synthetic exception captures the stack so the duplicate caller
+            // is visible in logs. Throwable construction is cheap relative
+            // to a network call and only fires inside the 5s window.
+            logger.warn(
+                "Duplicate login attempt for server '{}' within {}ms — possible UI re-fire or unintended re-auth before launch",
+                serverId, deltaMs, Throwable("duplicate-login stack").also { it.stackTrace = it.stackTrace.drop(1).toTypedArray() },
+            )
+        }
+    }
+
     private fun generateGameToken(uid: String?, sessionV3: String?): String? {
         if (sessionV3 == null || uid == null) return sessionV3
         return try {
@@ -172,6 +206,32 @@ class AuthService(
         rand.nextBytes(mac)
         mac[0] = (mac[0].toInt() and 254).toByte()
         return mac.joinToString("-") { "%02X".format(it) }
+    }
+
+    /**
+     * True for the narrow set of transient network failures we've seen on
+     * the SMARTYcraft channel — h2 frame resets over SOCKS, raw socket
+     * resets during TLS, ktor's wrapped channel-closed exception. NOT true
+     * for [AuthException] (those are server-side rejections, retrying just
+     * locks the user out faster) or SSL cert errors (those need user opt-in,
+     * not a silent retry).
+     */
+    private fun isTransientNetworkError(t: Throwable): Boolean {
+        if (t is AuthException) return false
+        if (t.isSslCertificateError()) return false
+        var cause: Throwable? = t
+        while (cause != null) {
+            if (cause is java.net.ConnectException ||
+                cause is java.net.SocketException ||
+                cause is io.ktor.utils.io.ClosedByteChannelException ||
+                cause is java.net.SocketTimeoutException
+            ) return true
+            if (cause is java.io.IOException &&
+                cause.message?.contains("Connection reset", ignoreCase = true) == true
+            ) return true
+            cause = cause.cause
+        }
+        return false
     }
 
     private fun Throwable.isSslCertificateError(): Boolean {

--- a/client-core/src/main/kotlin/hivens/core/api/AuthService.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/AuthService.kt
@@ -37,17 +37,19 @@ class AuthService(
      * one network request as long as the user clicks Play within the
      * TTL window.
      *
-     * Username is part of the cache key because in principle the user
-     * could re-auth as a different account between the two calls (rare,
-     * but not impossible). Password is not part of the key — when the
-     * user is the same the password is the same; if they differ we don't
-     * hit the cache anyway because of the username mismatch.
+     * Cache key is `(username, passwordHash, serverId)`. Password hash
+     * is mandatory in the key because otherwise a second login attempt
+     * with the *wrong* password within the 30 s TTL would silently
+     * succeed via cache, masking real credential rotation (Codex P2 on
+     * PR #128). We use the MD5 already computed for the auth request,
+     * not the plaintext password — same secret-handling profile as the
+     * rest of the call.
      *
      * 30 s TTL: long enough for "open launcher → pick server → click Play",
      * short enough that the upstream server still considers the session
      * fresh. Cache is in-memory only — process restart re-auths.
      */
-    private data class CacheKey(val username: String, val serverId: String)
+    private data class CacheKey(val username: String, val passwordHash: String, val serverId: String)
     private data class CachedSession(val session: SessionData, val expiresAt: Long)
 
     private val sessionCache = java.util.concurrent.ConcurrentHashMap<CacheKey, CachedSession>()
@@ -81,13 +83,16 @@ class AuthService(
     )
 
     override suspend fun login(username: String, password: String, serverId: String): SessionData {
-        cachedFor(username, serverId)?.let {
+        // Hash first so the cache key includes the password — otherwise a
+        // wrong/rotated password within the TTL would silently succeed
+        // via cache. (Codex P2 on PR #128.)
+        val passwordEncoded = HashUtils.md5(password)
+        cachedFor(username, passwordEncoded, serverId)?.let {
             logger.info("Login via API V3 (server: {}) — cache hit, skipping network", serverId)
             return it
         }
         logger.info("Login via API V3 (server: {})...", serverId)
 
-        val passwordEncoded = HashUtils.md5(password)
         val clientSessionId = UUID.randomUUID().toString().replace("-", "")
         val is64 = System.getProperty("os.arch").contains("64")
 
@@ -175,11 +180,11 @@ class AuthService(
             serverId = serverId,
             cachedPassword = password,
             balance = response.money
-        ).also { cacheSession(username, serverId, it) }
+        ).also { cacheSession(username, passwordEncoded, serverId, it) }
     }
 
-    private fun cachedFor(username: String, serverId: String): SessionData? {
-        val key = CacheKey(username, serverId)
+    private fun cachedFor(username: String, passwordHash: String, serverId: String): SessionData? {
+        val key = CacheKey(username, passwordHash, serverId)
         val cached = sessionCache[key] ?: return null
         if (System.currentTimeMillis() >= cached.expiresAt) {
             sessionCache.remove(key, cached)
@@ -188,8 +193,8 @@ class AuthService(
         return cached.session
     }
 
-    private fun cacheSession(username: String, serverId: String, session: SessionData) {
-        sessionCache[CacheKey(username, serverId)] =
+    private fun cacheSession(username: String, passwordHash: String, serverId: String, session: SessionData) {
+        sessionCache[CacheKey(username, passwordHash, serverId)] =
             CachedSession(session, System.currentTimeMillis() + sessionTtlMs)
     }
 

--- a/client-core/src/main/kotlin/hivens/core/api/interfaces/IUpdateApplicator.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/interfaces/IUpdateApplicator.kt
@@ -1,0 +1,32 @@
+package hivens.core.api.interfaces
+
+import java.nio.file.Path
+
+/**
+ * Schedules a downloaded update installer to be applied when the launcher
+ * exits. Implementations are platform-specific — they all run their work
+ * via a [Runtime.addShutdownHook] so the user-visible `exitProcess(0)`
+ * call from `UpdateDialog` triggers the install.
+ *
+ * Wired through Koin: a factory in `client-launcher/.../di/Modules.kt`
+ * picks the right [IUpdateApplicator] implementation by [hivens.launcher.platform.OS].
+ *
+ * Lives in `client-core` so `UpdateDialog` (in `client-ui`) can inject the
+ * interface without depending on the concrete platform classes — keeps
+ * the layering one-way (config ← core ← launcher ← ui).
+ */
+interface IUpdateApplicator {
+    /**
+     * Schedules [installerPath] to be installed right after the JVM exits.
+     * The implementation is responsible for:
+     *   - resolving where the current launcher binary lives,
+     *   - backing it up before overwrite,
+     *   - relaunching the new version,
+     *   - rolling back on failure where it can.
+     *
+     * Throws [UnsupportedOperationException] from the no-op implementation
+     * registered on unrecognised platforms; callers should treat that as
+     * "ask the user to download and install manually".
+     */
+    fun scheduleUpdate(installerPath: Path)
+}

--- a/client-core/src/main/kotlin/hivens/core/util/RetryWithBackoff.kt
+++ b/client-core/src/main/kotlin/hivens/core/util/RetryWithBackoff.kt
@@ -1,0 +1,55 @@
+package hivens.core.util
+
+import kotlinx.coroutines.delay
+import org.slf4j.LoggerFactory
+
+private val log = LoggerFactory.getLogger("RetryWithBackoff")
+
+/**
+ * Retries [block] up to [attempts] times with a hard-coded 1s / 3s / 9s
+ * backoff between attempts, retrying only on exceptions matching
+ * [shouldRetry]. The last exception bubbles up unmodified.
+ *
+ * Designed narrowly for the "transient HTTP/2 reset over SOCKS" case the
+ * launcher hits in production — auth flow and chunk downloads on the
+ * smartycraft channel periodically die mid-stream and a single retry
+ * almost always succeeds. Not a general-purpose retry utility; resist
+ * the urge to grow it.
+ *
+ * The [operation] string is for logs only — appears in the retry warning
+ * lines so a user log paste shows which call is flapping.
+ */
+suspend fun <T> retryWithBackoff(
+    operation: String,
+    attempts: Int = 3,
+    shouldRetry: (Throwable) -> Boolean,
+    block: suspend () -> T,
+): T {
+    require(attempts >= 1) { "attempts must be >= 1, got $attempts" }
+
+    val backoffMs = longArrayOf(1_000, 3_000, 9_000)
+    var lastError: Throwable? = null
+
+    repeat(attempts) { i ->
+        try {
+            return block()
+        } catch (e: Throwable) {
+            if (!shouldRetry(e)) throw e
+            lastError = e
+            if (i < attempts - 1) {
+                val wait = backoffMs.getOrElse(i) { backoffMs.last() }
+                log.warn(
+                    "{} attempt {}/{} failed: {} — retrying in {}ms",
+                    operation, i + 1, attempts, e.message ?: e::class.simpleName, wait,
+                )
+                delay(wait)
+            } else {
+                log.error(
+                    "{} failed after {} attempts: {}",
+                    operation, attempts, e.message ?: e::class.simpleName,
+                )
+            }
+        }
+    }
+    throw lastError!!
+}

--- a/client-core/src/main/kotlin/hivens/core/util/ZipUtils.kt
+++ b/client-core/src/main/kotlin/hivens/core/util/ZipUtils.kt
@@ -9,9 +9,21 @@ import java.util.zip.ZipInputStream
 object ZipUtils {
     private val logger = LoggerFactory.getLogger(ZipUtils::class.java)
 
-    fun unzip(zipFile: File, destDir: File) {
+    /**
+     * Unzips [zipFile] into [destDir]. Returns the relative paths of every
+     * file (NOT directory) extracted, normalised to forward slashes, in
+     * the order they appeared in the archive. Existing callers that
+     * ignore the return value are unaffected.
+     *
+     * The path list is what powers `FileDownloadService`'s extra.zip
+     * orphan-pruning — by snapshotting the contents of the previous
+     * unpack we can diff against the new contents and remove files that
+     * the upstream modpack dropped.
+     */
+    fun unzip(zipFile: File, destDir: File): List<String> {
         if (!destDir.exists()) destDir.mkdirs()
         val buffer = ByteArray(8192)
+        val extracted = mutableListOf<String>()
 
         ZipInputStream(FileInputStream(zipFile)).use { zis ->
             var zipEntry = zis.nextEntry
@@ -38,10 +50,12 @@ object ZipUtils {
                             fos.write(buffer, 0, len)
                         }
                     }
+                    extracted += zipEntry.name.replace('\\', '/')
                 }
                 zipEntry = zis.nextEntry
             }
             zis.closeEntry()
         }
+        return extracted
     }
 }

--- a/client-core/src/test/kotlin/hivens/core/util/RetryWithBackoffTest.kt
+++ b/client-core/src/test/kotlin/hivens/core/util/RetryWithBackoffTest.kt
@@ -1,0 +1,89 @@
+package hivens.core.util
+
+import kotlinx.coroutines.test.runTest
+import java.io.IOException
+import java.net.SocketException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class RetryWithBackoffTest {
+
+    @Test
+    fun `succeeds on first attempt without delay`() = runTest {
+        var calls = 0
+        val result = retryWithBackoff(
+            operation = "test",
+            shouldRetry = { true },
+        ) {
+            calls++
+            "ok"
+        }
+        assertEquals("ok", result)
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `retries on retryable exception then succeeds`() = runTest {
+        var calls = 0
+        val result = retryWithBackoff(
+            operation = "test",
+            shouldRetry = { it is SocketException },
+        ) {
+            calls++
+            if (calls < 2) throw SocketException("Connection reset")
+            "recovered"
+        }
+        assertEquals("recovered", result)
+        assertEquals(2, calls)
+    }
+
+    @Test
+    fun `bubbles non-retryable exception immediately`() = runTest {
+        var calls = 0
+        assertFailsWith<IllegalStateException> {
+            retryWithBackoff(
+                operation = "test",
+                shouldRetry = { it is SocketException },
+            ) {
+                calls++
+                throw IllegalStateException("don't retry me")
+            }
+        }
+        assertEquals(1, calls, "non-retryable exception must not trigger a retry")
+    }
+
+    @Test
+    fun `gives up after max attempts and throws last exception`() = runTest {
+        var calls = 0
+        val ex = assertFailsWith<IOException> {
+            retryWithBackoff(
+                operation = "test",
+                attempts = 3,
+                shouldRetry = { true },
+            ) {
+                calls++
+                throw IOException("attempt $calls")
+            }
+        }
+        assertEquals(3, calls)
+        assertTrue(ex.message!!.contains("attempt 3"), "last attempt's exception should bubble up")
+    }
+
+    @Test
+    fun `attempts of 1 means no retry`() = runTest {
+        var calls = 0
+        assertFailsWith<IOException> {
+            retryWithBackoff(
+                operation = "test",
+                attempts = 1,
+                shouldRetry = { true },
+            ) {
+                calls++
+                throw IOException("once")
+            }
+        }
+        assertEquals(1, calls)
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -253,9 +253,13 @@ class FileDownloadService(
                         HttpStatusCode.RequestedRangeNotSatisfiable -> {
                             // 416: partial on disk is bigger than the upstream file
                             // (corrupt write or upstream shrank). Clear and let retry
-                            // fetch from byte 0.
+                            // fetch from byte 0. Throw the dedicated subclass so
+                            // isTransientDownloadError recognises it as retryable
+                            // — a plain IOException with this message would NOT
+                            // match the predicate's substring checks and would
+                            // hard-fail instead of recovering.
                             Files.deleteIfExists(localPath)
-                            throw IOException("HTTP 416 for $url; cleared bad partial, will refetch")
+                            throw RetryableHttpException("HTTP 416 for $url; cleared bad partial, will refetch")
                         }
                         else -> throw IOException("HTTP ${response.status} for $url")
                     }
@@ -282,6 +286,17 @@ class FileDownloadService(
         }
     }
 
+    /**
+     * Sentinel for "we deliberately threw to trigger a retry after fixing
+     * local state". Currently the only thrower is the 416 branch in
+     * [downloadFileInternal], which deletes the bad partial before
+     * raising this so the next retry fetches from byte 0. Adding a
+     * subclass instead of pattern-matching the message keeps the contract
+     * explicit — string matching on `cause.message` was the bug Codex
+     * caught on PR #128.
+     */
+    private class RetryableHttpException(message: String) : IOException(message)
+
     private fun isTransientDownloadError(t: Throwable): Boolean {
         // CancellationException must NEVER be retried — it's how the parent
         // coroutine signals "stop"; swallowing and retrying would deadlock
@@ -289,6 +304,7 @@ class FileDownloadService(
         if (t is CancellationException) return false
         var cause: Throwable? = t
         while (cause != null) {
+            if (cause is RetryableHttpException) return true
             if (cause is java.net.ConnectException ||
                 cause is java.net.SocketException ||
                 cause is io.ktor.utils.io.ClosedByteChannelException ||

--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -62,13 +62,20 @@ class FileDownloadService(
         Files.createDirectories(targetDir)
 
         // ── Manifest cache short-circuit ─────────────────────────────────
-        // If this same manifest was successfully synced recently (≤TTL),
-        // skip the full per-file MD5 walk and the extra.zip processing.
-        // Both downstream steps are themselves hash-gated and would no-op,
-        // but the integrity walk alone dominates cold-start on 1000-file
-        // modpacks. The TTL inside ManifestCache is the safety valve
-        // for "but what if a file got corrupted on disk?" scenarios.
-        val manifestHash = manifestCache.hashOf(indexJson.encodeToString(manifest))
+        // If this same manifest *with the same ignoredFiles set* was
+        // successfully synced recently (≤TTL), skip the full per-file
+        // MD5 walk and the extra.zip processing. Both downstream steps
+        // are themselves hash-gated and would no-op, but the integrity
+        // walk alone dominates cold-start on 1000-file modpacks. The
+        // TTL inside ManifestCache is the safety valve for "what if a
+        // file got corrupted on disk?" scenarios.
+        //
+        // ignoredFiles is part of the cache input because cleanupIgnoredFiles
+        // (which physically deletes disabled mod jars) lives below this
+        // gate — caching only on manifest hash would let a freshly-disabled
+        // mod stay loaded until the cache expires or the manifest changes
+        // upstream. (Codex P2 on PR #128.)
+        val manifestHash = manifestCache.hashOf(cacheKeyInputFor(manifest, ignoredFiles))
         if (manifestCache.isClean(serverId, manifestHash)) {
             messageUI?.invoke("Files verified (cached)")
             return@withContext
@@ -95,6 +102,17 @@ class FileDownloadService(
         // 5. Mark this manifest as cleanly synced — next session with the
         // same manifest hash short-circuits the integrity walk above.
         manifestCache.markClean(serverId, manifestHash)
+    }
+
+    /**
+     * Composes the cache-key input as `<canonical-manifest-json>|ignored:<sorted-csv>`.
+     * Sorting the ignored set is mandatory — `Set` iteration order isn't
+     * stable, and the cache must be insensitive to insertion order while
+     * sensitive to membership changes.
+     */
+    private fun cacheKeyInputFor(manifest: FileManifest, ignoredFiles: Set<String>?): String {
+        val ignored = ignoredFiles?.toSortedSet()?.joinToString(",") ?: ""
+        return indexJson.encodeToString(manifest) + "|ignored:" + ignored
     }
 
     /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -32,6 +32,7 @@ import kotlin.math.roundToInt
 class FileDownloadService(
     private val clientProvider: HttpClientProvider,
     private val protectedPaths: ProtectedPaths,
+    private val manifestCache: ManifestCache,
 ) : IFileDownloadService {
     private val client get() = clientProvider.current
 
@@ -60,6 +61,19 @@ class FileDownloadService(
         val manifest = session.fileManifest ?: throw IOException("File manifest is empty!")
         Files.createDirectories(targetDir)
 
+        // ── Manifest cache short-circuit ─────────────────────────────────
+        // If this same manifest was successfully synced recently (≤TTL),
+        // skip the full per-file MD5 walk and the extra.zip processing.
+        // Both downstream steps are themselves hash-gated and would no-op,
+        // but the integrity walk alone dominates cold-start on 1000-file
+        // modpacks. The TTL inside ManifestCache is the safety valve
+        // for "but what if a file got corrupted on disk?" scenarios.
+        val manifestHash = manifestCache.hashOf(indexJson.encodeToString(manifest))
+        if (manifestCache.isClean(serverId, manifestHash)) {
+            messageUI?.invoke("Files verified (cached)")
+            return@withContext
+        }
+
         // 1. Flatten manifest
         val filesMap = flattenManifest(manifest)
 
@@ -77,6 +91,10 @@ class FileDownloadService(
 
         // 4. Processing Extra.zip
         processExtraZip(targetDir, filesMap, extraCheckSum, messageUI)
+
+        // 5. Mark this manifest as cleanly synced — next session with the
+        // same manifest hash short-circuits the integrity walk above.
+        manifestCache.markClean(serverId, manifestHash)
     }
 
     /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -43,6 +43,9 @@ class FileDownloadService(
             "mods", "config", "bin", "assets", "libraries", "resources",
             "saves", "resourcepacks", "shaderpacks", "natives"
         )
+
+        private const val INDEX_FILENAME = ".extra_unpacked_index.json"
+        private val indexJson = kotlinx.serialization.json.Json { ignoreUnknownKeys = true }
     }
 
     override suspend fun processSession(
@@ -312,6 +315,21 @@ class FileDownloadService(
         }
     }
 
+    /**
+     * Snapshot of the last successful extra.zip extraction. Persisted as
+     * [INDEX_FILENAME] in `baseDir` so the next sync can diff old paths
+     * against new and prune files the upstream modpack removed.
+     *
+     * Default-constructed (empty hash + empty paths) when no previous
+     * snapshot exists — first unpack writes the index, second-and-later
+     * unpacks get the prune behaviour.
+     */
+    @kotlinx.serialization.Serializable
+    private data class ExtraZipIndex(
+        val hash: String = "",
+        val paths: List<String> = emptyList(),
+    )
+
     private fun processExtraZip(
         baseDir: Path,
         files: Map<String, FileData>,
@@ -320,38 +338,79 @@ class FileDownloadService(
     ) {
         val extraKey = files.keys.firstOrNull { normalizePath(it).endsWith("extra.zip") } ?: return
         val localZip = baseDir.resolve(normalizePath(extraKey))
+        if (!Files.exists(localZip)) return
 
-        if (Files.exists(localZip)) {
-            var needUnzip = true
-            val localHash = try { calculateMD5(localZip) } catch(_: Exception) { "" }
-            val markerFile = baseDir.resolve(".extra_unpacked_hash")
+        val localHash = try { calculateMD5(localZip) } catch (_: Exception) { "" }
+        val indexFile = baseDir.resolve(INDEX_FILENAME)
+        val previousIndex = readIndex(indexFile)
 
-            // If the server sent a hash to check configs (extraCheckSum)
-            if (!serverCheckSum.isNullOrEmpty()) {
-                if (localHash.equals(serverCheckSum, ignoreCase = true)) {
-                    needUnzip = false
-                }
-            } else {
-                val lastUnpackedHash = try {
-                    if (Files.exists(markerFile)) Files.readString(markerFile) else ""
-                } catch(_: Exception) { "" }
+        // Skip-unzip decision: server hash takes precedence; fallback to
+        // index hash from last successful extract.
+        val skipReason = when {
+            !serverCheckSum.isNullOrEmpty() && localHash.equals(serverCheckSum, true) -> "server hash matches"
+            localHash.isNotEmpty() && localHash == previousIndex.hash               -> "index hash matches last unpack"
+            else                                                                    -> null
+        }
+        if (skipReason != null) {
+            logger.debug("extra.zip unpack skipped — {}", skipReason)
+            return
+        }
 
-                if (localHash == lastUnpackedHash && localHash.isNotEmpty()) {
-                    needUnzip = false
-                }
-            }
-
-            if (needUnzip) {
-                try {
-                    messageUI?.invoke("Setting up the client...")
-                    ZipUtils.unzip(localZip.toFile(), baseDir.toFile())
-                    try { Files.writeString(markerFile, localHash) } catch(_: Exception) {}
-                } catch (e: Exception) {
-                    logger.error("Error unpacking extra.zip", e)
-                }
-            }
+        try {
+            messageUI?.invoke("Setting up the client...")
+            val newPaths = ZipUtils.unzip(localZip.toFile(), baseDir.toFile())
+            pruneOrphans(baseDir, previousIndex.paths, newPaths)
+            writeIndex(indexFile, ExtraZipIndex(hash = localHash, paths = newPaths))
+        } catch (e: Exception) {
+            logger.error("Error unpacking extra.zip", e)
         }
     }
+
+    /**
+     * Files in [previousPaths] that no longer appear in [currentPaths] are
+     * orphans — the upstream modpack removed them, so the local install
+     * should drop them too. Protected paths (per [protectedPaths]) are
+     * never touched even if the index says they were last there: the
+     * user may have edited an `options.txt` that originally arrived in
+     * extra.zip, and we promised never to overwrite their config.
+     */
+    private fun pruneOrphans(baseDir: Path, previousPaths: List<String>, currentPaths: List<String>) {
+        val current = currentPaths.toSet()
+        val orphans = previousPaths.filter { it !in current }
+        if (orphans.isEmpty()) return
+
+        var pruned = 0
+        for (rel in orphans) {
+            if (protectedPaths.isProtected(rel)) {
+                logger.debug("orphan {} kept — protected path", rel)
+                continue
+            }
+            val target = baseDir.resolve(rel)
+            try {
+                if (Files.deleteIfExists(target)) pruned++
+            } catch (e: Exception) {
+                logger.warn("Failed to prune orphan {}", rel, e)
+            }
+        }
+        if (pruned > 0) logger.info("Pruned {} orphan files removed by upstream extra.zip", pruned)
+    }
+
+    private fun readIndex(indexFile: Path): ExtraZipIndex {
+        if (!Files.exists(indexFile)) return ExtraZipIndex()
+        return runCatching {
+            indexJson.decodeFromString<ExtraZipIndex>(Files.readString(indexFile))
+        }.getOrElse {
+            logger.warn("extra.zip index unreadable; treating as empty (one missed prune cycle)", it)
+            ExtraZipIndex()
+        }
+    }
+
+    private fun writeIndex(indexFile: Path, index: ExtraZipIndex) {
+        runCatching {
+            Files.writeString(indexFile, indexJson.encodeToString(index))
+        }.onFailure { logger.warn("Failed to persist extra.zip index", it) }
+    }
+
 
     /**
      * Removes prefixes like "Industrial/mods/..." -> "mods/..."

--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -7,6 +7,7 @@ import hivens.core.data.FileData
 import hivens.core.data.FileManifest
 import hivens.core.data.SessionData
 import hivens.core.util.ZipUtils
+import hivens.core.util.retryWithBackoff
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -200,21 +201,83 @@ class FileDownloadService(
         withContext(Dispatchers.IO) {
             if (localPath.parent != null) Files.createDirectories(localPath.parent)
 
-            client.prepareGet(url).execute { response ->
-                if (!response.status.isSuccess()) throw IOException("HTTP ${response.status} for $url")
+            // Retry the whole transfer on transient network errors. The
+            // SMARTYcraft channel periodically drops mid-stream over SOCKS;
+            // without retry-with-resume a flaky network turns 100MB asset sync
+            // into a Sisyphean restart-from-zero loop.
+            retryWithBackoff(
+                operation = "download $serverPath",
+                shouldRetry = ::isTransientDownloadError,
+            ) {
+                val existing = if (Files.exists(localPath)) Files.size(localPath) else 0L
 
-                val channel = response.bodyAsChannel()
-                FileOutputStream(localPath.toFile()).use { output ->
-                    val buffer = ByteArray(8192)
-                    while (!channel.isClosedForRead) {
-                        val read = channel.readAvailable(buffer, 0, buffer.size)
-                        if (read <= 0) break
-                        output.write(buffer, 0, read)
-                        onBytesRead?.invoke(read)
+                client.prepareGet(url) {
+                    if (existing > 0) header(HttpHeaders.Range, "bytes=$existing-")
+                }.execute { response ->
+                    when (response.status) {
+                        HttpStatusCode.PartialContent -> {
+                            // 206: server is honouring the Range — append the remainder.
+                            // Report the already-on-disk bytes upfront so the UI's
+                            // total-bytes progress hits 100% on completion. (Long-to-Int
+                            // narrowing is fine here — modpack assets are well under 2GB.)
+                            if (existing > 0) onBytesRead?.invoke(existing.toInt())
+                            writeBody(response, localPath, append = true, onBytesRead)
+                        }
+                        HttpStatusCode.OK -> {
+                            // 200: server ignored Range (or we sent none) — overwrite.
+                            // Don't report existing bytes; we're throwing them away.
+                            writeBody(response, localPath, append = false, onBytesRead)
+                        }
+                        HttpStatusCode.RequestedRangeNotSatisfiable -> {
+                            // 416: partial on disk is bigger than the upstream file
+                            // (corrupt write or upstream shrank). Clear and let retry
+                            // fetch from byte 0.
+                            Files.deleteIfExists(localPath)
+                            throw IOException("HTTP 416 for $url; cleared bad partial, will refetch")
+                        }
+                        else -> throw IOException("HTTP ${response.status} for $url")
                     }
                 }
             }
         }
+    }
+
+    private suspend fun writeBody(
+        response: HttpResponse,
+        localPath: Path,
+        append: Boolean,
+        onBytesRead: ((Int) -> Unit)?,
+    ) {
+        val channel = response.bodyAsChannel()
+        FileOutputStream(localPath.toFile(), append).use { output ->
+            val buffer = ByteArray(8192)
+            while (!channel.isClosedForRead) {
+                val read = channel.readAvailable(buffer, 0, buffer.size)
+                if (read <= 0) break
+                output.write(buffer, 0, read)
+                onBytesRead?.invoke(read)
+            }
+        }
+    }
+
+    private fun isTransientDownloadError(t: Throwable): Boolean {
+        // CancellationException must NEVER be retried — it's how the parent
+        // coroutine signals "stop"; swallowing and retrying would deadlock
+        // the launch flow.
+        if (t is CancellationException) return false
+        var cause: Throwable? = t
+        while (cause != null) {
+            if (cause is java.net.ConnectException ||
+                cause is java.net.SocketException ||
+                cause is io.ktor.utils.io.ClosedByteChannelException ||
+                cause is java.net.SocketTimeoutException
+            ) return true
+            if (cause is IOException &&
+                cause.message?.contains("Connection reset", ignoreCase = true) == true
+            ) return true
+            cause = cause.cause
+        }
+        return false
     }
 
     private fun formatSpeed(bytesPerSec: Double): String {

--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -30,7 +30,8 @@ import kotlin.math.roundToInt
 
 
 class FileDownloadService(
-    private val clientProvider: HttpClientProvider
+    private val clientProvider: HttpClientProvider,
+    private val protectedPaths: ProtectedPaths,
 ) : IFileDownloadService {
     private val client get() = clientProvider.current
 
@@ -295,20 +296,14 @@ class FileDownloadService(
         if (!Files.exists(file)) return true
         if (Files.isDirectory(file)) return false
         if (expectedMd5 == "any") return false // "any" hash means "do not check"
-        val lowerPath = relativePath.lowercase().replace("\\", "/")
-        val isProtectedClientConfig = lowerPath.endsWith("options.txt") ||
-                lowerPath.endsWith("servers.dat") ||
-                lowerPath.contains("xaerominimap") ||
-                lowerPath.contains("xaeroworldmap") ||
-                lowerPath.contains("voxelmap") ||
-                lowerPath.contains("journeymap") ||
-                lowerPath.contains("jei")
 
         return try {
             if (Files.size(file) == 0L) return true
 
-            // Если файл защищен и он уже существует (size > 0), мы запрещаем его перезапись!
-            if (isProtectedClientConfig) return false
+            // Protected user-config: present + non-empty means hands-off.
+            // The default list is in ProtectedPaths.kt; users extend it via
+            // dataDir/protected-paths.json without recompiling.
+            if (protectedPaths.isProtected(relativePath)) return false
 
             val localMd5 = calculateMD5(file)
             !localMd5.equals(expectedMd5, ignoreCase = true)

--- a/client-launcher/src/main/kotlin/hivens/launcher/ManifestCache.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/ManifestCache.kt
@@ -1,0 +1,108 @@
+package hivens.launcher
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+
+/**
+ * Per-server cache of "this manifest was successfully synced at time T".
+ *
+ * The SMARTYcraft auth response carries a multi-megabyte file manifest
+ * that `FileDownloadService` walks entry-by-entry, MD5-checking every
+ * file on disk. On a 1000-file modpack this dominates cold-start time
+ * even when nothing has actually changed since the last login.
+ *
+ * If the manifest hash is identical to the last successful sync AND
+ * that sync was within [TTL_MS], we presume the local install is still
+ * good and short-circuit the integrity walk. The TTL is the safety
+ * valve — files corrupt on disk, users delete things by hand, etc.,
+ * and we don't want a stale cache to mask that forever.
+ *
+ * Cache location: `<dataDir>/manifest-cache/<serverId>.json`. One file
+ * per server so a manifest change on `Industrial` doesn't invalidate
+ * the cache for `Create`.
+ */
+class ManifestCache(
+    private val cacheDir: Path,
+    private val json: Json,
+) {
+    private val log = LoggerFactory.getLogger(ManifestCache::class.java)
+
+    @Serializable
+    data class Entry(val hash: String, val syncedAt: Long)
+
+    /**
+     * Computes a stable hash of [manifestJson] (the canonical JSON form
+     * of `FileManifest`, encoded with the launcher's [Json] config so
+     * field order and whitespace are deterministic regardless of how the
+     * server serialised the response).
+     */
+    fun hashOf(manifestJson: String): String {
+        val md = MessageDigest.getInstance("MD5")
+        md.update(manifestJson.toByteArray(Charsets.UTF_8))
+        return md.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    fun isClean(serverId: String, manifestHash: String): Boolean {
+        val entry = read(serverId) ?: return false
+        if (entry.hash != manifestHash) return false
+        val ageMs = System.currentTimeMillis() - entry.syncedAt
+        if (ageMs >= TTL_MS) {
+            log.debug("manifest cache for {} expired ({}h old, TTL {}h)", serverId, ageMs / 3_600_000, TTL_MS / 3_600_000)
+            return false
+        }
+        return true
+    }
+
+    fun markClean(serverId: String, manifestHash: String) {
+        runCatching {
+            Files.createDirectories(cacheDir)
+            val entry = Entry(hash = manifestHash, syncedAt = System.currentTimeMillis())
+            Files.writeString(cacheFile(serverId), json.encodeToString(entry))
+        }.onFailure { log.warn("Failed to persist manifest-cache entry for {}", serverId, it) }
+    }
+
+    /**
+     * Drops the cache for [serverId] — call when the user explicitly
+     * requests "verify integrity" or after a known-corrupting event
+     * (failed game launch, repair tool run). Best-effort.
+     */
+    fun invalidate(serverId: String) {
+        runCatching { Files.deleteIfExists(cacheFile(serverId)) }
+    }
+
+    private fun read(serverId: String): Entry? {
+        val file = cacheFile(serverId)
+        if (!Files.exists(file)) return null
+        return runCatching {
+            json.decodeFromString<Entry>(Files.readString(file))
+        }.getOrElse {
+            log.debug("manifest-cache entry for {} unreadable; treating as miss", serverId, it)
+            null
+        }
+    }
+
+    private fun cacheFile(serverId: String): Path =
+        cacheDir.resolve("${sanitize(serverId)}.json")
+
+    /**
+     * Defensive: server ids are trusted (they come from upstream config)
+     * but we still don't want a server named `../etc/passwd` to escape
+     * the cache dir. Replace anything outside `[A-Za-z0-9._-]`.
+     */
+    private fun sanitize(serverId: String): String =
+        serverId.map { if (it.isLetterOrDigit() || it == '_' || it == '-' || it == '.') it else '_' }.joinToString("")
+
+    companion object {
+        /**
+         * Re-verify weekly even if the manifest hash matches. The bigger
+         * this number is, the longer a silently-corrupted local install
+         * stays masked. Seven days is a tradeoff between cold-start
+         * speedup and self-healing latency.
+         */
+        const val TTL_MS = 7L * 24 * 60 * 60 * 1000  // 7 days
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/ProtectedPaths.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/ProtectedPaths.kt
@@ -1,0 +1,76 @@
+package hivens.launcher
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * User-config files inside a synced client install that the launcher must
+ * NEVER overwrite even when the server's manifest claims they're stale.
+ *
+ * The default list covers in-game settings (`options.txt`, `servers.dat`)
+ * and per-mod state directories that mod authors traditionally store
+ * directly under the client root (Xaero's minimap waypoints, VoxelMap
+ * configs, JourneyMap data, JEI bookmarks). Without this gate, every
+ * server-side modpack push would erase a player's hand-tuned settings.
+ *
+ * Externalised so users can extend the list without recompiling — drop a
+ * mod name into `~/.local/share/aura-launcher/protected-paths.json` and
+ * restart. On first run the file is created with the defaults so users
+ * can see what's already covered before adding their own.
+ *
+ * `endsWith` matches exact filenames (case-insensitive, after path
+ * normalisation), `contains` matches anywhere in the relative path
+ * (typically a mod directory name).
+ */
+@Serializable
+data class ProtectedPathsConfig(
+    val endsWith: List<String> = listOf(
+        "options.txt",
+        "servers.dat",
+    ),
+    val contains: List<String> = listOf(
+        "xaerominimap",
+        "xaeroworldmap",
+        "voxelmap",
+        "journeymap",
+        "jei",
+    ),
+)
+
+class ProtectedPaths(
+    private val configFile: Path,
+    private val json: Json,
+) {
+    private val log = LoggerFactory.getLogger(ProtectedPaths::class.java)
+
+    private val config: ProtectedPathsConfig by lazy { loadOrCreate() }
+
+    fun isProtected(relativePath: String): Boolean {
+        val lower = relativePath.lowercase().replace("\\", "/")
+        return config.endsWith.any { lower.endsWith(it.lowercase()) } ||
+                config.contains.any { lower.contains(it.lowercase()) }
+    }
+
+    private fun loadOrCreate(): ProtectedPathsConfig {
+        if (!Files.exists(configFile)) {
+            val defaults = ProtectedPathsConfig()
+            runCatching {
+                configFile.parent?.let { Files.createDirectories(it) }
+                Files.writeString(configFile, json.encodeToString(defaults))
+                log.info("Wrote default protected-paths.json at {}", configFile)
+            }.onFailure {
+                log.warn("Failed to write default protected-paths.json — using in-memory defaults", it)
+            }
+            return defaults
+        }
+        return runCatching {
+            val text = Files.readString(configFile)
+            json.decodeFromString<ProtectedPathsConfig>(text)
+        }.onFailure {
+            log.warn("Failed to parse protected-paths.json — falling back to defaults (in-memory only, file left intact)", it)
+        }.getOrDefault(ProtectedPathsConfig())
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -15,6 +15,7 @@ import hivens.launcher.component.EnvironmentPreparer
 import hivens.launcher.component.GameCommandBuilder
 import hivens.launcher.component.ProcessLogHandler
 import hivens.launcher.platform.PlatformPaths
+import hivens.launcher.update.UpdateApplicators
 import hivens.launcher.update.UpdateService
 import io.ktor.client.*
 import io.ktor.client.engine.okhttp.*
@@ -236,6 +237,10 @@ val appModule = module {
             settingsService = get()
         )
     }
+
+    // Per-platform update applicator selected at startup. Kept as a singleton
+    // so the shutdown hook each implementation registers fires exactly once.
+    single<IUpdateApplicator> { UpdateApplicators.forCurrentPlatform() }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -254,7 +254,14 @@ val appModule = module {
  * is true. h2 multiplexing over the SOCKS hop drops mid-stream on long bodies;
  * 1.1 with parallel connections trades multiplexing for resilience. Skipped on
  * the direct channel — its third-party CDN endpoints have rock-solid h2 stacks.
+ *
+ * Qodana correctly notices the flag is currently always-true ([Network.FORCE_HTTP1_FOR_SMARTYCRAFT]
+ * is `const val true`), making the `else this` branch dead at compile time. The
+ * branch stays on purpose — it's a kill-switch for the day h2-over-SOCKS
+ * starts behaving (or for someone debugging whether the pin is what's
+ * causing a new symptom). Suppression below is the explicit "yes, on purpose".
  */
+@Suppress("KotlinConstantConditions")
 private fun OkHttpClient.Builder.applySmartycraftProtocols(): OkHttpClient.Builder =
     if (Network.FORCE_HTTP1_FOR_SMARTYCRAFT) protocols(listOf(OkProtocol.HTTP_1_1)) else this
 

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -25,6 +25,7 @@ import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
+import okhttp3.Protocol as OkProtocol
 import org.koin.core.module.dsl.singleOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -69,6 +70,7 @@ val networkModule = module {
             .connectTimeout(Network.TIMEOUT_CONNECT, TimeUnit.MILLISECONDS)
             .readTimeout(Network.TIMEOUT_READ, TimeUnit.MILLISECONDS)
             .proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress(Network.Proxy.HOST, Network.Proxy.PORT)))
+            .applySmartycraftProtocols()
             .build()
     }
 
@@ -86,6 +88,7 @@ val networkModule = module {
             .sslSocketFactory(socketFactory, trustManager)
             .hostnameVerifier { _, _ -> true }
             .proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress(Network.Proxy.HOST, Network.Proxy.PORT)))
+            .applySmartycraftProtocols()
             .build()
     }
 
@@ -232,6 +235,15 @@ val appModule = module {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Pins the smartycraft channel to HTTP/1.1 when [Network.FORCE_HTTP1_FOR_SMARTYCRAFT]
+ * is true. h2 multiplexing over the SOCKS hop drops mid-stream on long bodies;
+ * 1.1 with parallel connections trades multiplexing for resilience. Skipped on
+ * the direct channel — its third-party CDN endpoints have rock-solid h2 stacks.
+ */
+private fun OkHttpClient.Builder.applySmartycraftProtocols(): OkHttpClient.Builder =
+    if (Network.FORCE_HTTP1_FOR_SMARTYCRAFT) protocols(listOf(OkProtocol.HTTP_1_1)) else this
 
 /**
  * Builds an [HttpClient] backed by the given [OkHttpClient].

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -180,7 +180,11 @@ val appModule = module {
         SettingsService(get(), dataDir.resolve(Storage.SETTINGS_FILE))
     }
 
-    single<IFileDownloadService> { FileDownloadService(get()) }
+    single {
+        val dataDir: java.nio.file.Path = get()
+        ProtectedPaths(dataDir.resolve(Storage.PROTECTED_PATHS_FILE), get())
+    }
+    single<IFileDownloadService> { FileDownloadService(get(), get()) }
 
     single<IManifestProcessorService> { ManifestProcessorService(get()) }
     single { ProfileManager(get(), get()) }

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -185,7 +185,11 @@ val appModule = module {
         val dataDir: java.nio.file.Path = get()
         ProtectedPaths(dataDir.resolve(Storage.PROTECTED_PATHS_FILE), get())
     }
-    single<IFileDownloadService> { FileDownloadService(get(), get()) }
+    single {
+        val dataDir: java.nio.file.Path = get()
+        ManifestCache(dataDir.resolve("manifest-cache"), get())
+    }
+    single<IFileDownloadService> { FileDownloadService(get(), get(), get()) }
 
     single<IManifestProcessorService> { ManifestProcessorService(get()) }
     single { ProfileManager(get(), get()) }

--- a/client-launcher/src/main/kotlin/hivens/launcher/platform/OS.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/platform/OS.kt
@@ -1,0 +1,31 @@
+package hivens.launcher.platform
+
+/**
+ * Coarse OS detection. Read from `os.name` once at class-load and cached
+ * — every consumer reads the same JVM property and there's no live OS
+ * change to react to.
+ *
+ * `Darwin` is folded into [isMacOS] because some JVMs (Eclipse OpenJ9 in
+ * particular) report `Darwin` instead of the more common `Mac OS X`.
+ *
+ * Lives in `client-launcher/.../platform/` next to [PlatformPaths] and
+ * [SingleInstance] — the platform package owns "what is this machine"
+ * concerns; consumers in `client-launcher` and `client-ui` import from
+ * here. (No equivalent lives in `client-core` because cross-module the
+ * `os.name` system property is the same — there's no abstraction worth
+ * extracting.)
+ */
+object OS {
+    private val osName = System.getProperty("os.name").lowercase()
+
+    val isWindows: Boolean = osName.contains("windows")
+    val isMacOS: Boolean   = osName.contains("mac") || osName.contains("darwin")
+    val isLinux: Boolean   = osName.contains("linux") || osName.contains("unix")
+
+    fun getName(): String = when {
+        isWindows -> "Windows"
+        isMacOS   -> "macOS"
+        isLinux   -> "Linux"
+        else      -> "Unknown"
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/platform/SingleInstance.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/platform/SingleInstance.kt
@@ -1,0 +1,112 @@
+package hivens.launcher.platform
+
+import org.slf4j.LoggerFactory
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.channels.OverlappingFileLockException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+/**
+ * Single-instance gate via OS-level advisory file lock.
+ *
+ * Why this exists as its own object instead of inline in Main.kt:
+ *   - the lock channel and the [FileLock] handle must outlive the calling
+ *     scope. As local variables they would technically survive while
+ *     `application { }` blocks, but storing them on a static (object) field
+ *     removes any theoretical GC-eligibility ambiguity.
+ *   - a shutdown hook flushes the lock cleanly and logs release; without it,
+ *     the JVM still cleans up on exit but we lose the audit trail when
+ *     diagnosing "two instances running" complaints.
+ *   - the lock file carries the holder's PID so a stuck process can be
+ *     identified by inspection (`cat ~/.local/share/aura-launcher/.lock`).
+ *
+ * Failure mode is **fail-open**: if lock acquisition itself crashes for
+ * an unexpected reason (FS oddities, permissions), we log the warning
+ * and return true — better a possibly-double instance than no launcher
+ * startup at all. The corresponding correctness concern (double migration
+ * race) is now defused because [DataDirMigration] runs *after* this gate.
+ */
+object SingleInstance {
+    private val log = LoggerFactory.getLogger(SingleInstance::class.java)
+
+    @Volatile private var heldChannel: FileChannel? = null
+    @Volatile private var heldLock: FileLock? = null
+
+    /**
+     * Returns true if this process now owns the single-instance lock,
+     * false if another instance already holds it. On false, a `.show`
+     * signal file is dropped in [dataDir] so the running instance's
+     * watcher can raise its window.
+     */
+    fun acquire(dataDir: Path): Boolean {
+        val lockFile = dataDir.resolve(".lock")
+        return try {
+            val channel = FileChannel.open(
+                lockFile,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE,
+            )
+            val lock = try {
+                channel.tryLock()
+            } catch (_: OverlappingFileLockException) {
+                // Same-JVM overlap. The cross-process equivalent returns null
+                // from tryLock(); we collapse both to the "another holder"
+                // path so the test harness can simulate the conflict from
+                // within a single JVM and the production path stays correct.
+                channel.close()
+                writeShowSignal(dataDir)
+                log.info("Single-instance lock held in this JVM already; .show signal written")
+                return false
+            }
+            if (lock == null) {
+                channel.close()
+                writeShowSignal(dataDir)
+                log.info("Single-instance lock held by another process; .show signal written")
+                false
+            } else {
+                heldChannel = channel
+                heldLock = lock
+                writePid(channel)
+                Runtime.getRuntime().addShutdownHook(Thread(::release, "single-instance-release"))
+                log.info("Single-instance lock acquired (pid={})", ProcessHandle.current().pid())
+                true
+            }
+        } catch (e: Exception) {
+            log.warn("Lock acquisition failed; failing open to avoid bricking startup", e)
+            true
+        }
+    }
+
+    /**
+     * Idempotent release — safe to call from a shutdown hook *and* from
+     * an explicit teardown path; the second call is a no-op.
+     */
+    fun release() {
+        val channel = heldChannel
+        val lock = heldLock
+        heldLock = null
+        heldChannel = null
+        runCatching { lock?.release() }
+        runCatching { channel?.close() }
+        if (channel != null) log.info("Single-instance lock released")
+    }
+
+    private fun writeShowSignal(dataDir: Path) {
+        runCatching {
+            val show = dataDir.resolve(".show")
+            if (!Files.exists(show)) Files.createFile(show)
+        }
+    }
+
+    private fun writePid(channel: FileChannel) {
+        runCatching {
+            channel.position(0)
+            channel.truncate(0)
+            channel.write(ByteBuffer.wrap("${ProcessHandle.current().pid()}\n".toByteArray()))
+        }
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/update/LinuxUpdateApplicator.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/update/LinuxUpdateApplicator.kt
@@ -1,0 +1,168 @@
+package hivens.launcher.update
+
+import hivens.core.api.interfaces.IUpdateApplicator
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.PosixFilePermission
+
+/**
+ * Linux (AppImage) update flow.
+ *
+ * AppImage is a single executable; we back the current one up, copy the
+ * downloaded version into place, set +x, relaunch, and on rollback restore
+ * the backup. Desktop-shortcut paths are rewritten if the AppImage filename
+ * changed (because a new version moved from `AuraLauncher-2.2.8-x86_64.AppImage`
+ * to `AuraLauncher-2.2.9-x86_64.AppImage`).
+ *
+ * The complexity here vs Windows / macOS comes from rollback: the old
+ * AppImage is preserved as `<exe>.backup` until the new one proves it
+ * starts; failure restores the backup and re-relaunches it.
+ */
+class LinuxUpdateApplicator : IUpdateApplicator {
+    private val logger = LoggerFactory.getLogger(LinuxUpdateApplicator::class.java)
+
+    override fun scheduleUpdate(installerPath: Path) {
+        try {
+            val currentExe = resolveExecutable()
+            val downloadedFileName = installerPath.fileName.toString()
+            val targetExe = if (downloadedFileName.contains("AuraLauncher", ignoreCase = true) &&
+                downloadedFileName.endsWith(".AppImage", ignoreCase = true)
+            ) {
+                currentExe.resolveSibling(downloadedFileName)
+            } else {
+                currentExe
+            }
+
+            val backupPath = Paths.get("$currentExe.backup")
+
+            logger.info("Scheduled Linux update: {} -> {}", currentExe, targetExe)
+
+            Runtime.getRuntime().addShutdownHook(Thread {
+                try {
+                    logger.info("Applying Linux update...")
+
+                    // Backup current version
+                    if (Files.exists(currentExe)) {
+                        Files.move(currentExe, backupPath, StandardCopyOption.REPLACE_EXISTING)
+                        logger.info("Backed up current version")
+                    }
+
+                    // Copy new version to the target path
+                    Files.copy(installerPath, targetExe, StandardCopyOption.REPLACE_EXISTING)
+                    logger.info("Copied new version to {}", targetExe)
+
+                    setExecutable(targetExe)
+                    logger.info("Set executable permissions")
+
+                    if (currentExe != targetExe) {
+                        updateDesktopShortcuts(currentExe, targetExe)
+                    }
+
+                    // Relaunch
+                    logger.info("Relaunching updated version...")
+                    val process = ProcessBuilder(targetExe.toString()).start()
+
+                    // Cleanup
+                    Thread.sleep(2000)
+                    if (process.isAlive) {
+                        Files.deleteIfExists(backupPath)
+                        Files.deleteIfExists(installerPath)
+                        if (currentExe != targetExe) {
+                            Files.deleteIfExists(currentExe)
+                        }
+                        logger.info("Update completed successfully")
+                    } else {
+                        logger.error("New version failed to start, rolling back...")
+                        if (currentExe != targetExe) {
+                            Files.deleteIfExists(targetExe)
+                            updateDesktopShortcuts(targetExe, currentExe)
+                        }
+                        Files.move(backupPath, currentExe, StandardCopyOption.REPLACE_EXISTING)
+                        ProcessBuilder(currentExe.toString()).start()
+                    }
+                } catch (e: Exception) {
+                    logger.error("Update failed, attempting rollback", e)
+                    try {
+                        if (Files.exists(backupPath)) {
+                            if (currentExe != targetExe) {
+                                updateDesktopShortcuts(targetExe, currentExe)
+                            }
+                            Files.move(backupPath, currentExe, StandardCopyOption.REPLACE_EXISTING)
+                            ProcessBuilder(currentExe.toString()).start()
+                        }
+                    } catch (rollbackEx: Exception) {
+                        logger.error("Rollback failed!", rollbackEx)
+                    }
+                }
+            })
+        } catch (e: Exception) {
+            logger.error("Failed to schedule Linux update", e)
+            throw e
+        }
+    }
+
+    private fun setExecutable(path: Path) {
+        try {
+            Files.setPosixFilePermissions(path, setOf(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE,
+                PosixFilePermission.GROUP_READ,
+                PosixFilePermission.GROUP_EXECUTE,
+                PosixFilePermission.OTHERS_READ,
+                PosixFilePermission.OTHERS_EXECUTE
+            ))
+        } catch (_: UnsupportedOperationException) {
+            path.toFile().setExecutable(true)
+        }
+    }
+
+    private fun updateDesktopShortcuts(oldExe: Path, newExe: Path) {
+        try {
+            val userHome = System.getProperty("user.home") ?: return
+            val applicationsDir = Paths.get(userHome, ".local", "share", "applications")
+
+            if (!Files.exists(applicationsDir)) return
+
+            Files.list(applicationsDir).use { stream ->
+                stream.forEach { desktopFile ->
+                    if (desktopFile.toString().endsWith(".desktop")) {
+                        try {
+                            val content = Files.readString(desktopFile)
+                            if (content.contains(oldExe.toString())) {
+                                val updatedContent = content.replace(oldExe.toString(), newExe.toString())
+                                Files.writeString(desktopFile, updatedContent)
+                                logger.info("Updated desktop shortcut: {}", desktopFile.fileName)
+                            }
+                        } catch (e: Exception) {
+                            logger.warn("Failed to update desktop file: {}", desktopFile.fileName, e)
+                        }
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            logger.warn("Failed to scan for desktop shortcuts", e)
+        }
+    }
+
+    private fun resolveExecutable(): Path {
+        // When running as AppImage, the runtime automatically sets $APPIMAGE
+        // to the real path of the .AppImage file on disk.
+        //
+        // DO NOT use /proc/self/exe naively — under AppImage it resolves to the
+        // temporary FUSE mount point (/tmp/.mount_AuraLaXXXXX/usr/bin/AuraLauncher)
+        // which is gone the moment the process exits.
+        val appImageEnv = System.getenv("APPIMAGE")
+        if (!appImageEnv.isNullOrBlank()) return Paths.get(appImageEnv)
+        return try {
+            Paths.get("/proc/self/exe").toRealPath()
+        } catch (e: Exception) {
+            val classPath = System.getProperty("java.class.path")
+                ?: error("Cannot resolve Linux launcher binary: APPIMAGE unset, /proc/self/exe failed (${e.message}), java.class.path is null")
+            Paths.get(classPath.split(":").first()).toAbsolutePath()
+        }
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/update/MacUpdateApplicator.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/update/MacUpdateApplicator.kt
@@ -1,0 +1,94 @@
+package hivens.launcher.update
+
+import hivens.core.api.interfaces.IUpdateApplicator
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * macOS update flow.
+ *
+ * Mounts the downloaded `.dmg` at `/Volumes/AuraUpdate`, kills any
+ * AuraLauncher survivors, replaces the existing `.app` bundle, unmounts
+ * and relaunches via `open`. Self-deletes the bash trampoline script.
+ */
+class MacUpdateApplicator : IUpdateApplicator {
+    private val logger = LoggerFactory.getLogger(MacUpdateApplicator::class.java)
+
+    override fun scheduleUpdate(installerPath: Path) {
+        try {
+            val scriptPath = Files.createTempFile("aura_update", ".sh")
+            val currentBinary = resolveExecutable()
+            val currentAppBundle = currentBinary.parent?.parent?.parent ?: Paths.get("/Applications/AuraLauncher.app")
+            val targetDir = currentAppBundle.parent ?: Paths.get("/Applications")
+
+            scriptPath.toFile().writeText("""
+                #!/bin/bash
+                set -e
+
+                # Wait for launcher to exit
+                sleep 2
+
+                # Kill any remaining processes
+                killall -9 AuraLauncher 2>/dev/null || true
+
+                # Mount DMG
+                echo "Mounting update image..."
+                hdiutil attach "$installerPath" -mountpoint /Volumes/AuraUpdate -nobrowse -quiet || exit 1
+
+                if [ ! -d "/Volumes/AuraUpdate/AuraLauncher.app" ]; then
+                    echo "Error: AuraLauncher.app not found in DMG"
+                    hdiutil detach /Volumes/AuraUpdate -quiet || true
+                    exit 1
+                fi
+
+                # Remove old version
+                echo "Removing old version..."
+                rm -rf "$currentAppBundle" || true
+
+                # Copy new version
+                echo "Installing new version..."
+                cp -R /Volumes/AuraUpdate/AuraLauncher.app "$targetDir/"
+
+                # Unmount DMG
+                echo "Cleaning up..."
+                hdiutil detach /Volumes/AuraUpdate -quiet
+                rm -f "$installerPath"
+
+                # Relaunch
+                echo "Launching updated version..."
+                sleep 1
+                open "$targetDir/AuraLauncher.app"
+
+                # Cleanup script
+                rm -f "$scriptPath"
+            """.trimIndent())
+
+            scriptPath.toFile().setExecutable(true)
+            logger.info("Scheduled macOS update: {} targeting {}", installerPath, targetDir)
+
+            Runtime.getRuntime().addShutdownHook(Thread {
+                try {
+                    ProcessBuilder("bash", scriptPath.toString()).start()
+                } catch (e: Exception) {
+                    logger.error("Failed to execute update script", e)
+                }
+            })
+        } catch (e: Exception) {
+            logger.error("Failed to schedule macOS update", e)
+            throw e
+        }
+    }
+
+    private fun resolveExecutable(): Path {
+        // .app/Contents/app/<jar>.jar  ->  .app/Contents/MacOS/AuraLauncher
+        val classPath = System.getProperty("java.class.path")
+        if (!classPath.isNullOrBlank()) {
+            val jarPath = Paths.get(classPath.split(":").first()).toAbsolutePath()
+            val contents = jarPath.parent?.parent
+            if (contents != null) return contents.resolve("MacOS").resolve("AuraLauncher")
+        }
+        error("Cannot resolve macOS launcher binary: java.class.path missing or not in expected .app/Contents/app/ layout")
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/update/UpdateApplicator.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/update/UpdateApplicator.kt
@@ -1,337 +1,38 @@
 package hivens.launcher.update
 
-import org.slf4j.LoggerFactory
-import java.nio.file.Files
+import hivens.core.api.interfaces.IUpdateApplicator
+import hivens.launcher.platform.OS
 import java.nio.file.Path
-import java.nio.file.Paths
-import java.nio.file.StandardCopyOption
-import java.nio.file.attribute.PosixFilePermission
 
-object UpdateApplicator {
-    private val logger = LoggerFactory.getLogger(UpdateApplicator::class.java)
-
-    /**
-     * Schedules the update to be applied when exiting the launcher.
-     */
-    fun scheduleUpdate(installerPath: Path) {
-        when {
-            OS.isWindows -> scheduleWindowsUpdate(installerPath)
-            OS.isMacOS -> scheduleMacUpdate(installerPath)
-            OS.isLinux -> scheduleLinuxUpdate(installerPath)
-            else -> throw UnsupportedOperationException("Update not supported on ${OS.getName()}")
-        }
-    }
-
-    // ========== WINDOWS ==========
-
-    private fun scheduleWindowsUpdate(installerPath: Path) {
-        try {
-            val psScript = Files.createTempFile("aura_update", ".ps1")
-            val launcherPath = getCurrentExecutable()
-
-            psScript.toFile().writeText("""
-                # Wait for launcher to exit
-                Start-Sleep -Seconds 2
-                
-                # Ensure all processes are closed
-                Get-Process -Name "AuraLauncher" -ErrorAction SilentlyContinue | Stop-Process -Force
-                
-                # Run installer silently (Inno Setup /SILENT flag)
-                Write-Host "Installing update..."
-                Start-Process -FilePath "$installerPath" -ArgumentList "/SILENT", "/NORESTART" -Wait
-                
-                # Wait for installation
-                Start-Sleep -Seconds 3
-                
-                # Launch new version
-                if (Test-Path "$launcherPath") {
-                    Write-Host "Launching updated launcher..."
-                    Start-Process "$launcherPath"
-                } else {
-                    Write-Error "Launcher executable not found at $launcherPath"
-                }
-                
-                # Cleanup
-                Start-Sleep -Seconds 2
-                Remove-Item "$psScript" -Force -ErrorAction SilentlyContinue
-                Remove-Item "$installerPath" -Force -ErrorAction SilentlyContinue
-            """.trimIndent())
-
-            logger.info("Scheduled Windows update: $installerPath")
-
-            Runtime.getRuntime().addShutdownHook(Thread {
-                try {
-                    ProcessBuilder(
-                        "powershell.exe",
-                        "-ExecutionPolicy", "Bypass",
-                        "-WindowStyle", "Hidden",
-                        "-File", psScript.toString()
-                    ).start()
-                } catch (e: Exception) {
-                    logger.error("Failed to execute update script", e)
-                }
-            })
-
-        } catch (e: Exception) {
-            logger.error("Failed to schedule Windows update", e)
-            throw e
-        }
-    }
-
-    // ========== MACOS ==========
-
-    private fun scheduleMacUpdate(dmgPath: Path) {
-        try {
-            val scriptPath = Files.createTempFile("aura_update", ".sh")
-            val currentBinary = getCurrentExecutable()
-            val currentAppBundle = currentBinary.parent?.parent?.parent ?: Paths.get("/Applications/AuraLauncher.app")
-            val targetDir = currentAppBundle.parent ?: Paths.get("/Applications")
-
-            scriptPath.toFile().writeText("""
-                #!/bin/bash
-                set -e
-                
-                # Wait for launcher to exit
-                sleep 2
-                
-                # Kill any remaining processes
-                killall -9 AuraLauncher 2>/dev/null || true
-                
-                # Mount DMG
-                echo "Mounting update image..."
-                hdiutil attach "$dmgPath" -mountpoint /Volumes/AuraUpdate -nobrowse -quiet || exit 1
-                
-                if [ ! -d "/Volumes/AuraUpdate/AuraLauncher.app" ]; then
-                    echo "Error: AuraLauncher.app not found in DMG"
-                    hdiutil detach /Volumes/AuraUpdate -quiet || true
-                    exit 1
-                fi
-                
-                # Remove old version
-                echo "Removing old version..."
-                rm -rf "$currentAppBundle" || true
-                
-                # Copy new version
-                echo "Installing new version..."
-                cp -R /Volumes/AuraUpdate/AuraLauncher.app "$targetDir/"
-                
-                # Unmount DMG
-                echo "Cleaning up..."
-                hdiutil detach /Volumes/AuraUpdate -quiet
-                rm -f "$dmgPath"
-                
-                # Relaunch
-                echo "Launching updated version..."
-                sleep 1
-                open "$targetDir/AuraLauncher.app"
-                
-                # Cleanup script
-                rm -f "$scriptPath"
-            """.trimIndent())
-
-            scriptPath.toFile().setExecutable(true)
-            logger.info("Scheduled macOS update: $dmgPath targeting $targetDir")
-
-            Runtime.getRuntime().addShutdownHook(Thread {
-                try {
-                    ProcessBuilder("bash", scriptPath.toString()).start()
-                } catch (e: Exception) {
-                    logger.error("Failed to execute update script", e)
-                }
-            })
-
-        } catch (e: Exception) {
-            logger.error("Failed to schedule macOS update", e)
-            throw e
-        }
-    }
-
-    // ========== LINUX ==========
-
-    private fun scheduleLinuxUpdate(appImagePath: Path) {
-        try {
-            val currentExe = getCurrentExecutable()
-            val downloadedFileName = appImagePath.fileName.toString()
-            val targetExe = if (downloadedFileName.contains("AuraLauncher", ignoreCase = true) && downloadedFileName.endsWith(".AppImage", ignoreCase = true)) {
-                currentExe.resolveSibling(downloadedFileName)
-            } else {
-                currentExe
-            }
-
-            val backupPath = Paths.get("$currentExe.backup")
-
-            logger.info("Scheduled Linux update: $currentExe -> $targetExe")
-
-            Runtime.getRuntime().addShutdownHook(Thread {
-                try {
-                    logger.info("Applying Linux update...")
-
-                    // Backup current version
-                    if (Files.exists(currentExe)) {
-                        Files.move(currentExe, backupPath, StandardCopyOption.REPLACE_EXISTING)
-                        logger.info("Backed up current version")
-                    }
-
-                    // Copy new version to the target path
-                    Files.copy(appImagePath, targetExe, StandardCopyOption.REPLACE_EXISTING)
-                    logger.info("Copied new version to $targetExe")
-
-                    // Set executable permissions
-                    try {
-                        Files.setPosixFilePermissions(targetExe, setOf(
-                            PosixFilePermission.OWNER_READ,
-                            PosixFilePermission.OWNER_WRITE,
-                            PosixFilePermission.OWNER_EXECUTE,
-                            PosixFilePermission.GROUP_READ,
-                            PosixFilePermission.GROUP_EXECUTE,
-                            PosixFilePermission.OTHERS_READ,
-                            PosixFilePermission.OTHERS_EXECUTE
-                        ))
-                    } catch (_: UnsupportedOperationException) {
-                        targetExe.toFile().setExecutable(true)
-                    }
-                    logger.info("Set executable permissions")
-
-                    if (currentExe != targetExe) {
-                        updateLinuxDesktopShortcuts(currentExe, targetExe)
-                    }
-
-                    // Relaunch
-                    logger.info("Relaunching updated version...")
-                    val process = ProcessBuilder(targetExe.toString()).start()
-
-                    // Cleanup
-                    Thread.sleep(2000)
-                    if (process.isAlive) {
-                        Files.deleteIfExists(backupPath)
-                        Files.deleteIfExists(appImagePath)
-                        if (currentExe != targetExe) {
-                            Files.deleteIfExists(currentExe)
-                        }
-                        logger.info("Update completed successfully")
-                    } else {
-                        // Rollback on failure
-                        logger.error("New version failed to start, rolling back...")
-                        if (currentExe != targetExe) {
-                            Files.deleteIfExists(targetExe)
-                            updateLinuxDesktopShortcuts(targetExe, currentExe)
-                        }
-                        Files.move(backupPath, currentExe, StandardCopyOption.REPLACE_EXISTING)
-                        ProcessBuilder(currentExe.toString()).start()
-                    }
-
-                } catch (e: Exception) {
-                    logger.error("Update failed, attempting rollback", e)
-                    try {
-                        if (Files.exists(backupPath)) {
-                            if (currentExe != targetExe) {
-                                updateLinuxDesktopShortcuts(targetExe, currentExe)
-                            }
-                            Files.move(backupPath, currentExe, StandardCopyOption.REPLACE_EXISTING)
-                            ProcessBuilder(currentExe.toString()).start()
-                        }
-                    } catch (rollbackEx: Exception) {
-                        logger.error("Rollback failed!", rollbackEx)
-                    }
-                }
-            })
-
-        } catch (e: Exception) {
-            logger.error("Failed to schedule Linux update", e)
-            throw e
-        }
-    }
-
-    private fun updateLinuxDesktopShortcuts(oldExe: Path, newExe: Path) {
-        try {
-            val userHome = System.getProperty("user.home") ?: return
-            val applicationsDir = Paths.get(userHome, ".local", "share", "applications")
-
-            if (!Files.exists(applicationsDir)) return
-
-            Files.list(applicationsDir).use { stream ->
-                stream.forEach { desktopFile ->
-                    if (desktopFile.toString().endsWith(".desktop")) {
-                        try {
-                            val content = Files.readString(desktopFile)
-                            if (content.contains(oldExe.toString())) {
-                                val updatedContent = content.replace(oldExe.toString(), newExe.toString())
-                                Files.writeString(desktopFile, updatedContent)
-                                logger.info("Updated desktop shortcut: ${desktopFile.fileName}")
-                            }
-                        } catch (e: Exception) {
-                            logger.warn("Failed to update desktop file: ${desktopFile.fileName}", e)
-                        }
-                    }
-                }
-            }
-        } catch (e: Exception) {
-            logger.warn("Failed to scan for desktop shortcuts", e)
-        }
-    }
-
-    // ========== HELPERS ==========
-
-    private fun getCurrentExecutable(): Path = when {
-        OS.isWindows -> resolveWindowsExecutable()
-        OS.isMacOS   -> resolveMacOsExecutable()
-        OS.isLinux   -> resolveLinuxExecutable()
-        else -> error("Unsupported platform: ${OS.getName()}; cannot locate launcher binary")
-    }
-
-    private fun resolveWindowsExecutable(): Path {
-        val classPath = System.getProperty("java.class.path")
-            ?: error("java.class.path is unset; cannot locate Windows launcher binary")
-        val jarPath = Paths.get(classPath.split(";").first()).toAbsolutePath()
-        val installRoot = jarPath.parent?.parent
-            ?: error("Cannot resolve Windows install root from $jarPath; expected lib/<jar>.jar inside install dir")
-        return installRoot.resolve("AuraLauncher.exe")
-    }
-
-    private fun resolveMacOsExecutable(): Path {
-        // .app/Contents/app/<jar>.jar  ->  .app/Contents/MacOS/AuraLauncher
-        val classPath = System.getProperty("java.class.path")
-        if (!classPath.isNullOrBlank()) {
-            val jarPath = Paths.get(classPath.split(":").first()).toAbsolutePath()
-            val contents = jarPath.parent?.parent
-            if (contents != null) return contents.resolve("MacOS").resolve("AuraLauncher")
-        }
-        error("Cannot resolve macOS launcher binary: java.class.path missing or not in expected .app/Contents/app/ layout")
-    }
-
-    private fun resolveLinuxExecutable(): Path {
-        // When running as AppImage, the runtime automatically sets $APPIMAGE
-        // to the real path of the .AppImage file on disk.
-        //
-        // DO NOT use /proc/self/exe naively — under AppImage it resolves to the
-        // temporary FUSE mount point (/tmp/.mount_AuraLaXXXXX/usr/bin/AuraLauncher)
-        // which is gone the moment the process exits.
-        val appImageEnv = System.getenv("APPIMAGE")
-        if (!appImageEnv.isNullOrBlank()) return Paths.get(appImageEnv)
-        return try {
-            Paths.get("/proc/self/exe").toRealPath()
-        } catch (e: Exception) {
-            val classPath = System.getProperty("java.class.path")
-                ?: error("Cannot resolve Linux launcher binary: APPIMAGE unset, /proc/self/exe failed (${e.message}), java.class.path is null")
-            Paths.get(classPath.split(":").first()).toAbsolutePath()
-        }
+/**
+ * Factory entry point for [IUpdateApplicator] selection.
+ *
+ * Picks the right platform implementation based on [OS]; falls back to
+ * [NoOpUpdateApplicator] on anything unrecognised. The Koin module wires
+ * the result of [forCurrentPlatform] as a singleton so callers (notably
+ * `UpdateDialog` in `client-ui`) get the right concrete via injection.
+ *
+ * The previous flat `object UpdateApplicator` (320 lines, three platform
+ * flows + helpers crammed together) was unmockable and grew into the same
+ * smell that Config-split untangled for `AppConfig`.
+ */
+object UpdateApplicators {
+    fun forCurrentPlatform(): IUpdateApplicator = when {
+        OS.isWindows -> WindowsUpdateApplicator()
+        OS.isMacOS   -> MacUpdateApplicator()
+        OS.isLinux   -> LinuxUpdateApplicator()
+        else         -> NoOpUpdateApplicator()
     }
 }
 
 /**
- * OS detection utilities.
+ * Stand-in for unsupported platforms. Throws on [scheduleUpdate]; callers
+ * should treat the exception as "ask the user to download and install
+ * manually". Splitting this out keeps the factory branch logic exhaustive
+ * and gives Koin something to bind even when [OS] reports `Unknown`.
  */
-object OS {
-    private val osName = System.getProperty("os.name").lowercase()
-
-    val isWindows: Boolean = osName.contains("windows")
-    val isMacOS: Boolean = osName.contains("mac") || osName.contains("darwin")
-    val isLinux: Boolean = osName.contains("linux") || osName.contains("unix")
-
-    fun getName(): String = when {
-        isWindows -> "Windows"
-        isMacOS -> "macOS"
-        isLinux -> "Linux"
-        else -> "Unknown"
+class NoOpUpdateApplicator : IUpdateApplicator {
+    override fun scheduleUpdate(installerPath: Path) {
+        throw UnsupportedOperationException("Update not supported on ${OS.getName()}")
     }
 }

--- a/client-launcher/src/main/kotlin/hivens/launcher/update/WindowsUpdateApplicator.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/update/WindowsUpdateApplicator.kt
@@ -1,0 +1,81 @@
+package hivens.launcher.update
+
+import hivens.core.api.interfaces.IUpdateApplicator
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Windows update flow.
+ *
+ * Inno Setup installer (`.exe`, `/SILENT`) replaces the install in-place;
+ * a PowerShell script wakes ~2s after we exit, kills any AuraLauncher
+ * survivors, runs the silent installer, then relaunches the freshly
+ * installed binary. Script + installer self-delete on success.
+ */
+class WindowsUpdateApplicator : IUpdateApplicator {
+    private val logger = LoggerFactory.getLogger(WindowsUpdateApplicator::class.java)
+
+    override fun scheduleUpdate(installerPath: Path) {
+        try {
+            val psScript = Files.createTempFile("aura_update", ".ps1")
+            val launcherPath = resolveExecutable()
+
+            psScript.toFile().writeText("""
+                # Wait for launcher to exit
+                Start-Sleep -Seconds 2
+
+                # Ensure all processes are closed
+                Get-Process -Name "AuraLauncher" -ErrorAction SilentlyContinue | Stop-Process -Force
+
+                # Run installer silently (Inno Setup /SILENT flag)
+                Write-Host "Installing update..."
+                Start-Process -FilePath "$installerPath" -ArgumentList "/SILENT", "/NORESTART" -Wait
+
+                # Wait for installation
+                Start-Sleep -Seconds 3
+
+                # Launch new version
+                if (Test-Path "$launcherPath") {
+                    Write-Host "Launching updated launcher..."
+                    Start-Process "$launcherPath"
+                } else {
+                    Write-Error "Launcher executable not found at $launcherPath"
+                }
+
+                # Cleanup
+                Start-Sleep -Seconds 2
+                Remove-Item "$psScript" -Force -ErrorAction SilentlyContinue
+                Remove-Item "$installerPath" -Force -ErrorAction SilentlyContinue
+            """.trimIndent())
+
+            logger.info("Scheduled Windows update: {}", installerPath)
+
+            Runtime.getRuntime().addShutdownHook(Thread {
+                try {
+                    ProcessBuilder(
+                        "powershell.exe",
+                        "-ExecutionPolicy", "Bypass",
+                        "-WindowStyle", "Hidden",
+                        "-File", psScript.toString()
+                    ).start()
+                } catch (e: Exception) {
+                    logger.error("Failed to execute update script", e)
+                }
+            })
+        } catch (e: Exception) {
+            logger.error("Failed to schedule Windows update", e)
+            throw e
+        }
+    }
+
+    private fun resolveExecutable(): Path {
+        val classPath = System.getProperty("java.class.path")
+            ?: error("java.class.path is unset; cannot locate Windows launcher binary")
+        val jarPath = Paths.get(classPath.split(";").first()).toAbsolutePath()
+        val installRoot = jarPath.parent?.parent
+            ?: error("Cannot resolve Windows install root from $jarPath; expected lib/<jar>.jar inside install dir")
+        return installRoot.resolve("AuraLauncher.exe")
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/ManifestCacheTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/ManifestCacheTest.kt
@@ -1,0 +1,100 @@
+package hivens.launcher
+
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ManifestCacheTest {
+
+    private lateinit var cacheDir: Path
+    private lateinit var cache: ManifestCache
+    private val json = Json { encodeDefaults = true }
+
+    @BeforeTest
+    fun setUp() {
+        cacheDir = Files.createTempDirectory("manifest-cache-test")
+        cacheDir.toFile().deleteOnExit()
+        cache = ManifestCache(cacheDir, json)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        cacheDir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun `isClean returns false on a fresh cache`() {
+        assertFalse(cache.isClean("Industrial", "abc"))
+    }
+
+    @Test
+    fun `markClean then isClean with matching hash returns true`() {
+        cache.markClean("Industrial", "abc123")
+        assertTrue(cache.isClean("Industrial", "abc123"))
+    }
+
+    @Test
+    fun `isClean returns false when hash differs`() {
+        cache.markClean("Industrial", "abc123")
+        assertFalse(cache.isClean("Industrial", "different"))
+    }
+
+    @Test
+    fun `cache is per-server — Industrial mark doesn't satisfy Create check`() {
+        cache.markClean("Industrial", "abc123")
+        assertFalse(cache.isClean("Create", "abc123"))
+    }
+
+    @Test
+    fun `invalidate drops the cached entry`() {
+        cache.markClean("Industrial", "abc")
+        assertTrue(cache.isClean("Industrial", "abc"))
+        cache.invalidate("Industrial")
+        assertFalse(cache.isClean("Industrial", "abc"))
+    }
+
+    @Test
+    fun `hashOf is deterministic for identical input`() {
+        val a = cache.hashOf("""{"foo":"bar"}""")
+        val b = cache.hashOf("""{"foo":"bar"}""")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `hashOf differs for different input`() {
+        val a = cache.hashOf("""{"foo":"bar"}""")
+        val b = cache.hashOf("""{"foo":"baz"}""")
+        assertFalse(a == b)
+    }
+
+    @Test
+    fun `serverId with traversal characters is sanitised`() {
+        // Defensive — server id is from upstream config but we still don't
+        // want a malicious value to escape the cache dir.
+        cache.markClean("../etc/passwd", "abc")
+        // Cache file lands in cacheDir, not above it. We can't directly
+        // observe the sanitised filename without opening implementation
+        // details, but we can confirm the file shows up under cacheDir:
+        val files = Files.list(cacheDir).use { it.toList() }
+        assertEquals(1, files.size)
+        assertTrue(files[0].parent == cacheDir, "sanitised file must stay inside cacheDir")
+    }
+
+    @Test
+    fun `expired entry returns false even when hash matches`() {
+        // Manually write an entry with synced_at way in the past.
+        Files.createDirectories(cacheDir)
+        val entry = """{"hash":"abc","syncedAt":1000}"""  // year 1970
+        Files.writeString(cacheDir.resolve("Industrial.json"), entry)
+        assertFalse(
+            cache.isClean("Industrial", "abc"),
+            "entry older than TTL_MS must be treated as a cache miss"
+        )
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/ProtectedPathsTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/ProtectedPathsTest.kt
@@ -1,0 +1,105 @@
+package hivens.launcher
+
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProtectedPathsTest {
+
+    private lateinit var dataDir: Path
+    private lateinit var configFile: Path
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        prettyPrint = true
+        encodeDefaults = true
+    }
+
+    @BeforeTest
+    fun setUp() {
+        dataDir = Files.createTempDirectory("protected-paths-test")
+        dataDir.toFile().deleteOnExit()
+        configFile = dataDir.resolve("protected-paths.json")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        dataDir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun `first run writes default config and uses defaults`() {
+        val pp = ProtectedPaths(configFile, json)
+        // Trigger lazy load
+        assertTrue(pp.isProtected("options.txt"))
+
+        assertTrue(Files.exists(configFile), "default config should be written on first read")
+        val written = Files.readString(configFile)
+        assertContains(written, "options.txt")
+        assertContains(written, "xaerominimap")
+    }
+
+    @Test
+    fun `endsWith pattern matches case-insensitively after path normalisation`() {
+        val pp = ProtectedPaths(configFile, json)
+        assertTrue(pp.isProtected("options.txt"))
+        assertTrue(pp.isProtected("OPTIONS.TXT"))
+        assertTrue(pp.isProtected("Industrial/options.txt"))
+        assertTrue(pp.isProtected("Industrial\\options.txt"), "backslashes must be normalised to /")
+        assertTrue(pp.isProtected("servers.dat"))
+    }
+
+    @Test
+    fun `contains pattern matches mod directory anywhere in path`() {
+        val pp = ProtectedPaths(configFile, json)
+        assertTrue(pp.isProtected("config/xaerominimap/waypoints.dat"))
+        assertTrue(pp.isProtected("config/voxelmap/settings.txt"))
+        assertTrue(pp.isProtected("Industrial/config/jei/recipe-history.json"))
+    }
+
+    @Test
+    fun `non-protected paths return false`() {
+        val pp = ProtectedPaths(configFile, json)
+        assertFalse(pp.isProtected("mods/somemod-1.0.jar"))
+        assertFalse(pp.isProtected("config/forge.cfg"))
+        assertFalse(pp.isProtected("libraries/net/foo/bar.jar"))
+    }
+
+    @Test
+    fun `user-extended config is honoured`() {
+        Files.writeString(
+            configFile,
+            """
+            {
+              "endsWith": ["my-special-config.txt"],
+              "contains": ["mymod"]
+            }
+            """.trimIndent()
+        )
+
+        val pp = ProtectedPaths(configFile, json)
+        assertTrue(pp.isProtected("config/my-special-config.txt"))
+        assertTrue(pp.isProtected("mods/mymod/data.bin"))
+        // Defaults are NOT additive — user file fully replaces them. This is
+        // intentional: keeps the file shape predictable for users editing it
+        // by hand. If you want defaults+yours, copy the defaults in.
+        assertFalse(pp.isProtected("options.txt"))
+    }
+
+    @Test
+    fun `malformed json falls back to defaults without overwriting user file`() {
+        Files.writeString(configFile, "{ this is not valid json }")
+        val pp = ProtectedPaths(configFile, json)
+
+        // Defaults still apply
+        assertTrue(pp.isProtected("options.txt"))
+        // User's broken file is left intact (we don't auto-overwrite their data)
+        assertContains(Files.readString(configFile), "this is not valid json")
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/platform/SingleInstanceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/platform/SingleInstanceTest.kt
@@ -1,0 +1,89 @@
+package hivens.launcher.platform
+
+import java.nio.channels.FileChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SingleInstanceTest {
+
+    private lateinit var dataDir: Path
+
+    @BeforeTest
+    fun setUp() {
+        dataDir = Files.createTempDirectory("single-instance-test")
+        dataDir.toFile().deleteOnExit()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        // Always release between tests — SingleInstance is a static singleton
+        // and would carry state across test methods otherwise.
+        SingleInstance.release()
+    }
+
+    @Test
+    fun `acquire on a clean dir returns true and writes pid`() {
+        assertTrue(SingleInstance.acquire(dataDir), "first acquire on a fresh dir must succeed")
+
+        val lockFile = dataDir.resolve(".lock")
+        assertTrue(Files.exists(lockFile))
+        val pidLine = Files.readString(lockFile).trim()
+        assertContains(
+            pidLine,
+            ProcessHandle.current().pid().toString(),
+            message = "lock file should contain our pid for diagnostics"
+        )
+    }
+
+    @Test
+    fun `release is idempotent`() {
+        SingleInstance.acquire(dataDir)
+        SingleInstance.release()
+        SingleInstance.release()  // must not throw
+    }
+
+    @Test
+    fun `acquire returns false and writes show signal when lock already held`() {
+        // Simulate a foreign holder by opening the lock file ourselves and
+        // taking its FileLock in this process — SingleInstance.acquire then
+        // sees it from the same JVM and returns false.
+        val lockFile = dataDir.resolve(".lock")
+        val foreignChannel = FileChannel.open(
+            lockFile,
+            StandardOpenOption.CREATE,
+            StandardOpenOption.READ,
+            StandardOpenOption.WRITE,
+        )
+        val foreignLock = foreignChannel.tryLock()
+        try {
+            assertFalse(
+                SingleInstance.acquire(dataDir),
+                "second acquire must report failure when another holder has the lock"
+            )
+            assertTrue(
+                Files.exists(dataDir.resolve(".show")),
+                ".show signal must be written so the running instance raises its window"
+            )
+        } finally {
+            foreignLock?.release()
+            foreignChannel.close()
+        }
+    }
+
+    @Test
+    fun `acquire after release reacquires the lock`() {
+        assertTrue(SingleInstance.acquire(dataDir))
+        SingleInstance.release()
+        assertTrue(
+            SingleInstance.acquire(dataDir),
+            "released lock must be reacquirable in the same process"
+        )
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/update/UpdateApplicatorsTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/update/UpdateApplicatorsTest.kt
@@ -1,0 +1,23 @@
+package hivens.launcher.update
+
+import hivens.launcher.platform.OS
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class UpdateApplicatorsTest {
+
+    @Test
+    fun `factory returns the applicator matching the host OS`() {
+        val applicator = UpdateApplicators.forCurrentPlatform()
+        when {
+            OS.isWindows -> assertTrue(applicator is WindowsUpdateApplicator,
+                "Windows host must yield WindowsUpdateApplicator, got ${applicator::class.simpleName}")
+            OS.isMacOS   -> assertTrue(applicator is MacUpdateApplicator,
+                "macOS host must yield MacUpdateApplicator, got ${applicator::class.simpleName}")
+            OS.isLinux   -> assertTrue(applicator is LinuxUpdateApplicator,
+                "Linux host must yield LinuxUpdateApplicator, got ${applicator::class.simpleName}")
+            else         -> assertTrue(applicator is NoOpUpdateApplicator,
+                "Unknown host must yield NoOpUpdateApplicator, got ${applicator::class.simpleName}")
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -30,6 +30,7 @@ import hivens.launcher.di.appModule
 import hivens.launcher.di.networkModule
 import hivens.launcher.platform.DataDirMigration
 import hivens.launcher.platform.PlatformPaths
+import hivens.launcher.platform.SingleInstance
 import hivens.ui.background.BackgroundManager
 import hivens.ui.background.CustomBackground
 import hivens.ui.components.UpdateManager
@@ -69,7 +70,6 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.slf4j.LoggerFactory
 import java.io.File
-import java.io.FileOutputStream
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
 
@@ -160,18 +160,10 @@ fun main() {
 
     // Single-instance lock acquired BEFORE migration. Two launchers started
     // close together would otherwise both reach DataDirMigration.run() and
-    // race on REPLACE_EXISTING file copies — the loser exiting on .lock
-    // wouldn't undo half-written files. (Codex flagged the original order
-    // as P2 on PR #127.) DataDirMigration's emptiness check is taught to
-    // ignore .lock / .show / .migrated so its first-run trigger still fires.
-    val lockFile = paths.dataDir.resolve(".lock").toFile()
-    val lockChannel = FileOutputStream(lockFile).channel
-    val lock = lockChannel.tryLock()
-
-    if (lock == null) {
-        paths.dataDir.resolve(".show").toFile().createNewFile()
-        exitProcess(0)
-    }
+    // race on REPLACE_EXISTING file copies. DataDirMigration's emptiness
+    // check is taught to ignore .lock / .show / .migrated so its first-run
+    // trigger still fires.
+    if (!SingleInstance.acquire(paths.dataDir)) exitProcess(0)
 
     DataDirMigration.run(paths)
 
@@ -206,13 +198,23 @@ fun main() {
         val launchState by controller.state.collectAsState()
 
 
+        // Bumped each time the .show signal fires; the Window content uses it
+        // to invoke window.toFront() / requestFocus() so a duplicate-launch
+        // attempt actually raises the existing instance, not just makes it
+        // visible-but-buried-under-other-windows.
+        var raiseTick by remember { mutableStateOf(0) }
+
         LaunchedEffect(Unit) {
             val showFile = paths.dataDir.resolve(".show").toFile()
             while (true) {
                 delay(500)
                 if (showFile.exists()) {
                     showFile.delete()
+                    // Un-minimize: setting visible=true alone leaves a taskbar-
+                    // minimized window minimized.
+                    if (windowState.isMinimized) windowState.isMinimized = false
                     isWindowVisible = true
+                    raiseTick++
                 }
             }
         }
@@ -361,6 +363,24 @@ fun main() {
                 resizable = true,
                 icon      = windowIcon
             ) {
+                // Pulled-forward: triggered by the .show watcher above when a
+                // second instance fires its signal. Skip on raiseTick == 0 so
+                // the first composition doesn't steal focus from whatever the
+                // user was doing when the launcher started.
+                LaunchedEffect(raiseTick) {
+                    if (raiseTick == 0) return@LaunchedEffect
+                    SwingUtilities.invokeLater {
+                        // The isAlwaysOnTop trick is the only cross-WM way to
+                        // force a raise on X11 (KDE / Hyprland / GNOME all
+                        // ignore plain toFront() to discourage focus-stealing).
+                        // Pulse it: enable → toFront → requestFocus → disable.
+                        window.isAlwaysOnTop = true
+                        window.toFront()
+                        window.requestFocus()
+                        window.isAlwaysOnTop = false
+                    }
+                }
+
                 CelestiaTheme(useDarkTheme = isDarkTheme, customTheme = customTheme) {
                     AppRoot(
                         onCloseApp = {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/UpdateDialog.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/UpdateDialog.kt
@@ -18,12 +18,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.mikepenz.markdown.m3.Markdown
+import hivens.core.api.interfaces.IUpdateApplicator
 import hivens.core.data.LauncherUpdate
-import hivens.launcher.update.UpdateApplicator
 import hivens.launcher.update.UpdateService
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
 import kotlinx.coroutines.launch
+import org.koin.compose.koinInject
 import org.slf4j.LoggerFactory
 import kotlin.math.roundToInt
 import kotlin.system.exitProcess
@@ -35,9 +36,10 @@ fun UpdateDialog(
     updateService: UpdateService,
     onDismiss: () -> Unit
 ) {
-    val s      = LocalStrings.current
-    val logger = LoggerFactory.getLogger("UpdateDialog")
-    val scope  = rememberCoroutineScope()
+    val s              = LocalStrings.current
+    val logger         = LoggerFactory.getLogger("UpdateDialog")
+    val scope          = rememberCoroutineScope()
+    val updateApplicator: IUpdateApplicator = koinInject()
 
     var downloadState by remember { mutableStateOf<DownloadState>(DownloadState.Idle) }
     var errorMessage  by remember { mutableStateOf<String?>(null) }
@@ -289,7 +291,7 @@ fun UpdateDialog(
                             Button(
                                 onClick = {
                                     try {
-                                        UpdateApplicator.scheduleUpdate(java.nio.file.Paths.get(path))
+                                        updateApplicator.scheduleUpdate(java.nio.file.Paths.get(path))
                                         logger.info("Update scheduled, exiting...")
                                         exitProcess(0)
                                     } catch (e: Exception) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # Manual version override consumed by the root build script when set
 # (otherwise falls back to `git describe`). CI passes -Pversion=<tag> on tagged
 # release builds.
-appVersion=2.2.8
+appVersion=2.2.9
 
 # ============================================================================
 # GRADLE PERFORMANCE OPTIMIZATION

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# pre-push hook — runs the same test set CI does before a push lands.
+#
+# Symlinked from .git/hooks/pre-push by scripts/install-hooks.sh.
+#
+# Skip on temporary "WIP push" if you really need to:
+#     git push --no-verify
+# But please don't make a habit of it.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "── pre-push: running :client-core:test :client-launcher:test"
+if ! ./gradlew --quiet :client-core:test :client-launcher:test; then
+    echo
+    echo "── pre-push: FAILED. Push aborted."
+    echo "   Fix the failing tests, or push with --no-verify if you truly mean to."
+    exit 1
+fi
+echo "── pre-push: ✓ tests green"

--- a/scripts/compose-release-body.sh
+++ b/scripts/compose-release-body.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# compose-release-body.sh
+#
+# Composes the GitHub Release body markdown from CHANGELOG-extracted notes,
+# SHA256 checksums, and the canonical asset list. Extracted from inline yaml
+# in build_release.yml so it can be:
+#   - tested locally without pushing a tag,
+#   - diff-reviewed properly (yaml-with-printf is hostile to humans),
+#   - reused by future scripts (e.g. release dry-run / preview tools).
+#
+# Inputs (env):
+#   APP_VERSION       — version string without the v prefix (e.g. 2.2.9)
+#   CHANGELOG_NOTES   — full markdown body of the [APP_VERSION] CHANGELOG
+#                       section, fed in by the changelog job's output
+#   CHECKSUMS_FILE    — path to dist/SHA256SUMS.txt (default: dist/SHA256SUMS.txt)
+#
+# Output: writes the composed markdown to stdout.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+: "${APP_VERSION:?APP_VERSION is required (e.g. 2.2.9)}"
+: "${CHANGELOG_NOTES:?CHANGELOG_NOTES is required (markdown body for this version)}"
+CHECKSUMS_FILE="${CHECKSUMS_FILE:-dist/SHA256SUMS.txt}"
+
+REPO_BASE="https://github.com/Kitty-Hivens/Aura-Launcher/releases/download/v${APP_VERSION}"
+
+# Extract the ### Highlights section verbatim — the in-app updater renders
+# this as the "What's new" panel; the GitHub release body shows it too,
+# above the full changelog.
+HIGHLIGHTS=$(printf '%s' "$CHANGELOG_NOTES" \
+  | awk '/^### Highlights/ {flag=1; next} /^### / {flag=0} flag' \
+  | sed '/^[[:space:]]*$/d')
+
+# Build the SHA256 checksum table by walking dist/SHA256SUMS.txt.
+CHECKSUMS=""
+while IFS= read -r line; do
+  hash=$(echo "$line" | awk '{print $1}')
+  file=$(echo "$line" | awk '{print $2}' | sed 's|^\./||')
+  [ -z "$file" ] && continue
+  CHECKSUMS="${CHECKSUMS}| \`${file}\` | \`${hash}\` |"$'\n'
+done < "$CHECKSUMS_FILE"
+
+# Compose the body. Heredoc-style printf so the structure is readable;
+# the output is markdown, no shell expansion inside literal blocks.
+{
+  printf '> [!NOTE]\n'
+  printf '> **Aura Launcher** is an unofficial third-party launcher and is not affiliated with or endorsed by the original game developers.\n\n'
+
+  if [ -n "$HIGHLIGHTS" ]; then
+    printf "## What's New\n\n"
+    printf '%s\n\n' "$HIGHLIGHTS"
+  fi
+
+  printf '## Downloads\n\n'
+  printf '| Platform | File |\n|---|---|\n'
+  printf '| Windows Installer | [`AuraLauncher-%s-Setup.exe`](%s/AuraLauncher-%s-Setup.exe) |\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
+  printf '| Windows Portable  | [`AuraLauncher-%s-Windows-Portable.zip`](%s/AuraLauncher-%s-Windows-Portable.zip) |\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
+  printf '| Linux AppImage    | [`AuraLauncher-%s-x86_64.AppImage`](%s/AuraLauncher-%s-x86_64.AppImage) |\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
+  printf '| macOS             | [`AuraLauncher-%s.dmg`](%s/AuraLauncher-%s.dmg) |\n\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
+
+  printf '<details>\n<summary>SHA256 Checksums</summary>\n\n'
+  printf '| File | SHA256 |\n|---|---|\n'
+  printf '%s' "$CHECKSUMS"
+  printf '\n</details>\n\n'
+
+  printf "## What's Changed\n\n"
+  printf '%s\n' "$CHANGELOG_NOTES"
+}

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# install-hooks.sh
+#
+# Symlinks tracked git hooks from hooks/ into .git/hooks/. Symlink (not copy)
+# so a future hook change in the repo automatically reaches all contributors
+# who ran this once.
+#
+# Run after cloning:
+#     ./scripts/install-hooks.sh
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOKS_SRC="$REPO_ROOT/hooks"
+HOOKS_DST="$REPO_ROOT/.git/hooks"
+
+if [ ! -d "$HOOKS_DST" ]; then
+    echo "Not a git repo (no .git/hooks/) — refusing to install."
+    exit 1
+fi
+
+for hook in "$HOOKS_SRC"/*; do
+    name=$(basename "$hook")
+    target="$HOOKS_DST/$name"
+
+    if [ -e "$target" ] && [ ! -L "$target" ]; then
+        echo "├─ $name: already exists as a real file (not a symlink); skipping"
+        echo "│   move it aside if you want our version: mv $target $target.bak"
+        continue
+    fi
+
+    ln -sf "$hook" "$target"
+    chmod +x "$hook"
+    echo "├─ $name: symlinked"
+done
+
+echo "└─ done"


### PR DESCRIPTION
> [!IMPORTANT]
> Largest release since the fork in user-impact terms. 13 commits across
> reliability, performance, DX, code health, and docs. Each chunk lands as
> its own commit so a single theme can be reverted in isolation if it
> regresses, but the package is designed to ship as one.

## Summary by theme

**Reliability** *(rides on the 2.2.8 mandatory infra)*
- HTTP/1.1 pin on the smartycraft channel — h2 over SOCKS was dropping mid-stream on long bodies (auth payloads, manifest sync)
- Retry-with-backoff on auth + downloads (1s / 3s / 9s) on transient `Connection reset` / `SocketException` / `ClosedByteChannelException`
- File downloads resume via `Range:` header instead of restarting from byte 0; handles 206 / 200 / 416 explicitly
- Single-instance gate hardened — PID written to `.lock`, second-launch attempt actually raises the existing window via `isAlwaysOnTop` pulse + `toFront` (was: just `visible = true`, leaving it minimised on KDE/Hyprland/GNOME)
- Per-server session cache (30s TTL) deduplicates the dashboard-load + Play double-login down to one network request

**Performance**
- Per-server **manifest cache** (TTL 7d) short-circuits the cold-start per-file MD5 walk when the manifest hasn't changed since last sync. On 1000-file modpacks: multi-second integrity check → single hash compare
- **Orphan pruning** — files removed from upstream `extra.zip` are now dropped on next sync (was: lingered forever, often causing mismatch crashes on join)

**User-facing config**
- `protected-paths.json` — extend the "never overwrite this user-config" list per-install without recompiling. Defaults shipped on first run

**Code health**
- `UpdateApplicator` (320-line monolithic `object`) split into `IUpdateApplicator` interface + `Windows`/`Mac`/`Linux`/`NoOp` implementations selected by `OS` at startup. `UpdateDialog` switched to injected interface

**Dev-ex**
- `.editorconfig` pinned (utf-8 / lf / 4-space indent / 120 col)
- `hooks/pre-push` runs the CI test set; install via `./scripts/install-hooks.sh`
- `-Xlint:none` dropped from javac compilerArgs (silently swallowing warnings is a debt magnet)

**CI hygiene**
- Test matrix Win/macOS/Linux for `:client-core:test :client-launcher:test` (catches the \`Darwin contains 'win'\` class of bug at test-time, not build-time)
- `actions/cache@v4` for appimagetool (~30MB continuous build) — Linux assembly leg ~20s faster on cache hit
- Top-level `concurrency: release-${{ github.ref }}` group with `cancel-in-progress: false` — second tag push doesn't race the publish step
- Release-body composition extracted to `scripts/compose-release-body.sh` (testable locally, diff-friendly)

**Docs polish**
- Japanese-typographic `## ── name ──` dividers in CONTRIBUTING, `※` markers on disclaimers in README/CHANGELOG. Code already uses this convention; docs now consistent