### PR TITLE
Project Void: smoke infra + Wayland-Native trial backbone

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -64,12 +64,46 @@ jobs:
             client-launcher/build/reports/tests/
 
   # ─────────────────────────────────────────────────────────────────────────
+  # Live smoke — answers "is the upstream API actually reachable RIGHT NOW?"
+  # before we burn 25 minutes building artefacts that would ship a broken
+  # auth flow. Runs once on Linux (single-OS suffices: this probes upstream,
+  # not platform-specific code paths). Hard gate — `changelog` and all build
+  # jobs need this to pass.
+  # ─────────────────────────────────────────────────────────────────────────
+  smoke:
+    name: Live Smoke (smartycraft.ru)
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run live smoke against real upstream
+        env:
+          SMARTY_TEST_USER: ${{ secrets.SMARTY_TEST_USER }}
+          SMARTY_TEST_PASS: ${{ secrets.SMARTY_TEST_PASS }}
+        run: ./gradlew :client-launcher:smokeTest
+
+      - name: Upload smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report
+          path: client-launcher/build/reports/tests/smokeTest/
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Extract changelog section for this version from CHANGELOG.md
   # ─────────────────────────────────────────────────────────────────────────
   changelog:
     name: Extract Changelog
     runs-on: ubuntu-latest
-    needs: test   # we don’t build if the tests fail
+    needs: [test, smoke]   # tests AND live smoke must pass before we touch artefacts
     outputs:
       notes: ${{ steps.extract.outputs.notes }}
       version: ${{ steps.version.outputs.value }}

--- a/.github/workflows/smoke-daily.yml
+++ b/.github/workflows/smoke-daily.yml
@@ -1,0 +1,57 @@
+name: Smoke (daily)
+
+# ── Daily live-smoke probe against real smartycraft.ru ──────────────────────
+#
+# Distinct from the release-time smoke (which gates artefact assembly): this
+# one fires on its own schedule so we learn about upstream protocol drift
+# *before* we sit down to cut a release. Failure → workflow shows red on the
+# repo Actions tab and GitHub mobile sends the standard workflow-failure
+# notification. No extra wiring needed.
+#
+# Cron is 06:00 UTC = 09:00 MSK — early enough that we see the result over
+# morning coffee, late enough that any overnight upstream maintenance is
+# usually wrapped up.
+#
+# `workflow_dispatch` exposed so you can also fire it manually from the
+# Actions UI any time you want a sanity check (e.g. "did Серафим silently
+# rotate something this afternoon?").
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+# Two daily probes overlapping (manual run while cron is mid-flight, or a
+# rerun-on-failure landing on top of the next scheduled run) would just
+# waste the test account's session — serialize them.
+concurrency:
+  group: smoke-daily
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    name: Live Smoke (smartycraft.ru)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: jetbrains
+          java-version: '25'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run live smoke against real upstream
+        env:
+          SMARTY_TEST_USER: ${{ secrets.SMARTY_TEST_USER }}
+          SMARTY_TEST_PASS: ${{ secrets.SMARTY_TEST_PASS }}
+        run: ./gradlew :client-launcher:smokeTest
+
+      - name: Upload smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-report-${{ github.run_id }}
+          path: client-launcher/build/reports/tests/smokeTest/

