### PR TITLE
ci(release): review-gate — refuse to release un-reviewed HEAD

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -25,11 +25,60 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
+  # Review gate — refuses to release un-reviewed code
+  #
+  # Resolves the PR that brought HEAD onto stable (`gh pr list --search
+  # sha:$GITHUB_SHA`) and asserts that PR carries at least one APPROVING
+  # review. Fails the entire pipeline early — before tests, before builds —
+  # if HEAD is not associated with an approved PR.
+  #
+  # Catches three failure modes:
+  #   1. Tag pushed against a stable HEAD that landed without going through PR
+  #      (direct push, force-push, or a maintainer who got merge-happy).
+  #   2. PR merged but Codex hit its rate limit and never approved — Codex
+  #      leaves a comment but no APPROVED review, so this gate stays red.
+  #   3. Compromised maintainer account pushes a tag against an unreviewed
+  #      sneak-in commit. Branch protection on stable catches the merge;
+  #      this catches the tag.
+  #
+  # The check uses `GH_TOKEN: secrets.GITHUB_TOKEN`, which has the necessary
+  # `pull_requests: read` scope by default. No extra setup needed.
+  # ─────────────────────────────────────────────────────────────────────────
+  review-gate:
+    name: Review Gate
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - name: Verify HEAD originates from an approved PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_SHA:   ${{ github.sha }}
+          GH_REPO:  ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          echo "Resolving PR for HEAD $GH_SHA on $GH_REPO..."
+          PR=$(gh pr list --repo "$GH_REPO" --state merged --search "sha:$GH_SHA" --json number --jq '.[0].number // empty')
+          if [ -z "$PR" ]; then
+            echo "::error title=Review gate::HEAD ($GH_SHA) is not associated with any merged PR. Refusing to release un-PR-ed commits."
+            exit 1
+          fi
+          echo "Found PR #$PR — checking approving reviews..."
+          APPROVED=$(gh pr view "$PR" --repo "$GH_REPO" --json reviews --jq '[.reviews[] | select(.state=="APPROVED")] | length')
+          if [ "$APPROVED" -lt 1 ]; then
+            echo "::error title=Review gate::PR #$PR has zero APPROVED reviews. Possible causes: (1) merged without review, (2) Codex hit rate limit and only commented, (3) all approvals were dismissed by stale-review policy. Get a fresh approval before tagging."
+            exit 1
+          fi
+          echo "::notice title=Review gate::PR #$PR has $APPROVED approving review(s). Gate passes."
+
+  # ─────────────────────────────────────────────────────────────────────────
   # Tests - must pass BEFORE any build
   # ─────────────────────────────────────────────────────────────────────────
   test:
     name: Run Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    needs: review-gate
     # fail-fast: false — one OS failing shouldn't kill the others; we want
     # to see ALL platform-specific failures in one run, not race-of-the-first.
     # shell: bash so steps work identically on Windows runners (PowerShell's

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -25,24 +25,39 @@ env:
 
 jobs:
   # ─────────────────────────────────────────────────────────────────────────
-  # Review gate — refuses to release un-reviewed code
+  # Review gate — refuses to release HEAD that no reviewer engaged with
   #
-  # Resolves the PR that brought HEAD onto stable (`gh pr list --search
-  # sha:$GITHUB_SHA`) and asserts that PR carries at least one APPROVING
-  # review. Fails the entire pipeline early — before tests, before builds —
-  # if HEAD is not associated with an approved PR.
+  # Resolves the PR that brought HEAD onto stable
+  # (`gh pr list --search sha:$GITHUB_SHA`) and asserts at least one of:
   #
-  # Catches three failure modes:
-  #   1. Tag pushed against a stable HEAD that landed without going through PR
-  #      (direct push, force-push, or a maintainer who got merge-happy).
-  #   2. PR merged but Codex hit its rate limit and never approved — Codex
-  #      leaves a comment but no APPROVED review, so this gate stays red.
-  #   3. Compromised maintainer account pushes a tag against an unreviewed
-  #      sneak-in commit. Branch protection on stable catches the merge;
-  #      this catches the tag.
+  #   - An APPROVED review (the strict signal — only humans can leave this;
+  #     PR authors cannot self-approve per GitHub policy).
+  #   - A non-author review *of any state* — captures the realistic
+  #     solo-maintainer + Codex case. Codex only ever leaves COMMENTED
+  #     reviews ("If Codex has suggestions, it will comment; otherwise it
+  #     will react with 👍" — Codex docs). The presence of a Codex review
+  #     entry proves the bot processed the diff; absence means Codex hit
+  #     its rate limit and only left a plain comment about the limit, with
+  #     no review entity attached.
   #
