### PR TITLE
fix(appimage): propagate AURA_WAYLAND_TRIAL into AppRun

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -59,14 +59,28 @@ mkdir -p \
 # against StartupWMClass=AuraLauncher and pick up the hicolor icon at the
 # correct size. Mirrors client-ui/build.gradle.kts — the fat jar bypasses the
 # Compose-generated launcher script, so its jvmArgs do not flow through here.
-cat > "$APPDIR/AppRun" << 'EOF'
+#
+# Wayland-Native trial: when AURA_WAYLAND_TRIAL=1 is set in the build env,
+# bake `-Dawt.toolkit.name=WLToolkit` into the AppRun so the AppImage runtime
+# selects JBR's native Wayland toolkit instead of XToolkit/XWayland fallback.
+# The gradle-side `compose.desktop.application.jvmArgs` does NOT propagate
+# into AppImage builds (jpackage path is for Win/macOS distributables) — the
+# AppRun script is the only place where flags actually reach runtime.
+WAYLAND_TRIAL_FLAG=""
+if [ "${AURA_WAYLAND_TRIAL:-}" = "1" ]; then
+    WAYLAND_TRIAL_FLAG="-Dawt.toolkit.name=WLToolkit"
+    echo "AppRun: AURA_WAYLAND_TRIAL=1 — baking -Dawt.toolkit.name=WLToolkit"
+fi
+
+cat > "$APPDIR/AppRun" << EOF
 #!/bin/sh
-HERE="$(dirname "$(readlink -f "$0")")"
-exec "$HERE/usr/bin/java" \
-     -Dawt.appClassName=AuraLauncher \
-     --add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED \
-     -jar "$HERE/usr/lib/aura-launcher.jar" \
-     "$@"
+HERE="\$(dirname "\$(readlink -f "\$0")")"
+exec "\$HERE/usr/bin/java" \\
+     -Dawt.appClassName=AuraLauncher \\
+     --add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED \\
+     ${WAYLAND_TRIAL_FLAG} \\
+     -jar "\$HERE/usr/lib/aura-launcher.jar" \\
+     "\$@"
 EOF
 chmod +x "$APPDIR/AppRun"
 


### PR DESCRIPTION
## Summary

User reported the trial AppImage from #134 launched with XToolkit / XWayland fallback despite `AURA_WAYLAND_TRIAL=1` having been set in the build environment. Investigation found a real propagation gap.

## Root cause

`scripts/build-appimage.sh` writes its own AppRun shell script with hardcoded JVM args (`-Dawt.appClassName=AuraLauncher`, `--add-opens=...`). Compose Desktop's `application.jvmArgs` block in `client-ui/build.gradle.kts` is consumed only by the `jpackage` path (Windows EXE, macOS DMG); the AppImage path goes through `packageReleaseUberJarForCurrentOS` + this script and ignores everything else.

## Fix

`AURA_WAYLAND_TRIAL=1` in the build env now causes `build-appimage.sh` to inject `-Dawt.toolkit.name=WLToolkit` into the generated AppRun. Heredoc switched from no-expand (single-quoted EOF) to expand (unquoted EOF) so the variable interpolates; `\$` escapes preserved for shell-side variables.

## Side finding (NOT fixed here)

Only 2 of ~17 carefully-curated jvmArgs in `client-ui/build.gradle.kts` reach AppImage runtime. `-Djna.nosys=true`, heap settings, GC tuning, `--enable-native-access=ALL-UNNAMED`, etc. all silently drop. Followup task #75 tracks the broader audit.

## Test plan

- [x] `bash -n scripts/build-appimage.sh` — syntax OK
- [x] Inline simulation confirms AppRun would interpolate `-Dawt.toolkit.name=WLToolkit` when env set
- [ ] Re-trigger `trial-appimage.yml` after merge, user re-tests on Hyprland