--- a/.github/workflows/trial-appimage.yml
+++ b/.github/workflows/trial-appimage.yml
@@ -1,0 +1,128 @@
+name: Trial AppImage (Wayland-Native)
+
+# ── On-demand trial AppImage with Wayland-Native flag enabled ──────────────
+#
+# Builds an AppImage carrying `-Dawt.toolkit.name=WLToolkit` so JBR runs
+# under its native Wayland toolkit instead of XToolkit. NOT a release —
+# uploads only as a workflow artifact (7-day retention) for hand-testing on
+# real Wayland sessions (KDE Plasma 6, Hyprland, GNOME, etc.).
+#
+# Triggered manually only (`workflow_dispatch`). Default branch input lets
+# you build the trial from any branch without merging it first.
+#
+# After downloading, run on a Wayland session and grep `launcher.log` for:
+#   `grep -E 'Display: toolkit=' ~/.local/share/aura-launcher/logs/launcher.log`
+# Expected: `toolkit=sun.awt.wl.WLToolkit`. Anything else (XToolkit,
+# class-not-found) means the trial flag did not propagate — file in the
+# Wayland-Native investigation followups.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build (branch / tag / SHA). Default: triggering branch.'
+        required: false
+        default: ''
+
+# A second trial build of the same ref would just overwrite the artifact
+# with no useful difference. Keep the in-progress one running.
+concurrency:
+  group: trial-appimage-${{ github.event.inputs.ref || github.ref }}
+  cancel-in-progress: false
+
+env:
+  JAVA_VERSION: '25'
+  JAVA_DISTRIBUTION: 'jetbrains'
+  AURA_WAYLAND_TRIAL: '1'
+
+jobs:
+  build-trial:
+    name: Build Trial AppImage
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: ${{ env.JAVA_DISTRIBUTION }}
+          java-version: ${{ env.JAVA_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve trial version
+        id: version
+        run: |
+          # Synthetic version: visibly NOT a real release, ties artifact to
+          # the exact commit so multiple trial builds don't collide.
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          echo "value=0.0.0-trial-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Cache appimagetool
+        id: cache-appimagetool
+        uses: actions/cache@v4
+        with:
+          path: appimagetool
+          key: appimagetool-continuous-x86_64-2026-05
+
+      - name: Install AppImage tools
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y fuse libfuse2 desktop-file-utils appstream xmlstarlet
+          if [ -f appimagetool ]; then
+            sudo install -m 0755 appimagetool /usr/local/bin/appimagetool
+          else
+            wget -qO appimagetool \
+              "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+            chmod +x appimagetool
+            sudo install -m 0755 appimagetool /usr/local/bin/appimagetool
+          fi
+
+      # AURA_WAYLAND_TRIAL is read at gradle configuration time by
+      # client-ui/build.gradle.kts — it appends -Dawt.toolkit.name=WLToolkit
+      # to the bundled JVM args list. The variable is also kept in env at
+      # AppImage assembly time for symmetry, though only the gradle step
+      # actually consumes it.
+      - name: Build JAR with WLToolkit flag baked in
+        env:
+          APP_VERSION: ${{ steps.version.outputs.value }}
+        run: ./gradlew :client-ui:packageReleaseUberJarForCurrentOS -PappVersion="$APP_VERSION"
+
+      - name: Validate desktop entry
+        run: desktop-file-validate resources/aura-launcher.desktop
+
+      - name: Build AppImage
+        env:
+          APP_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          JAR=$(ls client-ui/build/compose/jars/*-release*.jar | head -1)
+          ./scripts/build-appimage.sh "$APP_VERSION" "$JAR"
+
+      - name: Upload trial AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: trial-appimage-${{ steps.version.outputs.value }}
+          path: AuraLauncher-${{ steps.version.outputs.value }}-x86_64.AppImage
+          retention-days: 7
+
+      - name: Note next steps in workflow summary
+        run: |
+          {
+            echo "## Trial AppImage built"
+            echo
+            echo "Download the artifact from this run, then on a Wayland session:"
+            echo
+            echo '```bash'
+            echo 'chmod +x AuraLauncher-*-x86_64.AppImage'
+            echo './AuraLauncher-*-x86_64.AppImage'
+            echo '# After it has run once and exited:'
+            echo 'grep -E "Display: toolkit=" ~/.local/share/aura-launcher/logs/launcher.log'
+            echo '```'
+            echo
+            echo "Expected line:"
+            echo '`Display: toolkit=sun.awt.wl.WLToolkit XDG_SESSION_TYPE=wayland ...`'
+            echo
+            echo "Capture observations per surface (raise pulse, tray, clipboard, window class)"
+            echo "in **docs/dev/wayland-investigation.md** under a new dated subsection."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/client-launcher/build.gradle.kts
+++ b/client-launcher/build.gradle.kts
@@ -29,5 +29,31 @@ dependencies {
 }
 
 tasks.test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags("smoke")
+    }
+}
+
+// ── Live smoke tests — gated on real `smartycraft.ru` ────────────────────────
+//
+// Lives in the same `test` source set under `hivens.launcher.smoke.*`,
+// segregated from the regular suite by the `@SmokeTest` JUnit Tag so that
+// `:client-launcher:test` excludes them and `:client-launcher:smokeTest`
+// runs only them. Reads `SMARTY_TEST_USER` / `SMARTY_TEST_PASS` from env;
+// `Assumptions.assumeTrue` short-circuits to "skipped" when absent, so
+// running this task locally without secrets does not fail.
+//
+// `outputs.upToDateWhen { false }` because the *point* of this task is to
+// probe live upstream state — caching a green "smoke passed" result against
+// unchanged inputs would defeat the purpose entirely.
+val smokeTest by tasks.registering(Test::class) {
+    description = "Runs live smoke tests against real smartycraft.ru. Requires SMARTY_TEST_USER/PASS env."
+    group = "verification"
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    useJUnitPlatform {
+        includeTags("smoke")
+    }
+    outputs.upToDateWhen { false }
+    shouldRunAfter(tasks.test)
 }

--- a/client-launcher/src/test/kotlin/hivens/launcher/smoke/LiveSmokeTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smoke/LiveSmokeTest.kt
@@ -1,0 +1,227 @@
+package hivens.launcher.smoke
+
+import hivens.config.Network
+import hivens.config.Protocol
+import hivens.core.api.AuthService
+import hivens.core.api.HttpClientProvider
+import hivens.core.api.ServerRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.header
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+import java.net.Authenticator
+import java.net.InetSocketAddress
+import java.net.PasswordAuthentication
+import java.net.Proxy
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import okhttp3.Protocol as OkProtocol
+
+/**
+ * Live smoke tests against the real `smartycraft.ru` API.
+ *
+ * Answers a single question per CI run: *can we currently authenticate
+ * end-to-end against the real upstream*? Distinct from the offline contract
+ * tests (which prove our parser matches frozen fixture shapes) and the
+ * regular unit tests (which mock the network entirely).
+ *
+ * **Hard release gate.** Tagged `@SmokeTest` so the regular `:client-launcher:test`
+ * task excludes it. The dedicated `:client-launcher:smokeTest` task runs only
+ * this class and is wired into `build_release.yml` BEFORE artefact assembly,
+ * so a smoke failure halts the release pipeline before any installer is built.
+ *
+ * **Credentials.** Reads `SMARTY_TEST_USER` / `SMARTY_TEST_PASS` from the
+ * environment. Locally these are unset, so [Assumptions.assumeTrue] short-
+ * circuits each test as "skipped" rather than failing the build. In CI both
+ * are wired through GitHub Secrets on `build_release.yml` and `smoke-daily.yml`.
+ *
+ * **What we do NOT exercise here:**
+ *   - file downloads (slow, large bandwidth, irrelevant to "is auth alive")
+ *   - process launch (would require a real game install + JDK + obviously
+ *     can't run unattended)
+ *   - destructive endpoints (purchases, password change, anything mutating)
+ */
+@SmokeTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class LiveSmokeTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        encodeDefaults = true
+    }
+
+    private lateinit var okHttp: OkHttpClient
+    private lateinit var ktor: HttpClient
+    private lateinit var provider: HttpClientProvider
+    private lateinit var serverRepo: ServerRepository
+    private lateinit var auth: AuthService
+    private lateinit var dataDir: Path
+
+    private val username: String? = System.getenv("SMARTY_TEST_USER")
+    private val password: String? = System.getenv("SMARTY_TEST_PASS")
+
+    /** Carried across ordered tests — first test discovers a server id, the next ones use it. */
+    @Volatile
+    private var discoveredServerId: String? = null
+
+    @BeforeAll
+    fun setup() {
+        // SOCKS proxy auth — same global Authenticator pattern as production
+        // wiring in client-launcher/.../di/Modules.kt. Test tearDown restores
+        // the previous Authenticator so we don't leak proxy creds into other
+        // suites that might run in the same JVM.
+        Authenticator.setDefault(object : Authenticator() {
+            override fun getPasswordAuthentication() =
+                PasswordAuthentication(Network.Proxy.USER, Network.Proxy.PASS.toCharArray())
+        })
+
+        okHttp = OkHttpClient.Builder()
+            .connectTimeout(Network.TIMEOUT_CONNECT, TimeUnit.MILLISECONDS)
+            .readTimeout(Network.TIMEOUT_READ, TimeUnit.MILLISECONDS)
+            .proxy(Proxy(Proxy.Type.SOCKS, InetSocketAddress(Network.Proxy.HOST, Network.Proxy.PORT)))
+            .also {
+                if (Network.FORCE_HTTP1_FOR_SMARTYCRAFT) {
+                    it.protocols(listOf(OkProtocol.HTTP_1_1))
+                }
+            }
+            .build()
+
+        ktor = HttpClient(OkHttp) {
+            engine { preconfigured = okHttp }
+            install(ContentNegotiation) { json(this@LiveSmokeTest.json) }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 600_000
+                connectTimeoutMillis = 30_000
+                socketTimeoutMillis = 600_000
+            }
+            defaultRequest {
+                header("User-Agent", "SMARTYlauncher/${Protocol.MIMIC_LAUNCHER_VERSION}")
+                contentType(ContentType.Application.Json)
+            }
+        }
+
+        provider = HttpClientProvider { ktor }
+        dataDir = Files.createTempDirectory("aura-smoke-")
+        serverRepo = ServerRepository(provider, json, dataDir.toFile())
+        auth = AuthService(provider, json)
+    }
+
+    @AfterAll
+    fun teardown() {
+        runCatching { ktor.close() }
+        runCatching {
+            Files.walk(dataDir).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+        }
+        Authenticator.setDefault(null)
+    }
+
+    @Test
+    @Order(1)
+    fun `dashboard returns at least one server with populated schema`() = runBlocking {
+        assumeCredentialsPresent()
+
+        val response = serverRepo.fetchDashboard()
+
+        assertNotNull(response.status, "dashboard response missing 'status' field — schema drift?")
+        assertTrue(
+            response.servers.isNotEmpty(),
+            "dashboard returned zero servers — either upstream is empty or the schema field renamed",
+        )
+
+        val first = response.servers.first()
+        assertTrue(first.id.isNotBlank(), "server entry has blank id ('name' in wire format)")
+        assertTrue(first.ip.isNotBlank(), "server entry has blank address")
+        assertTrue(first.port > 0, "server entry has invalid port: ${first.port}")
+        // assetDir is derived (defaults to id when wire field is null) — sanity-check
+        // the fallback hasn't silently broken.
+        assertTrue(first.assetDir.isNotBlank(), "assetDir derivation broken — fallback to id failed")
+
+        discoveredServerId = first.id
+    }
+
+    @Test
+    @Order(2)
+    fun `login produces a fully populated SessionData`() = runBlocking {
+        assumeCredentialsPresent()
+        val serverId = discoveredServerId
+            ?: error("test-order violation: dashboard test must run first to discover serverId")
+
+        val session = auth.login(username!!, password!!, serverId)
+
+        assertNotNull(session.status, "session.status null — auth response missing 'status'")
+        assertTrue(session.playerName.isNotBlank(), "session.playerName blank — schema field 'playername' may have renamed")
+        assertTrue(session.uuid.isNotBlank(), "session.uuid blank — auth incomplete or schema drift on 'uuid'")
+        assertTrue(session.uid.isNotBlank(), "session.uid blank — schema field 'uid' may have changed")
+        assertTrue(session.accessToken.isNotBlank(), "session.accessToken blank — generateGameToken returned empty")
+        // serverId round-trips so downstream consumers can identify the session
+        assertTrue(session.serverId == serverId, "session.serverId did not round-trip from login arg")
+    }
+
+    @Test
+    @Order(3)
+    fun `login response carries a non-trivial file manifest`() = runBlocking {
+        assumeCredentialsPresent()
+        val serverId = discoveredServerId
+            ?: error("test-order violation: dashboard test must run first to discover serverId")
+
+        val session = auth.login(username!!, password!!, serverId)
+        val manifest = session.fileManifest
+
+        assertNotNull(manifest, "fileManifest absent — auth response missing 'client' field")
+        // Real SmartyCraft manifests always carry at least the root-level file/dir
+        // collections. An empty manifest after a successful login is a strong
+        // signal of upstream protocol drift.
+        val hasAnyEntries = manifest!!.directories.isNotEmpty() || manifest.files.isNotEmpty()
+        assertTrue(hasAnyEntries, "manifest has zero directories AND zero files — schema drift on 'client' subtree?")
+    }
+
+    @Test
+    @Order(4)
+    fun `wrong password fails closed without leaking a session`() = runBlocking {
+        assumeCredentialsPresent()
+        val serverId = discoveredServerId
+            ?: error("test-order violation: dashboard test must run first to discover serverId")
+
+        // Negative path — protects against the very specific failure mode of
+        // an upstream change that returns OK + empty profile on bad creds
+        // (silent auth bypass). Catches the inverse of the positive flow.
+        val outcome = runCatching {
+            auth.login(username!!, "definitely-not-the-real-password-$${System.currentTimeMillis()}", serverId)
+        }
+        assertTrue(
+            outcome.isFailure,
+            "wrong password did NOT throw — upstream may be returning OK on bad creds (auth bypass)",
+        )
+        // Make sure no SessionData leaked despite the failure
+        assertNull(outcome.getOrNull(), "wrong-password call returned a SessionData instead of throwing")
+    }
+
+    private fun assumeCredentialsPresent() {
+        assumeTrue(
+            !username.isNullOrBlank() && !password.isNullOrBlank(),
+            "SMARTY_TEST_USER / SMARTY_TEST_PASS not set — skipping live smoke (expected on local dev)",
+        )
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/smoke/SmokeTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smoke/SmokeTest.kt
@@ -1,0 +1,19 @@
+package hivens.launcher.smoke
+
+import org.junit.jupiter.api.Tag
+
+/**
+ * Marks a test as a *live smoke* — touches the real `smartycraft.ru` API
+ * over the production proxy. Excluded from the regular `:client-launcher:test`
+ * task; included only by the dedicated `:client-launcher:smokeTest` task,
+ * which is gated behind the `SMARTY_TEST_USER` / `SMARTY_TEST_PASS`
+ * GitHub Secrets.
+ *
+ * JUnit Jupiter propagates `@Tag` through composed annotations, so
+ * tagging a class with `@SmokeTest` is equivalent to `@Tag("smoke")` on
+ * every test method inside it.
+ */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@Tag("smoke")
+annotation class SmokeTest

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -205,7 +205,25 @@ compose.desktop {
             "--enable-native-access=ALL-UNNAMED",
 
             // prevent JNA native lib version conflict
-            "-Djna.nosys=true"
+            "-Djna.nosys=true",
+
+            // ── Wayland-Native trial flag ─────────────────────────────────
+            //
+            // Force JBR's WLToolkit instead of XToolkit when AURA_WAYLAND_TRIAL=1
+            // is set in the build environment. JBR 25 ships sun.awt.wl.WLToolkit
+            // but defaults to XToolkit even on Wayland sessions; we have to opt in
+            // explicitly. Trial-only because the toolkit-aware fallback paths
+            // (WM_CLASS, raise pulse, jlink jetbrains.api module) are not yet in
+            // place — see docs/dev/wayland-investigation.md for the chunk plan.
+            //
+            // `providers.environmentVariable(...).orNull` is configuration-cache
+            // safe (vs. raw System.getenv); evaluation deferred to the proper
+            // gradle stage.
+            *(if (providers.environmentVariable("AURA_WAYLAND_TRIAL").orNull == "1") {
+                arrayOf("-Dawt.toolkit.name=WLToolkit")
+            } else {
+                emptyArray()
+            })
         )
     }
 }

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -182,7 +182,6 @@ compose.desktop {
             // Graphics optimization
             "-Dawt.useSystemAAFontSettings=on",
             "-Djdk.gtk.version=3",
-            "-Dwayland.debug.children=true",
             "-D_JAVA_AWT_WM_NONREPARENTING=1",
             "-Drobot.need_x11=false",
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -105,6 +105,28 @@ sealed class Screen {
 // ─── Entry Point ─────────────────────────────────────────────────────────────
 
 /**
+ * Single startup line summarising which AWT toolkit JBR/JDK picked and what
+ * Linux display-server environment we're in. The Wayland-Native investigation
+ * (docs/dev/wayland-investigation.md) needs every log we get back from a real
+ * user to triangulate the toolkit-vs-session matrix; this line makes it
+ * trivial to grep across `launcher.log` files attached to bundles.
+ *
+ * Always-on (not gated by AURA_WAYLAND_TRIAL) — the diagnostic value applies
+ * to every Linux user, not just trial participants.
+ */
+private fun logToolkitAndSession() {
+    if (!System.getProperty("os.name").lowercase().contains("linux")) return
+    val toolkit = runCatching { java.awt.Toolkit.getDefaultToolkit().javaClass.name }
+        .getOrElse { "<unavailable: ${it.javaClass.simpleName}>" }
+    fun env(k: String) = System.getenv(k) ?: "<unset>"
+    LoggerFactory.getLogger("Main").info(
+        "Display: toolkit={} XDG_SESSION_TYPE={} XDG_CURRENT_DESKTOP={} WAYLAND_DISPLAY={} DISPLAY={}",
+        toolkit, env("XDG_SESSION_TYPE"), env("XDG_CURRENT_DESKTOP"),
+        env("WAYLAND_DISPLAY"), env("DISPLAY"),
+    )
+}
+
+/**
  * Force the X11 toolkit's app class name so the WM_CLASS hint on every window
  * we create matches `StartupWMClass=` in the .desktop entry.
  *
@@ -166,6 +188,12 @@ fun main() {
     // OpenJDK we reflect into sun.awt.X11.XToolkit.awtAppClassName before the
     // first window is created. See jvmArgs in client-ui/build.gradle.kts.
     setLinuxXToolkitAppClassName(Branding.WM_CLASS)
+
+    // Capture toolkit + session-type as soon as the toolkit has been triggered
+    // by setLinuxXToolkitAppClassName above. One INFO line per launch — gives
+    // every user-attached `launcher.log` enough context to slot into the
+    // Wayland-Native investigation matrix.
+    logToolkitAndSession()
 
     java.nio.file.Files.createDirectories(paths.dataDir)
     CrashReporter.paths = paths

--- a/docs/src/content/docs/dev/wayland-investigation.md
+++ b/docs/src/content/docs/dev/wayland-investigation.md
@@ -1,0 +1,276 @@
+---
+title: Wayland-Native — investigation notes
+description: Current state of Wayland support in Aura Launcher and a roadmap for going from "XWayland-fallback" to "Wayland-native".
+---
+
+## ── Status as of 2026-05-12 ─────────────────────────────────────────────────
+
+Aura Launcher ships today as an **XWayland client**, not a native Wayland
+client. Everywhere we set "WM_CLASS" or reach into the JDK toolkit, we
+assume `XToolkit` (the X11 backend). On a pure Wayland session the JDK
+silently falls back to XWayland; visually nothing breaks, but we lose:
+
+- Native window-class identity (`xdg-shell` `app_id` is not set, so
+  GNOME / KDE / Hyprland associate windows by inferred heuristics rather
+  than the `.desktop` entry).
+- DPI accuracy on per-monitor fractional scaling.
+- Direct clipboard / portal integration.
+- Native input — Wayland-only features like `RelativePointerMovement` are
+  unreachable.
+
+The `troubleshooting.md` page implicitly admits this with the
+"if blank window — force XWayland" workaround.
+
+## ── Why this matters ───────────────────────────────────────────────────────
+
+KDE on Arch defaults to Wayland. GNOME on most modern distros defaults
+to Wayland. Hyprland is Wayland-only. Anyone reporting a "wrong icon" or
+"window won't focus" issue on those compositors is hitting our XToolkit
+assumptions, not a real bug in the launcher.
+
+Going Wayland-native also unlocks the usual modern-Linux niceties for
+free: HDR-correct colour, fractional scaling, gestures, secure portals
+for screen capture / file dialog. Compose Desktop already knows how to
+draw into a Wayland surface — the gap is in JDK windowing and our
+platform-specific glue.
+
+## ── What JBR 25 actually exposes ───────────────────────────────────────────
+
+JetBrains Runtime 25 ships **`WLToolkit`** as a peer to `XToolkit`.
+Confirmed via the `jbr-api` 1.9.0 javadoc:
+
+- `JBR.getHiDPIInfo()` — explicitly documents
+  *"Supported on Linux ({@code XToolkit}, {@code WLToolkit}) only"*.
+- `JBR.getRelativePointerMovement()` — documents
+  *"Supported on Linux and with {@code WLToolkit} only"* (this is a
+  Wayland-exclusive feature).
+
+Selection mechanism (per JBR docs / OpenJDK upstream):
+
+- Default selection is auto: when `XDG_SESSION_TYPE=wayland` and the JBR
+  toolkit was built with Wayland support, JBR picks `WLToolkit`.
+- Explicit override: `-Dawt.toolkit.name=WLToolkit` (or `XToolkit` to
+  force XWayland fallback).
+- The classic `awt.toolkit` system property still works for binary class
+  names but is the legacy path.
+
+## ── Where Aura currently breaks the abstraction ────────────────────────────
+
+Inventory of X11-specific assumptions in our code:
+
+### `client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt`
+
+| Lines | Code | Wayland behaviour |
+|-------|------|-------------------|
+| 121-137 | `setLinuxXToolkitAppClassName` reflects into `sun.awt.X11.XToolkit.awtAppClassName` | `Class.forName("sun.awt.X11.XToolkit")` succeeds (class is on the classpath) but on `WLToolkit` the field assignment has zero effect — `xdg-shell` `app_id` is set elsewhere. **Silent no-op**. |
+| 437-446 | `isAlwaysOnTop = true → toFront → requestFocus → false` raise trick | X11-specific behaviour: under Wayland compositors raise is gated by `xdg-activation-v1` or compositor policy, often refused entirely (Hyprland by default, GNOME without focus stealing prevention). The pulse trick may visibly flicker `always-on-top` without producing a raise. |
+
+### `client-ui/src/desktopMain/kotlin/hivens/ui/build.gradle.kts`
+
+| Line | Flag | Wayland relevance |
+|------|------|-------------------|
+| 179 | `-Dawt.appClassName=AuraLauncher` | JBR-only; ignored under `WLToolkit`. JBR sets `app_id` differently for Wayland — likely needs a new mechanism. |
+| 180 | `--add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED` | Harmless no-op on Wayland (the package exists but our reflection target doesn't apply). |
+| 184 | `-D_JAVA_AWT_WM_NONREPARENTING=1` | X11-specific Mutter workaround. Harmless under Wayland. |
+| 185 | `-Drobot.need_x11=false` | Hint for `Robot` class init under headless / X11. Wayland Robot uses its own portal-based path. Harmless. |
+
+### `client-ui/.../tray/TrayManager.kt`
+
+`dorkbox/SystemTray` 4.4 uses `LinuxAppIndicator` over DBus by default —
+the `StatusNotifierItem` protocol is display-server agnostic. **Should
+survive Wayland**, but needs verification:
+
+- KDE: native StatusNotifierWatcher. Works.
+- GNOME: needs the `AppIndicator and KStatusNotifierItem Support`
+  extension. Without it, no tray (already a known limitation, not
+  Wayland-specific).
+- Hyprland: works via waybar's SNI host.
+
+### `Desktop.getDesktop().browse(URI)` / `.open(File)`
+
+Used in `RightPanel.kt`, `ProfileScreen.kt`, `AboutScreen.kt`,
+`SettingsScreen.kt`, `ServerSettingsScreen.kt`, `UpdateDialog.kt`,
+`CrashReporter.kt`. All go through `xdg-open` on Linux, which routes
+through xdg-desktop-portal on Wayland sessions — works natively. No
+change needed.
+
+### Clipboard
+
+- `Toolkit.getDefaultToolkit().systemClipboard` in `SettingsScreen.kt`
+  and `CrashReporter.kt` — under `WLToolkit` JBR routes via
+  `wl_data_device_manager`. Should just work.
+- `LocalClipboard.current` in `ConsoleWindow.kt` — Compose Desktop
+  abstraction, delegates to JBR clipboard impl.
+
+### `Toolkit.getDefaultToolkit().screenSize` (`AboutScreen.kt:72`)
+
+Returns the primary screen's logical size. Under Wayland multi-monitor
+with fractional scaling this can be wrong; we use it for an "About"
+splash sizing decision so the impact is cosmetic, not functional.
+
+## ── Probe results — 2026-05-12, Hyprland Wayland ───────────────────────────
+
+`scripts/wayland-probe.sh` captured the following on the user's machine
+(Arch + Hyprland Wayland session):
+
+**System Liberica JDK 25** (`/usr/bin/java`, OpenJDK 25.0.3):
+
+| Mode | `Toolkit.getDefaultToolkit().getClass().getName()` |
+|------|---------------------------------------------------|
+| auto | `sun.awt.X11.XToolkit` |
+| `-Dawt.toolkit.name=XToolkit` | `sun.awt.X11.XToolkit` |
+| `-Dawt.toolkit.name=WLToolkit` | `sun.awt.X11.XToolkit` (silently ignored — no class) |
+
+Confirms upstream OpenJDK forks (Liberica, Temurin, Adoptium) **do not
+ship `WLToolkit`** even on JDK 25 / Wayland session.
+
+**Bundled JBR from the v2.2.11 AppImage** (`JBR-25.0.2+10-432.48-nomod`):
+
+| Mode | `Toolkit.getDefaultToolkit().getClass().getName()` |
+|------|---------------------------------------------------|
+| auto (Wayland session) | `sun.awt.X11.XToolkit` — JBR does **not** auto-pick WLToolkit |
+| `-Dawt.toolkit.name=XToolkit` | `sun.awt.X11.XToolkit` |
+| `-Dawt.toolkit.name=WLToolkit` | `sun.awt.wl.WLToolkit` ← **native Wayland reachable** |
+
+Two important corollaries:
+
+1. **WLToolkit is opt-in, not auto.** Even on a clear Wayland session
+   (`XDG_SESSION_TYPE=wayland`, `WAYLAND_DISPLAY=wayland-1`,
+   `XDG_CURRENT_DESKTOP=Hyprland`) JBR defaults to XToolkit. We must
+   add `-Dawt.toolkit.name=WLToolkit` to `compose.desktop.application.jvmArgs`,
+   gated on Linux + Wayland session.
+2. **`com.jetbrains.JBR` is missing from our jlinked runtime.** Probing
+   `Class.forName("com.jetbrains.JBR")` returns ClassNotFoundException
+   even on JBR. The Compose plugin's `modules(...)` list in
+   `client-ui/build.gradle.kts` lines 128-140 includes only standard
+   `java.*` and `jdk.crypto.ec` / `jdk.unsupported` / `jdk.zipfs`. Any
+   JBR-only Wayland API (`HiDPIInfo`, `RelativePointerMovement`,
+   `Screenshoter`) is unreachable in our shipped artifacts. Adding
+   `jetbrains.api` (or whatever the correct module name is) to the
+   modules list pulls JBR API into the jlinked runtime.
+
+Smoke-level **window-creation** test (Swing JFrame, 2.5s pop-and-close)
+on JBR / Hyprland with both toolkits:
+
+- Default (XToolkit auto, XWayland-backed): exits 0, no warnings.
+- Forced WLToolkit (`sun.awt.wl.WLToolkit`): exits 0, no warnings.
+
+Both modes produce a visible window on screen with no stderr noise. This
+is a *necessary* but not *sufficient* signal — Compose Desktop, with its
+Skiko renderer, focus management, and tray integration, is the real
+test. But the basic JBR Wayland toolkit path is alive on Hyprland.
+
+## ── Proposed prove-or-deny test ────────────────────────────────────────────
+
+Two-step verification before committing to a Wayland-native chunk:
+
+1. **Toolkit detection**. Run a short JBR program (~20 lines) that prints
+   `Toolkit.getDefaultToolkit().getClass().getName()` under both
+   `XToolkit` (forced) and auto-selection on a Wayland session. Confirms
+   our assumption that JBR picks `WLToolkit` automatically without
+   intervention.
+
+2. **End-to-end visual smoke**. Run the **CI-built v2.2.11 AppImage**
+   (which carries jlinked JBR runtime, not the dev-machine Liberica) on
+   a KDE Wayland session. Capture:
+
+   - Window opens and renders the splash + main UI.
+   - Tray icon appears (or expected GNOME-without-extension caveat).
+   - `Toolkit.getDefaultToolkit().getClass().getName()` from a runtime
+     log line — confirms which toolkit is active.
+   - WM_CLASS / `app_id` as reported by `qdbus` / `hyprctl clients` —
+     confirms whether the `.desktop` association works.
+   - Focus / raise behaviour when triggering the second-instance pulse.
+
+3. **Failure-mode log capture**. Even if it works, the
+   `setLinuxXToolkitAppClassName` reflection will hit the `onFailure`
+   branch and produce a `WARN` line. Confirm that warning is the only
+   visible error — anything else is unexpected and goes on the
+   investigation worksheet.
+
+A test script for step 1+3 lives at `scripts/wayland-probe.sh` (to be
+added alongside this doc).
+
+## ── Decision — 2026-05-12 ──────────────────────────────────────────────────
+
+**GO**, with conditions. Probe data above shows the path exists
+and is alive at the JBR layer on the user's Hyprland session. Promote
+**Wayland-native** to a real chunk in Project Void as a Bridge-pillar
+continuation.
+
+The chunk splits into a **trial** (small, low-risk, reversible) and an
+**adoption** (only after the trial demonstrates Compose-level success):
+
+### Trial chunk — toolkit opt-in + measure
+
+Smallest reversible change that exposes the truth at Compose level:
+
+1. Add `-Dawt.toolkit.name=WLToolkit` to
+   `compose.desktop.application.jvmArgs` in `client-ui/build.gradle.kts`,
+   gated by an env var `AURA_WAYLAND_TRIAL=1` so default builds and
+   regular users are unaffected. (Use `providers.environmentVariable` at
+   configuration time to keep the configuration cache happy.)
+2. Add a startup log line in `Main.kt` capturing
+   `Toolkit.getDefaultToolkit().getClass().getName()`,
+   `XDG_SESSION_TYPE`, `WAYLAND_DISPLAY` so any field tester's
+   `launcher.log` immediately reports which toolkit they got.
+3. Build the trial AppImage in CI behind `workflow_dispatch` (not on
+   release tags) and have the user run it on Hyprland + KDE Plasma 6
+   Wayland sessions.
+4. Capture failure modes per [[Where Aura currently breaks]] inventory
+   above: WM_CLASS reflection (expected silent fail), raise pulse
+   (expected to refuse), tray (expected to survive via DBus), clipboard,
+   Desktop.browse, screen size.
+
+Trial is **S-sized**: ~30 LOC + a workflow override. Output is a
+follow-up writeup in this same doc with concrete pass/fail per surface.
+
+### Adoption chunk — Linux-Wayland-by-default
+
+Only after trial demonstrates Compose actually starts and renders:
+
+- **S** — add the `jetbrains.api` (or correct name; verify by inspecting
+  the JBR runtime) module to the `modules(...)` list so
+  `com.jetbrains.JBR` becomes reachable in jlinked artifacts. Without
+  this, Wayland-only JBR services stay locked behind `ClassNotFoundException`.
+- **S** — wrap `setLinuxXToolkitAppClassName` in a toolkit check so it
+  only runs under `XToolkit`; on `WLToolkit` route to a placeholder
+  `setLinuxWLAppId(name)` (initially a TODO log line, fixed when JBR
+  exposes the right setter — needs separate research).
+- **M** — replace the X11-specific `isAlwaysOnTop` raise pulse with
+  either `xdg-activation-v1` activation tokens (if JBR exposes them
+  via API) or a documented "Wayland users: use the tray icon to
+  surface the window" caveat. Flickering `always-on-top` under
+  Hyprland is worse than no raise at all.
+- **S** — flip the env-var gate off, default to WLToolkit on Linux
+  Wayland sessions, keep XToolkit fallback on `XDG_SESSION_TYPE=x11`
+  or when `WAYLAND_DISPLAY` is unset. The toolkit choice is per-launch,
+  not a user-toggle in Settings (no good reason to ship both code
+  paths at runtime).
+- **S** — update `troubleshooting.md` (en + ru) to remove the
+  "force XWayland" workaround and replace with "if Wayland renders
+  wrong, set `AURA_TOOLKIT=X11` env to fall back".
+
+### Open research items (don't block trial)
+
+- **JBR `app_id` setter mechanism** — JBR-API has `WindowDecorations`
+  and `WindowMove` exposed; an `app_id` setter may live there or be
+  set via the platform window peer. Needs source-level look at JBR
+  upstream (separate task; the trial doesn't need it because the
+  AppImage's `.desktop` entry's `StartupWMClass` covers the splash
+  case adequately on most compositors).
+- **Skiko + Vulkan on Wayland** — Compose Desktop renderer. Skiko is
+  GPU-agnostic; Vulkan path may already work natively. Worth measuring
+  fps/jitter against XWayland baseline as a side-benefit number for
+  the chunk's commit message.
+- **Tray on GNOME Wayland without extension** — known caveat,
+  pre-existing, not Wayland-native-induced. Not in scope for this
+  chunk; handled by [[dorkbox-systemtray-replace]] when that lands.
+
+### Sequencing
+
+Independent of Echo / smoke / contract tests. Slots in cleanly anywhere
+after smoke is merged to stable (so we have a release-gate when the
+trial AppImage breaks something subtle). Plausibly 2.2.13 (trial) +
+2.2.14 (adoption) given the size split, or one combined release if the
+trial reports clean.

--- a/scripts/wayland-probe.sh
+++ b/scripts/wayland-probe.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# wayland-probe — investigative probe for "is JBR really picking WLToolkit?".
+#
+# Run this on a Linux Wayland session (KDE / GNOME / Hyprland / ...) to
+# answer:
+#   1. Is the current session actually Wayland (XDG_SESSION_TYPE)?
+#   2. Which AWT toolkit does the active JDK resolve to (X11 fallback or
+#      native WLToolkit)?
+#   3. Are JBR's Wayland-only services (RelativePointerMovement, HiDPIInfo)
+#      reachable?
+#
+# Two run modes:
+#   - Default: uses whichever `java` is on PATH. On Liberica/Temurin/etc.
+#     this will report XToolkit only — that's expected; those JDKs do not
+#     ship WLToolkit.
+#   - With AppImage: pass an Aura AppImage path to extract its bundled
+#     JBR runtime and probe through that. This is the realistic scenario
+#     because shipped artifacts use JBR.
+#
+# Usage:
+#   ./scripts/wayland-probe.sh
+#   ./scripts/wayland-probe.sh /path/to/AuraLauncher-2.2.11-x86_64.AppImage
+#
+# Output: human-readable report. Save the output to attach to the
+# Wayland-native investigation in docs/dev/wayland-investigation.md.
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+APPIMAGE="${1:-}"
+WORK="$(mktemp -d -t wayland-probe.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "── Wayland probe — Aura Launcher"
+echo "── $(date -Iseconds)"
+echo
+
+# ── Section 1: session environment ─────────────────────────────────────────
+echo "▼ Session environment"
+echo "  XDG_SESSION_TYPE   = ${XDG_SESSION_TYPE:-<unset>}"
+echo "  XDG_CURRENT_DESKTOP= ${XDG_CURRENT_DESKTOP:-<unset>}"
+echo "  WAYLAND_DISPLAY    = ${WAYLAND_DISPLAY:-<unset>}"
+echo "  DISPLAY            = ${DISPLAY:-<unset>}"
+echo "  GDK_BACKEND        = ${GDK_BACKEND:-<unset>}"
+echo
+
+if [[ "${XDG_SESSION_TYPE:-}" != "wayland" ]]; then
+    echo "  ⚠ Not on a Wayland session — toolkit results below are X11-by-design."
+    echo "    Re-run from a Wayland session (KDE / GNOME / Hyprland) for a useful probe."
+    echo
+fi
+
+# ── Section 2: pick a JDK ──────────────────────────────────────────────────
+JAVA_BIN=""
+if [[ -n "$APPIMAGE" ]]; then
+    if [[ ! -f "$APPIMAGE" ]]; then
+        echo "✗ AppImage not found: $APPIMAGE" >&2
+        exit 1
+    fi
+    echo "▼ Extracting bundled JBR from $APPIMAGE"
+    cp "$APPIMAGE" "$WORK/aura.AppImage"
+    chmod +x "$WORK/aura.AppImage"
+    (cd "$WORK" && ./aura.AppImage --appimage-extract >/dev/null 2>&1)
+    # AppImages built by build-appimage.sh place the JRE under usr/lib/runtime/
+    if [[ -x "$WORK/squashfs-root/usr/lib/runtime/bin/java" ]]; then
+        JAVA_BIN="$WORK/squashfs-root/usr/lib/runtime/bin/java"
+    else
+        # Fallback: search for any java binary in the extracted tree.
+        JAVA_BIN="$(find "$WORK/squashfs-root" -type f -name java -executable | head -n 1 || true)"
+    fi
+    if [[ -z "$JAVA_BIN" ]]; then
+        echo "✗ No java binary found inside AppImage extraction." >&2
+        exit 1
+    fi
+    echo "  using: $JAVA_BIN"
+else
+    JAVA_BIN="$(command -v java || true)"
+    if [[ -z "$JAVA_BIN" ]]; then
+        echo "✗ No java on PATH and no AppImage path provided." >&2
+        exit 1
+    fi
+    echo "▼ No AppImage given — probing PATH java"
+    echo "  using: $JAVA_BIN"
+fi
+echo "  $($JAVA_BIN -version 2>&1 | head -n 2 | sed 's/^/    /')"
+echo
+
+# ── Section 3: tiny Java probe ────────────────────────────────────────────
+PROBE_DIR="$WORK/probe"
+mkdir -p "$PROBE_DIR"
+cat > "$PROBE_DIR/ToolkitProbe.java" <<'JAVA'
+public class ToolkitProbe {
+    public static void main(String[] args) throws Exception {
+        // Fence off any window pop — Toolkit init is OK headless.
+        System.setProperty("java.awt.headless", "false");
+
+        java.awt.Toolkit tk = java.awt.Toolkit.getDefaultToolkit();
+        System.out.println("toolkit.class      = " + tk.getClass().getName());
+        System.out.println("awt.toolkit.name   = " + System.getProperty("awt.toolkit.name", "<unset>"));
+        System.out.println("awt.toolkit        = " + System.getProperty("awt.toolkit", "<unset>"));
+
+        // Try to peek at JBR Wayland-only services without forcing the
+        // jbr-api jar onto the classpath. Reflection through com.jetbrains.JBR
+        // resolves only when running on JBR with WLToolkit + the service
+        // implemented.
+        try {
+            Class<?> jbr = Class.forName("com.jetbrains.JBR");
+            Object hidpi = jbr.getMethod("getHiDPIInfo").invoke(null);
+            System.out.println("JBR.getHiDPIInfo   = " + (hidpi != null ? "available" : "null"));
+            Object rpm = jbr.getMethod("getRelativePointerMovement").invoke(null);
+            System.out.println("JBR.getRPM         = " + (rpm != null ? "available (Wayland-only)" : "null (not WLToolkit?)"));
+        } catch (ClassNotFoundException e) {
+            System.out.println("JBR API            = not present (this is not JBR — expected on Liberica/Temurin/...)");
+        } catch (Throwable t) {
+            System.out.println("JBR API            = error: " + t.getClass().getSimpleName() + ": " + t.getMessage());
+        }
+    }
+}
+JAVA
+
+# Locate javac. The AppImage runtime jlink build rarely includes javac;
+# fall back to system javac when running through AppImage.
+JAVAC_BIN=""
+if [[ -n "$APPIMAGE" ]]; then
+    JAVAC_BIN="$(command -v javac || true)"
+    if [[ -z "$JAVAC_BIN" ]]; then
+        echo "✗ Need a system javac to compile the probe. Install JDK or run without an AppImage arg." >&2
+        exit 1
+    fi
+else
+    JAVAC_BIN="${JAVA_BIN%/java}/javac"
+    [[ -x "$JAVAC_BIN" ]] || JAVAC_BIN="$(command -v javac || true)"
+fi
+"$JAVAC_BIN" -d "$PROBE_DIR" "$PROBE_DIR/ToolkitProbe.java"
+
+run_probe() {
+    local label="$1"
+    shift
+    echo "▼ $label"
+    "$JAVA_BIN" "$@" -cp "$PROBE_DIR" ToolkitProbe 2>&1 | sed 's/^/  /'
+    echo
+}
+
+# Auto-selection: whatever JBR / JDK picks given the session.
+run_probe "Default toolkit selection (auto)"
+
+# Forced X11 — guaranteed-portable baseline.
+run_probe "Forced -Dawt.toolkit.name=XToolkit" -Dawt.toolkit.name=XToolkit
+
+# Forced WLToolkit — only meaningful on JBR; OpenJDK forks will fall back
+# silently and report XToolkit again, which is itself a useful data point.
+run_probe "Forced -Dawt.toolkit.name=WLToolkit" -Dawt.toolkit.name=WLToolkit
+
+echo "── Probe complete."
+echo "── Attach the output above to docs/dev/wayland-investigation.md or paste"
+echo "   it into the next iteration's prompt for the go/no-go decision."


### PR DESCRIPTION
## Summary

Backbone update from Project-Void onto stable. **Not a release** — no tag will be pushed alongside. Lands the infrastructure pieces that subsequent work depends on.

- **Smoke (live `smartycraft.ru`)**: `@SmokeTest` JUnit tag + `LiveSmokeTest` covering dashboard / login / manifest / wrong-password. Dedicated `:client-launcher:smokeTest` gradle task. New `smoke` job in `build_release.yml` is a hard release gate. New `smoke-daily.yml` cron at 06:00 UTC catches upstream protocol drift between releases.
- **Wayland-Native investigation**: `docs/dev/wayland-investigation.md` writeup with concrete probe data (Liberica vs JBR-25.0.2, XToolkit vs WLToolkit, JBR API gating). `scripts/wayland-probe.sh` for reproducing locally. Decision: GO with conditions, split into Trial (S) → Adoption (M).
- **Trial chunk** (Wayland-Native step 1): `AURA_WAYLAND_TRIAL=1` env-gated `-Dawt.toolkit.name=WLToolkit` in `client-ui/build.gradle.kts`. Always-on `Display: toolkit=...` log line in `Main.kt` for everyone (not just trial users). New `.github/workflows/trial-appimage.yml` (workflow_dispatch only) for hand-tested AppImages on real Wayland sessions.
- **Cleanup**: dropped phantom `-Dwayland.debug.children=true` JVM arg (no such property in any JDK / JBR — cargo cult).

## Activates on merge

- `smoke-daily.yml` will start running at 06:00 UTC daily (live probe of `smartycraft.ru` via SMARTY_TEST_USER/PASS secrets).
- Next release tag will gate on `:client-launcher:smokeTest` before any artefact assembly.
- `trial-appimage.yml` becomes dispatchable from Actions UI (or `gh workflow run trial-appimage.yml --ref Project-Void`).

## Test plan

- [x] `./gradlew :client-launcher:test` green locally — smoke tests excluded by tag filter
- [x] `./gradlew :client-launcher:smokeTest` locally — 4 tests skipped (assumeTrue on missing creds), exit 0
- [x] `./gradlew :client-ui:compileKotlinDesktop` green after Main.kt change
- [x] `scripts/wayland-probe.sh` exercised on Hyprland with both Liberica and bundled JBR — data captured in investigation doc
- [ ] After merge: trigger `trial-appimage.yml` via UI, download artifact, run on Hyprland + KDE Wayland, capture launcher.log