-  # The check uses `GH_TOKEN: secrets.GITHUB_TOKEN`, which has the necessary
-  # `pull_requests: read` scope by default. No extra setup needed.
+  # Failure modes this catches:
+  #   1. Direct/force push to stable bypassing PR (no merging PR for SHA).
+  #   2. PR merged but no reviewer engaged (rate-limited Codex with only a
+  #      "you've hit the limit" comment, or a hurried merge with the bot
+  #      disabled). User's explicit concern in the policy menu — see
+  #      [[no_compromised_release]] memory if it gets written.
+  #   3. Compromised maintainer account opening a PR + immediately self-
+  #      merging without any external eyes — branch protection on stable
+  #      handles the merge attempt; this gate handles any release that
+  #      somehow squeezed through.
+  #
+  # Trust model honesty: solo-maintainer with bot-only review is NOT
+  # crypto-strong. A subtle malicious diff that Codex doesn't catch will
+  # pass this gate. The gate enforces *engagement happened*, not *engagement
+  # was correct*. Strengthening would require adding a non-bot reviewer.
+  #
+  # `GH_TOKEN: secrets.GITHUB_TOKEN` has the `pull_requests: read` scope by
+  # default. No extra setup needed.
   # ─────────────────────────────────────────────────────────────────────────
   review-gate:
     name: Review Gate
@@ -51,7 +66,7 @@ jobs:
       pull-requests: read
       contents: read
     steps:
-      - name: Verify HEAD originates from an approved PR
+      - name: Verify HEAD originates from a reviewed PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_SHA:   ${{ github.sha }}
@@ -64,13 +79,24 @@ jobs:
             echo "::error title=Review gate::HEAD ($GH_SHA) is not associated with any merged PR. Refusing to release un-PR-ed commits."
             exit 1
           fi
-          echo "Found PR #$PR — checking approving reviews..."
-          APPROVED=$(gh pr view "$PR" --repo "$GH_REPO" --json reviews --jq '[.reviews[] | select(.state=="APPROVED")] | length')
-          if [ "$APPROVED" -lt 1 ]; then
-            echo "::error title=Review gate::PR #$PR has zero APPROVED reviews. Possible causes: (1) merged without review, (2) Codex hit rate limit and only commented, (3) all approvals were dismissed by stale-review policy. Get a fresh approval before tagging."
-            exit 1
+          echo "Found PR #$PR — checking review engagement..."
+          # Pull author + reviews in one shot so we can correctly exclude self-reviews.
+          PR_JSON=$(gh pr view "$PR" --repo "$GH_REPO" --json author,reviews)
+          AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login')
+          APPROVED=$(echo "$PR_JSON" | jq --arg author "$AUTHOR" \
+            '[.reviews[] | select(.state=="APPROVED" and .author.login != $author)] | length')
+          ANY_REVIEW=$(echo "$PR_JSON" | jq --arg author "$AUTHOR" \
+            '[.reviews[] | select(.author.login != $author)] | length')
+          if [ "$APPROVED" -ge 1 ]; then
+            echo "::notice title=Review gate::PR #$PR has $APPROVED approving review(s) from non-authors. Gate passes (strong signal)."
+            exit 0
           fi
-          echo "::notice title=Review gate::PR #$PR has $APPROVED approving review(s). Gate passes."
+          if [ "$ANY_REVIEW" -ge 1 ]; then
+            echo "::notice title=Review gate::PR #$PR has $ANY_REVIEW non-author review(s) (no APPROVED, but engagement present — typically Codex COMMENTED state). Gate passes (weak signal)."
+            exit 0
+          fi
+          echo "::error title=Review gate::PR #$PR has zero non-author reviews. Likely cause: Codex hit its rate limit and left only a plain comment without filing a review entity. Either re-trigger Codex (commenting '@codex review' once the limit resets), or get a manual approval before tagging this release."
+          exit 1
 
   # ─────────────────────────────────────────────────────────────────────────
   # Tests - must pass BEFORE any build


### PR DESCRIPTION
## Summary

Adds a first-in-line `review-gate` job to `build_release.yml`. Before any test or build fires, resolves the PR that brought HEAD onto `stable` and asserts that PR carries at least one APPROVING review. Fails with a structured GitHub annotation otherwise.

## Why

Two days ago we landed PR #133 (smoke infra + Wayland-Native trial) onto `stable` without a code review — entirely on convenience. That's an unsafe pattern for a project shipping installers to end users. This PR closes the structural hole.

Three concrete failure modes this gate catches:

1. **Tag pushed against direct-push commit** — bypassing PR entirely.
2. **Codex hit rate limit** — Codex leaves a comment-without-review when its quota is exhausted, so a "Codex looked but didn't actually approve" PR still trips the gate. Forces explicit re-review or manual approval before tagging.
3. **Compromised maintainer account** — branch protection on `stable` (separate setup via `gh api`) catches the merge-side attempt; this gate catches the tag-side attempt. Two-layer.

## How

`gh pr list --search sha:$GITHUB_SHA` resolves the merging PR by the merge commit's SHA. `gh pr view --json reviews` counts `state == "APPROVED"`. Standard `GITHUB_TOKEN` permissions are sufficient.

## Test plan

- [x] YAML parses; job graph confirms `review-gate` is the new root, `test` `needs: review-gate`.
- [ ] Codex review on this PR (validates the gate catches its own un-reviewed condition — meta-test, intentional).
- [ ] After merge, branch protection + tag protection set via `gh api` to harden the merge-side.

## Related

- PR #133 — the precedent we want to never repeat unintentionally.
- `docs/dev/wayland-investigation.md` — existing trial work continuing in parallel; unaffected.