### PR TITLE
feat(vault): encrypt accessToken too via keyring + file fallback (v4)

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/CredentialsManager.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/CredentialsManager.kt
@@ -18,33 +18,40 @@ import javax.crypto.spec.SecretKeySpec
 
 /**
  * Secure credential storage with OS-keyring primary + AES-256-GCM file
- * fallback.
+ * fallback. Two independent sensitive fields — password and accessToken —
+ * are each handled through the same per-secret chain.
  *
- * Storage hierarchy (most-to-least preferred):
+ * Per-secret storage hierarchy (most-to-least preferred):
  *
  *  1. **OS keyring** (libsecret on Linux, follow-ups for Win/Mac).
- *     The plaintext password lives here when [IKeyringStorage.isAvailable]
- *     and `store()` succeed. The credentials JSON file then carries
- *     `keyringHasPassword=true` and a null `encryptedPassword` field —
- *     keyring is the sole source of the secret.
+ *     The plaintext lives here when [IKeyringStorage.isAvailable] and
+ *     `store()` succeed. The credentials JSON file then carries
+ *     `keyringHasX=true` and a null `encryptedX` field — keyring is
+ *     the sole source of the secret.
  *
  *  2. **AES-256-GCM file** (`credentials.json`). Activated when keyring
  *     is unreachable (no daemon, no library, no permission). Encryption
  *     key is derived from a machine-specific seed via PBKDF2 — the
  *     classic "casual file-copy" defense, not real protection.
  *
- *  3. **Legacy v1 Base64** — read-only path, migrated to v3 on the next
- *     successful save.
+ *  3. **Legacy plaintext** — read-only path for older format files,
+ *     migrated to v4 on the next successful save. Two legacy entries
+ *     supported: v1 `savedPasswordBase64`, and v3 plaintext `accessToken`.
  *
- * The credentials file ALWAYS exists when there's a session; it's the
- * source of truth for username / uuid / uid / accessToken and the
- * "which storage mode is active" flag. Only the password ciphertext
- * moves between locations based on keyring availability.
+ * The credentials file ALWAYS exists when there's a session and stays
+ * the source of truth for `username` / `uuid` / `uid` and the
+ * "which storage mode is active" flags. Only the secret ciphertexts move
+ * between locations based on keyring availability — per-secret, so a
+ * keyring outage for one doesn't necessarily force the other into the
+ * file (though in practice both succeed or fail together with the same
+ * daemon).
  *
- * NOT YET in scope (tracked as Vault #1.F): `accessToken` is still
- * stored plaintext in the file. It's derived from the game-token
- * decryption flow and equally sensitive as the password — should also
- * live in the keyring. Separate PR.
+ * Load behaviour: a session whose accessToken cannot be resolved
+ * (keyring entry wiped, decryption failed, no legacy fallback) returns
+ * null from [load], cleanly triggering the re-login path. A session whose
+ * password is missing but accessToken survived returns a SessionData with
+ * `cachedPassword=null` — the user can still play; re-login is requested
+ * the next time the password is actually needed.
  */
 class CredentialsManager(
     workDir: Path,
@@ -62,21 +69,23 @@ class CredentialsManager(
         private const val SALT = "AuraLauncher_v2_salt" // Static salt component
 
         // Keyring identity. SERVICE is the launcher-wide brand scope;
-        // ACCOUNT_PASSWORD is the per-secret name inside that scope.
+        // ACCOUNT_* is the per-secret name inside that scope. Each
+        // sensitive credential gets its own account so they're
+        // independently retrievable, rotatable, and clearable.
         // Multi-account support (currently SmartyCraft is single-account
         // per launcher install) would extend this with the username.
         private const val KEYRING_SERVICE = "io.github.kitty_hivens.AuraLauncher"
         private const val KEYRING_ACCOUNT_PASSWORD = "password"
+        private const val KEYRING_ACCOUNT_ACCESS_TOKEN = "accessToken"
     }
 
     @Serializable
     private data class SavedCredentials(
         val username: String,
-        // TODO Vault #1.F — accessToken should live in the keyring or be
-        // encrypted. Currently plaintext on disk.
-        val accessToken: String,
         val uuid: String,
         val uid: String? = null,
+
+        // ── Password storage (added in v3) ───────────────────────────────
         /**
          * True when the password lives in the OS keyring under
          * (KEYRING_SERVICE, KEYRING_ACCOUNT_PASSWORD). When true,
@@ -87,10 +96,31 @@ class CredentialsManager(
         val encryptedPassword: String? = null,
         /** IV for AES-GCM decryption (Base64-encoded). */
         val passwordIv: String? = null,
+
+        // ── Access-token storage (added in v4) ───────────────────────────
+        /**
+         * True when the accessToken lives in the OS keyring under
+         * (KEYRING_SERVICE, KEYRING_ACCOUNT_ACCESS_TOKEN). When true,
+         * [encryptedAccessToken] and [accessTokenIv] are null.
+         */
+        val keyringHasAccessToken: Boolean = false,
+        /** Encrypted accessToken (AES-256-GCM, Base64-encoded ciphertext). */
+        val encryptedAccessToken: String? = null,
+        /** IV for AES-GCM decryption of [encryptedAccessToken] (Base64-encoded). */
+        val accessTokenIv: String? = null,
+
+        /**
+         * @deprecated Legacy plaintext accessToken from v3 and earlier.
+         * Read-only — populated only when loading older files. Always
+         * null in v4+ writes; the next save() migrates the value into
+         * either the keyring or [encryptedAccessToken].
+         */
+        val accessToken: String? = null,
         /** @deprecated Legacy Base64-encoded password — read-only for migration */
         val savedPasswordBase64: String? = null,
-        /** Format version: 1 = Base64 (legacy), 2 = AES-GCM, 3 = keyring-or-AES-GCM */
-        val version: Int = 3
+
+        /** Format version: 1 = Base64 password, 2 = AES-GCM password, 3 = keyring-or-AES-GCM password + plaintext accessToken, 4 = keyring-or-AES-GCM for both */
+        val version: Int = 4
     )
 
     fun save(session: SessionData) {
@@ -100,48 +130,47 @@ class CredentialsManager(
         if (session.accessToken.isBlank()) return
 
         try {
-            // Try keyring first. On success, file omits the ciphertext
-            // (sole-source semantics). On failure, fall through to
-            // AES-GCM file path so the user doesn't get logged out by
-            // a transient daemon outage.
-            val storedInKeyring = session.cachedPassword?.let { pw ->
+            // Each secret tries keyring first; on failure falls back to
+            // AES-GCM file. Independent per-secret so a transient
+            // keyring failure for one doesn't force both into the file.
+            // (Practically speaking they tend to succeed or fail
+            // together — same daemon — but the modeling is cleaner.)
+            val passwordInKeyring = session.cachedPassword?.let { pw ->
                 keyring.store(KEYRING_SERVICE, KEYRING_ACCOUNT_PASSWORD, pw)
             } ?: false
 
-            val data = if (storedInKeyring) {
-                SavedCredentials(
-                    username = session.playerName,
-                    accessToken = session.accessToken,
-                    uuid = session.uuid,
-                    uid = session.uid,
-                    keyringHasPassword = true,
-                    encryptedPassword = null,
-                    passwordIv = null,
-                    savedPasswordBase64 = null,
-                    version = 3,
-                )
-            } else {
-                val (encrypted, iv) = encryptPassword(session.cachedPassword)
-                SavedCredentials(
-                    username = session.playerName,
-                    accessToken = session.accessToken,
-                    uuid = session.uuid,
-                    uid = session.uid,
-                    keyringHasPassword = false,
-                    encryptedPassword = encrypted,
-                    passwordIv = iv,
-                    savedPasswordBase64 = null,
-                    version = 3,
-                )
-            }
+            val accessTokenInKeyring = keyring.store(
+                KEYRING_SERVICE, KEYRING_ACCOUNT_ACCESS_TOKEN, session.accessToken,
+            )
+
+            val (passwordCipher, passwordIv) = if (passwordInKeyring) null to null
+                else encryptString(session.cachedPassword)
+            val (accessTokenCipher, accessTokenIv) = if (accessTokenInKeyring) null to null
+                else encryptString(session.accessToken)
+
+            val data = SavedCredentials(
+                username = session.playerName,
+                uuid = session.uuid,
+                uid = session.uid,
+                keyringHasPassword = passwordInKeyring,
+                encryptedPassword = passwordCipher,
+                passwordIv = passwordIv,
+                keyringHasAccessToken = accessTokenInKeyring,
+                encryptedAccessToken = accessTokenCipher,
+                accessTokenIv = accessTokenIv,
+                accessToken = null,           // never written in v4+ (legacy field only for reads)
+                savedPasswordBase64 = null,   // ditto
+                version = 4,
+            )
 
             if (credentialsFile.parent != null) Files.createDirectories(credentialsFile.parent)
 
             val text = json.encodeToString(data)
             Files.writeString(credentialsFile, text)
             log.info(
-                "Credentials saved (password storage: {})",
-                if (storedInKeyring) "keyring" else "AES-256-GCM file",
+                "Credentials saved (password: {}, accessToken: {})",
+                if (passwordInKeyring) "keyring" else "AES-256-GCM file",
+                if (accessTokenInKeyring) "keyring" else "AES-256-GCM file",
             )
 
         } catch (e: Exception) {
@@ -156,46 +185,25 @@ class CredentialsManager(
             val text = Files.readString(credentialsFile)
             val data = json.decodeFromString<SavedCredentials>(text)
 
-            val password = when {
-                // v3 keyring-mode: password lives in the OS keyring.
-                data.keyringHasPassword -> {
-                    keyring.retrieve(KEYRING_SERVICE, KEYRING_ACCOUNT_PASSWORD).also {
-                        if (it == null) {
-                            // File says keyring should have it, but the keyring
-                            // doesn't — daemon was wiped, user logged out of
-                            // their session keyring, or the entry was manually
-                            // removed. The session is effectively gone; load
-                            // returns the metadata but cachedPassword=null.
-                            // The launcher's relogin path triggers when the
-                            // user clicks Play and we discover the missing
-                            // password.
-                            log.warn(
-                                "credentials file marks keyring-resident password, " +
-                                    "but keyring lookup returned null — re-login required",
-                            )
-                        }
-                    }
-                }
+            val password = resolvePassword(data)
+            val accessToken = resolveAccessToken(data)
 
-                // v3/v2 file-mode: AES-GCM ciphertext on disk.
-                data.encryptedPassword != null && data.passwordIv != null -> {
-                    decryptPassword(data.encryptedPassword, data.passwordIv)
-                }
-
-                // v1 legacy: Base64 — implicit migration on next save.
-                data.savedPasswordBase64 != null -> {
-                    log.info("Migrating credentials from v1 Base64 to v3 keyring-or-AES")
-                    String(Base64.getDecoder().decode(data.savedPasswordBase64))
-                }
-
-                else -> null
+            // accessToken is load-blocking — without it the launcher cannot
+            // launch the game, so a missing/decryption-failed accessToken
+            // means the session is effectively gone and the user must
+            // re-login. Returning null here cleanly triggers that path in
+            // the calling controller.
+            if (accessToken.isNullOrBlank()) {
+                log.warn(
+                    "credentials present but accessToken could not be resolved " +
+                        "(keyring entry wiped? AES decryption failed?) — treating session as gone",
+                )
+                return null
             }
 
-            // Restoring SessionData. The remaining fields (manifest, balance)
-            // get refreshed when the dashboard request fires.
             SessionData(
                 playerName = data.username,
-                accessToken = data.accessToken,
+                accessToken = accessToken,
                 uuid = data.uuid,
                 uid = data.uid ?: "",
                 cachedPassword = password,
@@ -207,12 +215,65 @@ class CredentialsManager(
         }
     }
 
+    private fun resolvePassword(data: SavedCredentials): String? = when {
+        // v3+ keyring-mode: password lives in the OS keyring.
+        data.keyringHasPassword -> keyring.retrieve(KEYRING_SERVICE, KEYRING_ACCOUNT_PASSWORD).also {
+            if (it == null) {
+                log.warn(
+                    "credentials file marks keyring-resident password, " +
+                        "but keyring lookup returned null — re-login may be required",
+                )
+            }
+        }
+
+        // v3+/v2 file-mode: AES-GCM ciphertext on disk.
+        data.encryptedPassword != null && data.passwordIv != null ->
+            decryptString(data.encryptedPassword, data.passwordIv)
+
+        // v1 legacy: Base64 — implicit migration on next save.
+        data.savedPasswordBase64 != null -> {
+            log.info("Migrating password from v1 Base64 to keyring-or-AES")
+            String(Base64.getDecoder().decode(data.savedPasswordBase64))
+        }
+
+        else -> null
+    }
+
+    private fun resolveAccessToken(data: SavedCredentials): String? = when {
+        // v4 keyring-mode.
+        data.keyringHasAccessToken -> keyring.retrieve(KEYRING_SERVICE, KEYRING_ACCOUNT_ACCESS_TOKEN).also {
+            if (it == null) {
+                log.warn(
+                    "credentials file marks keyring-resident accessToken, " +
+                        "but keyring lookup returned null",
+                )
+            }
+        }
+
+        // v4 file-mode: AES-GCM ciphertext on disk.
+        data.encryptedAccessToken != null && data.accessTokenIv != null ->
+            decryptString(data.encryptedAccessToken, data.accessTokenIv)
+
+        // v3 and earlier: plaintext accessToken. Reads transparently;
+        // on the next save() it gets migrated into the keyring or
+        // encrypted in the file.
+        data.accessToken != null -> {
+            log.info("Migrating accessToken from legacy plaintext to keyring-or-AES on next save")
+            data.accessToken
+        }
+
+        else -> null
+    }
+
     fun clear() {
-        // Wipe both the keyring entry and the file unconditionally. Either
-        // could be the source of the active password depending on mode;
-        // catching just one would leave a stale credential in the other.
+        // Wipe both keyring entries and the file unconditionally. Each
+        // entry could independently be the source of an active credential
+        // depending on its mode; missing one would leave stale secrets in
+        // either the keyring or the file.
         runCatching { keyring.clear(KEYRING_SERVICE, KEYRING_ACCOUNT_PASSWORD) }
-            .onFailure { log.warn("Failed to clear keyring entry", it) }
+            .onFailure { log.warn("Failed to clear keyring password entry", it) }
+        runCatching { keyring.clear(KEYRING_SERVICE, KEYRING_ACCOUNT_ACCESS_TOKEN) }
+            .onFailure { log.warn("Failed to clear keyring accessToken entry", it) }
         try {
             Files.deleteIfExists(credentialsFile)
         } catch (e: IOException) {
@@ -221,9 +282,14 @@ class CredentialsManager(
     }
 
     // ── AES-256-GCM Encryption ─────────────────────────────────────────────
+    //
+    // Generic encrypt/decrypt helpers used by both the password and the
+    // accessToken file-fallback paths. Each call generates a fresh IV so
+    // two values encrypted with the same machine-derived key remain
+    // distinguishable on disk.
 
-    private fun encryptPassword(password: String?): Pair<String?, String?> {
-        if (password == null) return null to null
+    private fun encryptString(plaintext: String?): Pair<String?, String?> {
+        if (plaintext == null) return null to null
 
         val key = deriveKey()
         val iv = ByteArray(GCM_IV_LENGTH).also { SecureRandom().nextBytes(it) }
@@ -231,13 +297,13 @@ class CredentialsManager(
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
         cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_LENGTH, iv))
 
-        val ciphertext = cipher.doFinal(password.toByteArray(Charsets.UTF_8))
+        val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
 
         return Base64.getEncoder().encodeToString(ciphertext) to
                 Base64.getEncoder().encodeToString(iv)
     }
 
-    private fun decryptPassword(encryptedBase64: String, ivBase64: String): String? {
+    private fun decryptString(encryptedBase64: String, ivBase64: String): String? {
         return try {
             val key = deriveKey()
             val iv = Base64.getDecoder().decode(ivBase64)
@@ -248,7 +314,7 @@ class CredentialsManager(
 
             String(cipher.doFinal(ciphertext), Charsets.UTF_8)
         } catch (e: Exception) {
-            log.error("Failed to decrypt password", e)
+            log.error("Failed to decrypt encrypted value", e)
             null
         }
     }

--- a/client-launcher/src/test/kotlin/hivens/launcher/CredentialsManagerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/CredentialsManagerTest.kt
@@ -22,12 +22,9 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * Tests the keyring-primary + file-fallback refactor.
- *
- * Uses an in-memory [FakeKeyring] instead of a mock so the test reads
- * like a state-machine: store/retrieve/clear operations behave like a
- * real keyring would, but with explicit toggles for "daemon went away"
- * scenarios. Simpler than mockk for this many cases.
+ * Tests the keyring-primary + file-fallback refactor with two independent
+ * sensitive fields (password + accessToken). Uses an in-memory
+ * [FakeKeyring] instead of mockk so the tests read like state machines.
  */
 class CredentialsManagerTest {
 
@@ -48,9 +45,9 @@ class CredentialsManagerTest {
         Files.walk(workDir).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
     }
 
-    private fun session(password: String? = "secret-pw") = SessionData(
+    private fun session(password: String? = "secret-pw", accessToken: String = "fake-game-token") = SessionData(
         playerName = "ChaosA",
-        accessToken = "fake-game-token",
+        accessToken = accessToken,
         uuid = "550e8400e29b41d4a716446655440000",
         uid = "1",
         cachedPassword = password,
@@ -62,64 +59,70 @@ class CredentialsManagerTest {
         return json.parseToJsonElement(text).jsonObject
     }
 
+    private val passwordKey = "io.github.kitty_hivens.AuraLauncher::password"
+    private val accessTokenKey = "io.github.kitty_hivens.AuraLauncher::accessToken"
+
     // ── save() ─────────────────────────────────────────────────────────────
 
     @Test
-    fun `save with keyring available — password lands in keyring, file holds flag`() {
+    fun `save with keyring available — both secrets land in keyring, file holds flags`() {
         manager.save(session())
 
-        // Keyring got the secret. Service/account match the constants in
-        // CredentialsManager — if those rename, this test must too (which
-        // is the point: pin the wire format).
-        assertEquals("secret-pw", keyring.entries["io.github.kitty_hivens.AuraLauncher::password"])
-        // File records the flag, no ciphertext.
+        assertEquals("secret-pw", keyring.entries[passwordKey])
+        assertEquals("fake-game-token", keyring.entries[accessTokenKey])
+
         val obj = fileJson()
         assertEquals(true, obj["keyringHasPassword"]?.jsonPrimitive?.boolean)
+        assertEquals(true, obj["keyringHasAccessToken"]?.jsonPrimitive?.boolean)
         assertNull(obj["encryptedPassword"]?.jsonPrimitive?.contentOrNull)
-        assertNull(obj["passwordIv"]?.jsonPrimitive?.contentOrNull)
-        assertEquals(3, obj["version"]?.jsonPrimitive?.contentOrNull?.toInt())
+        assertNull(obj["encryptedAccessToken"]?.jsonPrimitive?.contentOrNull)
+        // Legacy plaintext accessToken field is never written in v4+.
+        assertNull(obj["accessToken"]?.jsonPrimitive?.contentOrNull)
+        assertEquals(4, obj["version"]?.jsonPrimitive?.contentOrNull?.toInt())
     }
 
     @Test
-    fun `save with keyring failing — falls back to AES-GCM file path`() {
+    fun `save with keyring failing — both secrets fall back to AES-GCM file`() {
         keyring.failStore = true
         manager.save(session())
 
-        // Nothing in keyring (it refused).
         assertTrue(keyring.entries.isEmpty())
-        // File has the ciphertext + iv, flag is false.
+
         val obj = fileJson()
         assertEquals(false, obj["keyringHasPassword"]?.jsonPrimitive?.boolean)
+        assertEquals(false, obj["keyringHasAccessToken"]?.jsonPrimitive?.boolean)
         assertNotNull(obj["encryptedPassword"]?.jsonPrimitive?.contentOrNull)
         assertNotNull(obj["passwordIv"]?.jsonPrimitive?.contentOrNull)
+        assertNotNull(obj["encryptedAccessToken"]?.jsonPrimitive?.contentOrNull)
+        assertNotNull(obj["accessTokenIv"]?.jsonPrimitive?.contentOrNull)
     }
 
     @Test
     fun `save with blank accessToken — no-op, no file written`() {
-        val noToken = session().copy(accessToken = "")
+        val noToken = session(accessToken = "")
         manager.save(noToken)
         assertFalse(Files.exists(workDir / "credentials.json"))
         assertTrue(keyring.entries.isEmpty())
     }
 
     @Test
-    fun `save with null cachedPassword — keyring not touched, file path used`() {
-        // SessionData allows null cachedPassword (e.g. user logged in via cached token).
-        // Should not invoke keyring.store(null) — would be a contract violation.
+    fun `save with null cachedPassword — password not stored, accessToken still goes to keyring`() {
         manager.save(session(password = null))
-        assertTrue(keyring.entries.isEmpty(), "keyring must not store null password")
-        // File still gets written for the metadata; encryptedPassword is null too.
+
+        assertNull(keyring.entries[passwordKey], "keyring must not store null password")
+        assertEquals("fake-game-token", keyring.entries[accessTokenKey], "accessToken still gets stored")
+
         val obj = fileJson()
         assertEquals(false, obj["keyringHasPassword"]?.jsonPrimitive?.boolean)
+        assertEquals(true, obj["keyringHasAccessToken"]?.jsonPrimitive?.boolean)
         assertNull(obj["encryptedPassword"]?.jsonPrimitive?.contentOrNull)
     }
 
     // ── load() ─────────────────────────────────────────────────────────────
 
     @Test
-    fun `load v3 keyring-mode — pulls password from keyring`() {
+    fun `load v4 keyring-mode — both secrets come from keyring`() {
         manager.save(session())
-        // Re-create manager to simulate process restart.
         val freshManager = CredentialsManager(workDir, json, keyring)
         val loaded = freshManager.load()
 
@@ -130,39 +133,88 @@ class CredentialsManagerTest {
     }
 
     @Test
-    fun `load v3 keyring-mode but keyring lookup returns null — session loads with null password`() {
+    fun `load v4 keyring-mode but accessToken entry wiped — returns null (session gone)`() {
         manager.save(session())
-        // Wipe the keyring entry as if the daemon was reset between sessions.
-        keyring.entries.clear()
+        // Wipe only the accessToken keyring entry — daemon issue, manual
+        // delete in seahorse, etc. Without accessToken the launcher cannot
+        // launch the game; load returns null to trigger re-login.
+        keyring.entries.remove(accessTokenKey)
         val freshManager = CredentialsManager(workDir, json, keyring)
-        val loaded = freshManager.load()
-
-        assertNotNull(loaded, "metadata must survive keyring wipe — only the password is gone")
-        assertEquals("ChaosA", loaded.playerName)
-        assertNull(loaded.cachedPassword, "password is gone — re-login required")
+        assertNull(freshManager.load(), "no accessToken = unusable session")
     }
 
     @Test
-    fun `load v3 file-mode — pulls password from AES-GCM file`() {
+    fun `load v4 keyring-mode but password entry wiped — session loads with null cachedPassword`() {
+        manager.save(session())
+        // Wipe only the password entry. accessToken still works, so the
+        // user can still launch the game; only password-dependent flows
+        // (re-auth) need to prompt.
+        keyring.entries.remove(passwordKey)
+        val freshManager = CredentialsManager(workDir, json, keyring)
+        val loaded = freshManager.load()
+
+        assertNotNull(loaded, "accessToken survived — session is usable")
+        assertEquals("fake-game-token", loaded.accessToken)
+        assertNull(loaded.cachedPassword, "password is gone — relogin needed for re-auth")
+    }
+
+    @Test
+    fun `load v4 file-mode — both secrets come from AES-GCM file`() {
         keyring.failStore = true
         manager.save(session())
-        // Restart with same keyring (still failing) to confirm file path round-trip.
         val freshManager = CredentialsManager(workDir, json, keyring)
         val loaded = freshManager.load()
 
         assertNotNull(loaded)
         assertEquals("secret-pw", loaded.cachedPassword)
+        assertEquals("fake-game-token", loaded.accessToken)
     }
 
     @Test
-    fun `load v1 legacy Base64 — migrates on read, returns valid session`() {
-        // Hand-craft a v1-format file as it would have existed before AES-GCM.
+    fun `load v3 legacy file with plaintext accessToken — migrates on next save`() {
+        // Hand-craft a v3-format file: password in keyring (flag set, no
+        // ciphertext) but accessToken still plaintext on disk. This is
+        // exactly what a launcher upgraded from #139 → this PR would have
+        // on disk for an already-logged-in user.
+        val legacyFile = workDir / "credentials.json"
+        keyring.entries[passwordKey] = "v3-password" // pretend keyring had it
+        val legacyText = """
+            {
+                "username": "OldUser",
+                "uuid": "00000000000000000000000000000000",
+                "uid": "42",
+                "keyringHasPassword": true,
+                "accessToken": "v3-plaintext-token",
+                "version": 3
+            }
+        """.trimIndent()
+        Files.writeString(legacyFile, legacyText)
+
+        // First load: reads v3 schema, surfaces the legacy plaintext token.
+        val loaded = manager.load()
+        assertNotNull(loaded)
+        assertEquals("v3-plaintext-token", loaded.accessToken)
+        assertEquals("v3-password", loaded.cachedPassword)
+
+        // Save migrates accessToken into the keyring + bumps version.
+        manager.save(loaded)
+        assertEquals("v3-plaintext-token", keyring.entries[accessTokenKey])
+        val obj = fileJson()
+        assertEquals(4, obj["version"]?.jsonPrimitive?.contentOrNull?.toInt())
+        assertEquals(true, obj["keyringHasAccessToken"]?.jsonPrimitive?.boolean)
+        assertNull(obj["accessToken"]?.jsonPrimitive?.contentOrNull, "legacy plaintext field cleared")
+    }
+
+    @Test
+    fun `load v1 legacy Base64 — migrates password on read, returns valid session`() {
+        // v1 schema also had plaintext accessToken — same migration path
+        // as v3 for the token; password comes from savedPasswordBase64.
         val legacyFile = workDir / "credentials.json"
         val legacyB64 = Base64.getEncoder().encodeToString("legacy-pw".toByteArray())
         val legacyText = """
             {
                 "username": "OldUser",
-                "accessToken": "old-token",
+                "accessToken": "v1-token",
                 "uuid": "00000000000000000000000000000000",
                 "uid": "42",
                 "savedPasswordBase64": "$legacyB64",
@@ -175,11 +227,11 @@ class CredentialsManagerTest {
         assertNotNull(loaded)
         assertEquals("OldUser", loaded.playerName)
         assertEquals("legacy-pw", loaded.cachedPassword)
+        assertEquals("v1-token", loaded.accessToken)
     }
 
     @Test
     fun `load with no file — returns null`() {
-        // Fresh state, no save() was called.
         assertNull(manager.load())
     }
 
@@ -192,22 +244,21 @@ class CredentialsManagerTest {
     // ── clear() ────────────────────────────────────────────────────────────
 
     @Test
-    fun `clear wipes keyring AND file — both must be gone`() {
+    fun `clear wipes both keyring entries AND file`() {
         manager.save(session())
-        assertTrue(Files.exists(workDir / "credentials.json"))
-        assertTrue(keyring.entries.isNotEmpty())
+        assertEquals(2, keyring.entries.size, "save populated password + accessToken")
 
         manager.clear()
 
         assertFalse(Files.exists(workDir / "credentials.json"), "file must be deleted")
-        assertTrue(keyring.entries.isEmpty(), "keyring entry must be cleared")
+        assertTrue(keyring.entries.isEmpty(), "both keyring entries must be cleared")
     }
 
     @Test
     fun `clear is idempotent — calling twice does not throw`() {
         manager.save(session())
         manager.clear()
-        manager.clear() // second call against empty state
+        manager.clear()
         assertFalse(Files.exists(workDir / "credentials.json"))
     }
 
@@ -223,12 +274,6 @@ class CredentialsManagerTest {
 
     // ── In-memory keyring fake ────────────────────────────────────────────
 
-    /**
-     * Simple in-memory IKeyringStorage that tracks entries by
-     * "service::account" key. `failStore` toggle simulates a
-     * keyring daemon that's reachable (isAvailable=true) but
-     * refuses writes — covers the "user revoked permission" case.
-     */
     private class FakeKeyring : IKeyringStorage {
         val entries: MutableMap<String, String> = mutableMapOf()
         var failStore: Boolean = false

--- a/client-launcher/src/test/kotlin/hivens/launcher/CredentialsManagerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/CredentialsManagerTest.kt
@@ -274,6 +274,25 @@ class CredentialsManagerTest {
 
     // ── In-memory keyring fake ────────────────────────────────────────────
 
+    /**
+     * Simple in-memory [IKeyringStorage] that tracks entries by a
+     * `"service::account"` key. Covers two scenarios CredentialsManager
+     * cares about:
+     *
+     *  - **Happy path**: `store` succeeds, `retrieve` returns what was
+     *    written, `clear` removes (returns true only when something was
+     *    actually removed — matches libsecret's no-match semantics).
+     *  - **`failStore = true`**: simulates a keyring daemon that's
+     *    reachable (`isAvailable() = true`) but refuses every write.
+     *    Covers the "user revoked permission" / "default collection
+     *    locked" cases that should transparently degrade to the
+     *    AES-GCM file fallback.
+     *
+     * One toggle covers both password and accessToken paths because the
+     * production code calls `store` per-secret — flipping `failStore`
+     * triggers the file fallback for both, which is what we want to
+     * exercise in the file-mode tests.
+     */
     private class FakeKeyring : IKeyringStorage {
         val entries: MutableMap<String, String> = mutableMapOf()
         var failStore: Boolean = false


### PR DESCRIPTION
## Summary

Vault sub-chunk #1.F. Closes the plaintext-accessToken-on-disk gap surfaced during #1.C. `accessToken` is the derived game-token that authenticates Minecraft launches — equally sensitive as the password, and was previously stored unencrypted in `credentials.json`.

## Storage hierarchy now per-secret (both fields)

| Tier | Active when | What's on disk |
|---|---|---|
| **OS keyring** | `IKeyringStorage.isAvailable()` AND `store()` returns true | `keyringHasX=true`, no ciphertext |
| **AES-GCM file (v4)** | Keyring unreachable / refused | `encryptedX` + `Iv` |
| **Legacy plaintext** | Reading older files only | (n/a in v4+ writes) |

Two independent accounts under one service in the keyring:

```
SERVICE = io.github.kitty_hivens.AuraLauncher
  ACCOUNT password       ← v3+
  ACCOUNT accessToken    ← v4 (new)
```

Independent accounts so each secret is retrievable / rotatable / clearable on its own.

## Schema bump v3 → v4

New flags + ciphertext fields: `keyringHasAccessToken`, `encryptedAccessToken`, `accessTokenIv`. Legacy `accessToken: String?` becomes nullable and is never populated in v4+ writes — read-only for migration.

Three legacy paths handled on read:
- `savedPasswordBase64` (v1) → password decoded, written into v4 form on next save
- `encryptedPassword` (v2/v3 file-mode) → decrypted in place
- `accessToken` plaintext (v3) → surfaced into SessionData, migrated to keyring on next save

## Load behaviour — explicit decision for missing secrets

- **accessToken missing** (keyring wiped, AES failed, no legacy fallback) → `load()` returns `null`. Rationale: without accessToken the launcher cannot launch the game; cleanly triggers re-login path.
- **Only password missing** but accessToken survived → returns SessionData with `cachedPassword=null`. User can still play; re-auth prompted only when password is actually needed.

This is a deliberate asymmetry: accessToken is load-blocking, password is degradable.

## Side cleanup

`encryptPassword` / `decryptPassword` renamed to `encryptString` / `decryptString` — they're now generic, used for both password and accessToken file paths.

## Test coverage — 15 cases

- v4 keyring/file mode round-trips for both secrets
- Partial-wipe scenarios:
  - Only accessToken keyring entry wiped → `load()` returns null
  - Only password keyring entry wiped → `load()` returns SessionData with `cachedPassword=null`, accessToken intact
- v3 → v4 migration: plaintext accessToken on disk migrates into keyring on next save (verified via JSON inspection)
- v1 → v4 migration: Base64 password migrates, accessToken legacy plaintext also migrates
- `clear()` wipes both keyring entries + file regardless of which mode was active
- Edge cases: blank accessToken (save no-op), null cachedPassword (file path for password, keyring for accessToken), malformed file (returns null)

## Test plan

- [x] `:client-launcher:test` — green (15 + existing all pass)
- [x] `:client-core:test` — green
- [ ] Live Hyprland: relogin, verify `secret-tool search service io.github.kitty_hivens.AuraLauncher` returns BOTH `password` AND `accessToken` accounts
- [ ] Qodana

## After merge

- Vault #2 — scope-restricted SSL bypass (per-host + expiry)
- Windows + macOS keyring platform impls (separate PRs)