### PR TITLE
fix(ci): checkout repo source in release job (2.2.9 retry #2)

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -271,6 +271,13 @@ jobs:
     env:
       APP_VERSION: ${{ needs.changelog.outputs.version }}
     steps:
+      # Need the repo source for scripts/compose-release-body.sh that the
+      # "Compose release body" step calls below. Without checkout it errors
+      # with `./scripts/compose-release-body.sh: No such file or directory`
+      # (regression introduced by CI-modernize #6 on PR #128 when the
+      # release-body composition was extracted out of inline yaml).
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           pattern: '*-artifacts'


### PR DESCRIPTION
> [!IMPORTANT]
> Second hotfix on top of the 2.2.9 release sequence. The first \`v2.2.9\` tag
> failed Windows tests (PR #129 fixed); the second \`v2.2.9\` tag retry built
> all 4 jobs successfully and then died at the publish step because the
> release-job lacked \`actions/checkout\` — \`scripts/compose-release-body.sh\`
> didn't exist on the runner. Tag will be deleted again, retried after merge.

## Root cause

CI-modernize #6 on PR #128 extracted the inline release-body \`printf\`
block into \`scripts/compose-release-body.sh\`. The release-job historically
ran only inline yaml + downloaded build artifacts, so it never needed
\`actions/checkout\`. Calling a script from the repo changed that requirement,
which I missed in #128.

Failure mode: 25 minutes of build work succeeds, publish step hits
\`./scripts/compose-release-body.sh: No such file or directory\` with
exit 127, no GitHub Release created.

## Fix

One-line: \`actions/checkout@v4\` as the first step of the release job.
Comment in the workflow explains the regression so future-self doesn't
helpfully "clean up redundant checkout".