### PR TITLE
feat(vault): wire keyring into CredentialsManager with file fallback

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/CredentialsManager.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/CredentialsManager.kt
@@ -1,6 +1,7 @@
 package hivens.launcher
 
 import hivens.core.data.SessionData
+import hivens.core.security.IKeyringStorage
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
@@ -16,17 +17,39 @@ import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.SecretKeySpec
 
 /**
- * Secure credential storage.
+ * Secure credential storage with OS-keyring primary + AES-256-GCM file
+ * fallback.
  *
- * Replaces Base64 "protection" with AES-256-GCM encryption.
- * The key is derived from a machine-specific seed (MAC + username + OS)
- * via PBKDF2. Not OS Keyring, but significantly better than plaintext/Base64.
+ * Storage hierarchy (most-to-least preferred):
  *
- * Migration: reads old Base64 format transparently, re-saves encrypted.
+ *  1. **OS keyring** (libsecret on Linux, follow-ups for Win/Mac).
+ *     The plaintext password lives here when [IKeyringStorage.isAvailable]
+ *     and `store()` succeed. The credentials JSON file then carries
+ *     `keyringHasPassword=true` and a null `encryptedPassword` field —
+ *     keyring is the sole source of the secret.
+ *
+ *  2. **AES-256-GCM file** (`credentials.json`). Activated when keyring
+ *     is unreachable (no daemon, no library, no permission). Encryption
+ *     key is derived from a machine-specific seed via PBKDF2 — the
+ *     classic "casual file-copy" defense, not real protection.
+ *
+ *  3. **Legacy v1 Base64** — read-only path, migrated to v3 on the next
+ *     successful save.
+ *
+ * The credentials file ALWAYS exists when there's a session; it's the
+ * source of truth for username / uuid / uid / accessToken and the
+ * "which storage mode is active" flag. Only the password ciphertext
+ * moves between locations based on keyring availability.
+ *
+ * NOT YET in scope (tracked as Vault #1.F): `accessToken` is still
+ * stored plaintext in the file. It's derived from the game-token
+ * decryption flow and equally sensitive as the password — should also
+ * live in the keyring. Separate PR.
  */
 class CredentialsManager(
     workDir: Path,
-    private val json: Json
+    private val json: Json,
+    private val keyring: IKeyringStorage,
 ) {
     private val log = LoggerFactory.getLogger(CredentialsManager::class.java)
     private val credentialsFile = workDir.resolve("credentials.json")
@@ -37,47 +60,89 @@ class CredentialsManager(
         private const val GCM_TAG_LENGTH = 128
         private const val PBKDF2_ITERATIONS = 65536
         private const val SALT = "AuraLauncher_v2_salt" // Static salt component
+
+        // Keyring identity. SERVICE is the launcher-wide brand scope;
+        // ACCOUNT_PASSWORD is the per-secret name inside that scope.
+        // Multi-account support (currently SmartyCraft is single-account
+        // per launcher install) would extend this with the username.
+        private const val KEYRING_SERVICE = "io.github.kitty_hivens.AuraLauncher"
+        private const val KEYRING_ACCOUNT_PASSWORD = "password"
     }
 
     @Serializable
     private data class SavedCredentials(
         val username: String,
+        // TODO Vault #1.F — accessToken should live in the keyring or be
+        // encrypted. Currently plaintext on disk.
         val accessToken: String,
         val uuid: String,
         val uid: String? = null,
-        /** Encrypted password (AES-256-GCM, Base64-encoded ciphertext) */
+        /**
+         * True when the password lives in the OS keyring under
+         * (KEYRING_SERVICE, KEYRING_ACCOUNT_PASSWORD). When true,
+         * [encryptedPassword] and [passwordIv] are null.
+         */
+        val keyringHasPassword: Boolean = false,
+        /** Encrypted password (AES-256-GCM, Base64-encoded ciphertext). */
         val encryptedPassword: String? = null,
-        /** IV for AES-GCM decryption (Base64-encoded) */
+        /** IV for AES-GCM decryption (Base64-encoded). */
         val passwordIv: String? = null,
         /** @deprecated Legacy Base64-encoded password — read-only for migration */
         val savedPasswordBase64: String? = null,
-        /** Format version: 1 = Base64 (legacy), 2 = AES-GCM */
-        val version: Int = 2
+        /** Format version: 1 = Base64 (legacy), 2 = AES-GCM, 3 = keyring-or-AES-GCM */
+        val version: Int = 3
     )
 
     fun save(session: SessionData) {
-        // We save only if the user requested or the session is valid
+        // Skip when there's nothing real to save — accessToken is the
+        // canary for "auth actually completed" since blank means we
+        // never got a session back.
         if (session.accessToken.isBlank()) return
 
         try {
-            val (encrypted, iv) = encryptPassword(session.cachedPassword)
+            // Try keyring first. On success, file omits the ciphertext
+            // (sole-source semantics). On failure, fall through to
+            // AES-GCM file path so the user doesn't get logged out by
+            // a transient daemon outage.
+            val storedInKeyring = session.cachedPassword?.let { pw ->
+                keyring.store(KEYRING_SERVICE, KEYRING_ACCOUNT_PASSWORD, pw)
+            } ?: false
 
-            val data = SavedCredentials(
-                username = session.playerName,
-                accessToken = session.accessToken,
-                uuid = session.uuid,
-                uid = session.uid,
-                encryptedPassword = encrypted,
-                passwordIv = iv,
-                savedPasswordBase64 = null, // No longer store legacy format
-                version = 2
-            )
+            val data = if (storedInKeyring) {
+                SavedCredentials(
+                    username = session.playerName,
+                    accessToken = session.accessToken,
+                    uuid = session.uuid,
+                    uid = session.uid,
+                    keyringHasPassword = true,
+                    encryptedPassword = null,
+                    passwordIv = null,
+                    savedPasswordBase64 = null,
+                    version = 3,
+                )
+            } else {
+                val (encrypted, iv) = encryptPassword(session.cachedPassword)
+                SavedCredentials(
+                    username = session.playerName,
+                    accessToken = session.accessToken,
+                    uuid = session.uuid,
+                    uid = session.uid,
+                    keyringHasPassword = false,
+                    encryptedPassword = encrypted,
+                    passwordIv = iv,
+                    savedPasswordBase64 = null,
+                    version = 3,
+                )
+            }
 
             if (credentialsFile.parent != null) Files.createDirectories(credentialsFile.parent)
 
             val text = json.encodeToString(data)
             Files.writeString(credentialsFile, text)
-            log.info("Credentials saved (AES-256-GCM encrypted)")
+            log.info(
+                "Credentials saved (password storage: {})",
+                if (storedInKeyring) "keyring" else "AES-256-GCM file",
+            )
 
         } catch (e: Exception) {
             log.error("Could not save credentials", e)
@@ -92,27 +157,49 @@ class CredentialsManager(
             val data = json.decodeFromString<SavedCredentials>(text)
 
             val password = when {
-                // v2: AES-GCM encrypted
-                data.version >= 2 && data.encryptedPassword != null && data.passwordIv != null -> {
+                // v3 keyring-mode: password lives in the OS keyring.
+                data.keyringHasPassword -> {
+                    keyring.retrieve(KEYRING_SERVICE, KEYRING_ACCOUNT_PASSWORD).also {
+                        if (it == null) {
+                            // File says keyring should have it, but the keyring
+                            // doesn't — daemon was wiped, user logged out of
+                            // their session keyring, or the entry was manually
+                            // removed. The session is effectively gone; load
+                            // returns the metadata but cachedPassword=null.
+                            // The launcher's relogin path triggers when the
+                            // user clicks Play and we discover the missing
+                            // password.
+                            log.warn(
+                                "credentials file marks keyring-resident password, " +
+                                    "but keyring lookup returned null — re-login required",
+                            )
+                        }
+                    }
+                }
+
+                // v3/v2 file-mode: AES-GCM ciphertext on disk.
+                data.encryptedPassword != null && data.passwordIv != null -> {
                     decryptPassword(data.encryptedPassword, data.passwordIv)
                 }
-                // v1 (legacy): Base64 — migrate on next save
+
+                // v1 legacy: Base64 — implicit migration on next save.
                 data.savedPasswordBase64 != null -> {
-                    log.info("Migrating credentials from Base64 to AES-GCM")
+                    log.info("Migrating credentials from v1 Base64 to v3 keyring-or-AES")
                     String(Base64.getDecoder().decode(data.savedPasswordBase64))
                 }
+
                 else -> null
             }
 
-            // Restoring SessionData.
-            // The remaining fields (manifest, balance) will be updated when the profile is updated.
+            // Restoring SessionData. The remaining fields (manifest, balance)
+            // get refreshed when the dashboard request fires.
             SessionData(
                 playerName = data.username,
                 accessToken = data.accessToken,
                 uuid = data.uuid,
                 uid = data.uid ?: "",
                 cachedPassword = password,
-                status = null
+                status = null,
             )
         } catch (e: Exception) {
             log.error("Error reading credentials.json file", e)
@@ -121,6 +208,11 @@ class CredentialsManager(
     }
 
     fun clear() {
+        // Wipe both the keyring entry and the file unconditionally. Either
+        // could be the source of the active password depending on mode;
+        // catching just one would leave a stale credential in the other.
+        runCatching { keyring.clear(KEYRING_SERVICE, KEYRING_ACCOUNT_PASSWORD) }
+            .onFailure { log.warn("Failed to clear keyring entry", it) }
         try {
             Files.deleteIfExists(credentialsFile)
         } catch (e: IOException) {
@@ -162,10 +254,12 @@ class CredentialsManager(
     }
 
     /**
-     * Derives a machine-specific AES key via PBKDF2.
-     * The seed combines OS username, user.home, and os.name —
-     * different machines / users will have different keys.
+     * Derives a machine-specific AES key via PBKDF2 for the file-fallback
+     * encryption path. The seed combines OS username, user.home, and
+     * os.name — different machines / users will have different keys.
      * Not perfect (no TPM/Keyring), but prevents casual file-copy attacks.
+     * Only used when the keyring path is unavailable; the keyring is the
+     * preferred storage when it works.
      */
     private fun deriveKey(): SecretKeySpec {
         val machineSeed = buildString {

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -174,7 +174,16 @@ val appModule = module {
     single<java.nio.file.Path>(createdAtStart = true) { get<PlatformPaths>().dataDir }
 
     // Managers and services
-    single { CredentialsManager(get(), get()) }
+    //
+    // IKeyringStorage chosen at startup via KeyringStorageFactory.system()
+    // — Linux libsecret on this platform, NoOp fallback elsewhere or when
+    // the daemon is unreachable. CredentialsManager handles the file-fallback
+    // path internally when keyring.store() returns false, so this single
+    // line wires both the happy path and the degraded path.
+    single<hivens.core.security.IKeyringStorage> {
+        hivens.launcher.security.KeyringStorageFactory.system()
+    }
+    single { CredentialsManager(get(), get(), get()) }
 
     single<ISettingsService> {
         val dataDir: java.nio.file.Path = get()

--- a/client-launcher/src/test/kotlin/hivens/launcher/CredentialsManagerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/CredentialsManagerTest.kt
@@ -1,0 +1,252 @@
+package hivens.launcher
+
+import hivens.core.data.SessionData
+import hivens.core.security.IKeyringStorage
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Base64
+import kotlin.io.path.div
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests the keyring-primary + file-fallback refactor.
+ *
+ * Uses an in-memory [FakeKeyring] instead of a mock so the test reads
+ * like a state-machine: store/retrieve/clear operations behave like a
+ * real keyring would, but with explicit toggles for "daemon went away"
+ * scenarios. Simpler than mockk for this many cases.
+ */
+class CredentialsManagerTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true; encodeDefaults = true }
+    private lateinit var workDir: Path
+    private lateinit var keyring: FakeKeyring
+    private lateinit var manager: CredentialsManager
+
+    @BeforeTest
+    fun setup() {
+        workDir = Files.createTempDirectory("aura-creds-test-")
+        keyring = FakeKeyring()
+        manager = CredentialsManager(workDir, json, keyring)
+    }
+
+    @AfterTest
+    fun teardown() {
+        Files.walk(workDir).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+    }
+
+    private fun session(password: String? = "secret-pw") = SessionData(
+        playerName = "ChaosA",
+        accessToken = "fake-game-token",
+        uuid = "550e8400e29b41d4a716446655440000",
+        uid = "1",
+        cachedPassword = password,
+        status = null,
+    )
+
+    private fun fileJson(): JsonObject {
+        val text = Files.readString(workDir / "credentials.json")
+        return json.parseToJsonElement(text).jsonObject
+    }
+
+    // ── save() ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `save with keyring available — password lands in keyring, file holds flag`() {
+        manager.save(session())
+
+        // Keyring got the secret. Service/account match the constants in
+        // CredentialsManager — if those rename, this test must too (which
+        // is the point: pin the wire format).
+        assertEquals("secret-pw", keyring.entries["io.github.kitty_hivens.AuraLauncher::password"])
+        // File records the flag, no ciphertext.
+        val obj = fileJson()
+        assertEquals(true, obj["keyringHasPassword"]?.jsonPrimitive?.boolean)
+        assertNull(obj["encryptedPassword"]?.jsonPrimitive?.contentOrNull)
+        assertNull(obj["passwordIv"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(3, obj["version"]?.jsonPrimitive?.contentOrNull?.toInt())
+    }
+
+    @Test
+    fun `save with keyring failing — falls back to AES-GCM file path`() {
+        keyring.failStore = true
+        manager.save(session())
+
+        // Nothing in keyring (it refused).
+        assertTrue(keyring.entries.isEmpty())
+        // File has the ciphertext + iv, flag is false.
+        val obj = fileJson()
+        assertEquals(false, obj["keyringHasPassword"]?.jsonPrimitive?.boolean)
+        assertNotNull(obj["encryptedPassword"]?.jsonPrimitive?.contentOrNull)
+        assertNotNull(obj["passwordIv"]?.jsonPrimitive?.contentOrNull)
+    }
+
+    @Test
+    fun `save with blank accessToken — no-op, no file written`() {
+        val noToken = session().copy(accessToken = "")
+        manager.save(noToken)
+        assertFalse(Files.exists(workDir / "credentials.json"))
+        assertTrue(keyring.entries.isEmpty())
+    }
+
+    @Test
+    fun `save with null cachedPassword — keyring not touched, file path used`() {
+        // SessionData allows null cachedPassword (e.g. user logged in via cached token).
+        // Should not invoke keyring.store(null) — would be a contract violation.
+        manager.save(session(password = null))
+        assertTrue(keyring.entries.isEmpty(), "keyring must not store null password")
+        // File still gets written for the metadata; encryptedPassword is null too.
+        val obj = fileJson()
+        assertEquals(false, obj["keyringHasPassword"]?.jsonPrimitive?.boolean)
+        assertNull(obj["encryptedPassword"]?.jsonPrimitive?.contentOrNull)
+    }
+
+    // ── load() ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `load v3 keyring-mode — pulls password from keyring`() {
+        manager.save(session())
+        // Re-create manager to simulate process restart.
+        val freshManager = CredentialsManager(workDir, json, keyring)
+        val loaded = freshManager.load()
+
+        assertNotNull(loaded)
+        assertEquals("ChaosA", loaded.playerName)
+        assertEquals("secret-pw", loaded.cachedPassword)
+        assertEquals("fake-game-token", loaded.accessToken)
+    }
+
+    @Test
+    fun `load v3 keyring-mode but keyring lookup returns null — session loads with null password`() {
+        manager.save(session())
+        // Wipe the keyring entry as if the daemon was reset between sessions.
+        keyring.entries.clear()
+        val freshManager = CredentialsManager(workDir, json, keyring)
+        val loaded = freshManager.load()
+
+        assertNotNull(loaded, "metadata must survive keyring wipe — only the password is gone")
+        assertEquals("ChaosA", loaded.playerName)
+        assertNull(loaded.cachedPassword, "password is gone — re-login required")
+    }
+
+    @Test
+    fun `load v3 file-mode — pulls password from AES-GCM file`() {
+        keyring.failStore = true
+        manager.save(session())
+        // Restart with same keyring (still failing) to confirm file path round-trip.
+        val freshManager = CredentialsManager(workDir, json, keyring)
+        val loaded = freshManager.load()
+
+        assertNotNull(loaded)
+        assertEquals("secret-pw", loaded.cachedPassword)
+    }
+
+    @Test
+    fun `load v1 legacy Base64 — migrates on read, returns valid session`() {
+        // Hand-craft a v1-format file as it would have existed before AES-GCM.
+        val legacyFile = workDir / "credentials.json"
+        val legacyB64 = Base64.getEncoder().encodeToString("legacy-pw".toByteArray())
+        val legacyText = """
+            {
+                "username": "OldUser",
+                "accessToken": "old-token",
+                "uuid": "00000000000000000000000000000000",
+                "uid": "42",
+                "savedPasswordBase64": "$legacyB64",
+                "version": 1
+            }
+        """.trimIndent()
+        Files.writeString(legacyFile, legacyText)
+
+        val loaded = manager.load()
+        assertNotNull(loaded)
+        assertEquals("OldUser", loaded.playerName)
+        assertEquals("legacy-pw", loaded.cachedPassword)
+    }
+
+    @Test
+    fun `load with no file — returns null`() {
+        // Fresh state, no save() was called.
+        assertNull(manager.load())
+    }
+
+    @Test
+    fun `load with malformed file — returns null instead of throwing`() {
+        Files.writeString(workDir / "credentials.json", "not valid json {{{")
+        assertNull(manager.load(), "load should swallow parse errors and return null")
+    }
+
+    // ── clear() ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `clear wipes keyring AND file — both must be gone`() {
+        manager.save(session())
+        assertTrue(Files.exists(workDir / "credentials.json"))
+        assertTrue(keyring.entries.isNotEmpty())
+
+        manager.clear()
+
+        assertFalse(Files.exists(workDir / "credentials.json"), "file must be deleted")
+        assertTrue(keyring.entries.isEmpty(), "keyring entry must be cleared")
+    }
+
+    @Test
+    fun `clear is idempotent — calling twice does not throw`() {
+        manager.save(session())
+        manager.clear()
+        manager.clear() // second call against empty state
+        assertFalse(Files.exists(workDir / "credentials.json"))
+    }
+
+    @Test
+    fun `clear when only file path is in use — still wipes both sides`() {
+        keyring.failStore = true
+        manager.save(session())
+        manager.clear()
+
+        assertFalse(Files.exists(workDir / "credentials.json"))
+        assertTrue(keyring.entries.isEmpty())
+    }
+
+    // ── In-memory keyring fake ────────────────────────────────────────────
+
+    /**
+     * Simple in-memory IKeyringStorage that tracks entries by
+     * "service::account" key. `failStore` toggle simulates a
+     * keyring daemon that's reachable (isAvailable=true) but
+     * refuses writes — covers the "user revoked permission" case.
+     */
+    private class FakeKeyring : IKeyringStorage {
+        val entries: MutableMap<String, String> = mutableMapOf()
+        var failStore: Boolean = false
+
+        private fun key(service: String, account: String) = "$service::$account"
+
+        override fun isAvailable(): Boolean = true
+
+        override fun store(service: String, account: String, secret: String): Boolean {
+            if (failStore) return false
+            entries[key(service, account)] = secret
+            return true
+        }
+
+        override fun retrieve(service: String, account: String): String? =
+            entries[key(service, account)]
+
+        override fun clear(service: String, account: String): Boolean =
+            entries.remove(key(service, account)) != null
+    }
+}


### PR DESCRIPTION
## Summary

Vault sub-chunks #1.C + #1.D. Replaces the PBKDF2(machine-properties) + AES-256-GCM-only credential storage with a keyring-primary, file-fallback chain. Builds on the IKeyringStorage scaffold from #138.

## Storage hierarchy

| Tier | Active when | What's on disk |
|---|---|---|
| **OS keyring** | `IKeyringStorage.isAvailable()` AND `store()` returns true | `keyringHasPassword=true`, no ciphertext |
| **AES-GCM file (v3)** | Keyring unreachable / refused | `encryptedPassword` + `passwordIv` (existing impl) |
| **Legacy v1 Base64** | Read-only — migrated to v3 on next save | (n/a) |

The credentials JSON file always exists when there's a session and stays the source of truth for `username` / `uuid` / `uid` / `accessToken` / "which password store is active". Only the password ciphertext moves between locations based on keyring availability.

## DI wiring (#1.D bundled in)

`KeyringStorageFactory.system()` resolves once at startup. `LinuxLibsecretKeyringStorage` on Linux today; `NoOpKeyringStorage` (always-fail) on Windows + macOS until those platform impls land. `NoOp.store()` returning false transparently triggers the file fallback — no Windows/macOS user is broken by this PR.

## Test coverage — 13 cases

- Keyring success path: file holds flag, keyring holds secret
- Keyring failure path: file holds AES-GCM ciphertext (degraded mode)
- Process restart with keyring wiped between save and load: session loads with `cachedPassword=null`, WARN logged, re-login required
- v1 legacy Base64 migration on read
- `clear()` wipes both sides regardless of which mode was active
- Edge cases: blank accessToken (no-op), null cachedPassword (file path, no keyring write), malformed file (returns null, doesn't throw)

In-memory `FakeKeyring` with a `failStore` toggle covers all cases without mockk overhead.

## Discovered during this work — separate followup

`SavedCredentials.accessToken` is still stored **plaintext** in `credentials.json`. accessToken is the derived game-token that authenticates Minecraft launches as the user — equally sensitive as the password. Should also live in the keyring (or be encrypted alongside the password). Tracked as Vault sub-chunk #1.F, separate PR.

## Test plan

- [x] `:client-launcher:test` — green (full suite, 13 new + existing all pass)
- [x] `:client-core:test` — green
- [ ] Live Hyprland end-to-end (#1.E): launch Aura, login, verify with `secret-tool search service io.github.kitty_hivens.AuraLauncher` that the password is in gnome-keyring. Logout, verify it's gone.
- [ ] Qodana on PR (Codex still on cooldown until 21st)

## After merge

- #1.E live test on Hyprland
- #1.F encrypt accessToken too (separate PR)
- Vault #2 — scope-restricted SSL bypass (per-host + expiry)
- Windows + macOS keyring platform impls (separate PRs each)