### PR TITLE
fix(startup): make SingleInstance PID readable on Windows (2.2.9 retry)

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/platform/DataDirMigration.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/platform/DataDirMigration.kt
@@ -22,6 +22,19 @@ object DataDirMigration {
     private val log = LoggerFactory.getLogger(DataDirMigration::class.java)
     private const val MARKER = ".migrated"
 
+    /**
+     * Files the launcher writes to its dataDir BEFORE migration runs (because
+     * SingleInstance.acquire grabs the lock before DataDirMigration.run, by
+     * design — see Main.kt). Their presence MUST NOT make the target look
+     * "already populated" or first-run migration silently skips and the
+     * legacy `.aura/` payload is lost.
+     *
+     * Add new entries here whenever startup gains another pre-migration
+     * housekeeping file. Codex caught the .lock.pid regression on PR #129
+     * exactly this way.
+     */
+    private val HOUSEKEEPING = setOf(".lock", ".lock.pid", ".show", MARKER)
+
     fun run(paths: PlatformPaths) {
         val legacy = paths.legacyDataDir
         val target = paths.dataDir
@@ -72,21 +85,19 @@ object DataDirMigration {
     }
 
     /**
-     * True when the directory contains anything beyond housekeeping markers.
+     * True when the directory contains anything beyond [HOUSEKEEPING].
      *
-     * The launcher writes `.lock` (single-instance file lock) and `.show`
-     * (cross-process "raise the existing instance" signal) into the data
-     * directory before migration runs — see Main.kt's startup sequence.
-     * `.migrated` lands in the legacy directory, but is filtered here too
-     * for symmetry. Treating those as "user data" would cause us to skip
-     * a legitimate first-run migration on the second launch (the .lock
-     * from the first run would already be in place).
+     * The launcher writes housekeeping markers (.lock / .lock.pid / .show /
+     * .migrated) before migration runs — see Main.kt's startup sequence.
+     * Treating those as "user data" would cause us to skip a legitimate
+     * first-run migration (the lock files from this very startup would
+     * already be in place).
      */
     private fun Path.hasUserData(): Boolean =
         Files.list(this).use { stream ->
             stream.anyMatch { entry ->
                 val name = entry.fileName?.toString() ?: return@anyMatch false
-                name != ".lock" && name != ".show" && name != MARKER
+                name !in HOUSEKEEPING
             }
         }
 }

--- a/client-launcher/src/main/kotlin/hivens/launcher/platform/SingleInstance.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/platform/SingleInstance.kt
@@ -1,7 +1,6 @@
 package hivens.launcher.platform
 
 import org.slf4j.LoggerFactory
-import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import java.nio.channels.FileLock
 import java.nio.channels.OverlappingFileLockException
@@ -70,7 +69,7 @@ object SingleInstance {
             } else {
                 heldChannel = channel
                 heldLock = lock
-                writePid(channel)
+                writePid(dataDir)
                 Runtime.getRuntime().addShutdownHook(Thread(::release, "single-instance-release"))
                 log.info("Single-instance lock acquired (pid={})", ProcessHandle.current().pid())
                 true
@@ -102,11 +101,19 @@ object SingleInstance {
         }
     }
 
-    private fun writePid(channel: FileChannel) {
+    /**
+     * PID is written to a SEPARATE `.lock.pid` file rather than into `.lock`
+     * itself because Windows treats `FileChannel.tryLock()` as a mandatory
+     * OS-level lock — once acquired, no other handle (even in the same JVM)
+     * can open the file for read, and `Files.readString(.lock)` throws
+     * IOException. Linux and macOS use advisory locks where reads work
+     * fine, but cross-platform consistency wins. `.lock` stays empty and
+     * sole-purpose; `.lock.pid` is informational and freely readable for
+     * `cat ~/.local/share/aura-launcher/.lock.pid` debugging.
+     */
+    private fun writePid(dataDir: Path) {
         runCatching {
-            channel.position(0)
-            channel.truncate(0)
-            channel.write(ByteBuffer.wrap("${ProcessHandle.current().pid()}\n".toByteArray()))
+            Files.writeString(dataDir.resolve(".lock.pid"), "${ProcessHandle.current().pid()}\n")
         }
     }
 }

--- a/client-launcher/src/test/kotlin/hivens/launcher/platform/DataDirMigrationTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/platform/DataDirMigrationTest.kt
@@ -99,14 +99,16 @@ class DataDirMigrationTest {
     @Test
     fun `target containing only housekeeping files still triggers migration`() {
         // Main.kt now acquires the single-instance lock BEFORE running
-        // migration, which means .lock and .show may already exist in the
-        // (otherwise empty) target on a true first launch. Migration must
-        // still see the directory as "no user data here, proceed".
+        // migration, which means .lock / .lock.pid / .show may already
+        // exist in the (otherwise empty) target on a true first launch.
+        // Migration must still see the directory as "no user data here,
+        // proceed". Codex caught the .lock.pid regression on PR #129.
         Files.createDirectories(paths.legacyDataDir)
         Files.writeString(paths.legacyDataDir.resolve("legacy.json"), "legacy")
 
         Files.createDirectories(paths.dataDir)
         Files.writeString(paths.dataDir.resolve(".lock"), "")
+        Files.writeString(paths.dataDir.resolve(".lock.pid"), "12345")
         Files.writeString(paths.dataDir.resolve(".show"), "")
 
         DataDirMigration.run(paths)
@@ -114,7 +116,7 @@ class DataDirMigrationTest {
         assertEquals(
             "legacy",
             Files.readString(paths.dataDir.resolve("legacy.json")),
-            "Migration must run when target contains only .lock / .show housekeeping"
+            "Migration must run when target contains only housekeeping (.lock / .lock.pid / .show)"
         )
         assertTrue(Files.exists(paths.legacyDataDir.resolve(".migrated")))
     }

--- a/client-launcher/src/test/kotlin/hivens/launcher/platform/SingleInstanceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/platform/SingleInstanceTest.kt
@@ -32,13 +32,14 @@ class SingleInstanceTest {
     fun `acquire on a clean dir returns true and writes pid`() {
         assertTrue(SingleInstance.acquire(dataDir), "first acquire on a fresh dir must succeed")
 
-        val lockFile = dataDir.resolve(".lock")
-        assertTrue(Files.exists(lockFile))
-        val pidLine = Files.readString(lockFile).trim()
+        // Lock file itself is held exclusively (mandatory on Windows) — read
+        // the diagnostic PID from the side-car .lock.pid file instead.
+        assertTrue(Files.exists(dataDir.resolve(".lock")))
+        val pidLine = Files.readString(dataDir.resolve(".lock.pid")).trim()
         assertContains(
             pidLine,
             ProcessHandle.current().pid().toString(),
-            message = "lock file should contain our pid for diagnostics"
+            message = ".lock.pid must contain our pid for diagnostics"
         )
     }
 


### PR DESCRIPTION
> [!IMPORTANT]
> Hotfix on top of the (failed) 2.2.9 release. The original \`v2.2.9\` tag
> built artifacts that never published because Windows tests blocked the
> pipeline. Tag is deleted; this PR lands the Windows fix so we can re-tag
> a clean \`v2.2.9\` from \`stable\`.

## What broke

\`SingleInstanceTest > acquire on a clean dir returns true and writes pid\`
failed only on \`windows-latest\` — exactly the platform-specific class of
bug the freshly-added matrix tests were meant to catch (working as
designed: caught on first run, before the artifact build wasted compute).

\`FileChannel.tryLock()\` is **mandatory** on Windows (NTFS handle-level
lock at OS layer). Once the launcher acquires the lock, no other handle
in any JVM can open \`.lock\` for read. \`Files.readString(.lock)\` for the
PID-debug feature threw \`IOException\` in tests; in production the PID
would be unreadable for \`cat ~/.local/share/aura-launcher/.lock\`
forensics. Linux/macOS use *advisory* locks where reads work fine,
hence local-pass / CI-fail.

## Fix

PID moved to a side-car \`.lock.pid\` file:
- \`.lock\` stays empty, sole-purpose, exclusively held — does its job
- \`.lock.pid\` is plain-text, readable on any platform, doesn't disturb
  the lock holder

No behaviour change visible to users. CI matrix should now pass all
three OSes on retry.