### PR TITLE
feat(vault): WindowsCredentialManagerKeyringStorage via Project Panama

### DIFF
--- a/client-launcher/build.gradle.kts
+++ b/client-launcher/build.gradle.kts
@@ -34,10 +34,12 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform {
-        // Both tags are dev / maintenance only — neither belongs in the
-        // regular unit-test set. `smoke` hits real smartycraft.ru;
-        // `live-keyring` hits the developer's own Secret Service daemon.
-        excludeTags("smoke", "live-keyring")
+        // Dev / maintenance only — none of these belong in the regular
+        // unit-test set. `smoke` hits real smartycraft.ru;
+        // `live-keyring` hits the developer's Secret Service daemon
+        // (Linux); `live-windows-keyring` hits real Windows Credential
+        // Manager (Windows only).
+        excludeTags("smoke", "live-keyring", "live-windows-keyring")
     }
 }
 
@@ -69,6 +71,22 @@ val liveKeyringTest by tasks.registering(Test::class) {
 // and Panama symbol lookup happens at construction time.
 tasks.test {
     jvmArgs("--enable-native-access=ALL-UNNAMED")
+}
+
+// Windows-only live probe against real Credential Manager via Panama
+// bindings to advapi32. Same opt-in shape as liveKeyringTest: skips
+// gracefully when not on Windows or when advapi32 isn't loadable.
+val liveWindowsKeyringTest by tasks.registering(Test::class) {
+    description = "Runs WindowsCredentialManagerKeyringStorage live probe against the local Credential Manager service."
+    group = "verification"
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    useJUnitPlatform {
+        includeTags("live-windows-keyring")
+    }
+    jvmArgs("--enable-native-access=ALL-UNNAMED")
+    outputs.upToDateWhen { false }
+    shouldRunAfter(tasks.test)
 }
 
 // ── Live smoke tests — gated on real `smartycraft.ru` ────────────────────────

--- a/client-launcher/src/main/kotlin/hivens/launcher/security/KeyringStorageFactory.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/security/KeyringStorageFactory.kt
@@ -25,9 +25,17 @@ object KeyringStorageFactory {
     fun system(): IKeyringStorage {
         val osName = System.getProperty("os.name", "").lowercase()
         val candidate: IKeyringStorage? = when {
-            osName.contains("linux") -> tryProbe("LinuxLibsecret") { LinuxLibsecretKeyringStorage() }
-            // Windows + macOS impls land in follow-up PRs (Vault sub-chunks).
-            // Until then, those platforms get the file fallback via NoOp.
+            // BSDs ship the same Secret Service / libsecret stack as Linux
+            // desktops (FreeBSD ports: security/libsecret + gnome-keyring,
+            // OpenBSD: equivalent). Same JNI symbol resolution flow on ELF,
+            // same DBus protocol. The "Linux" name in the class is historical.
+            osName.contains("linux") || osName.contains("bsd") ->
+                tryProbe("LinuxLibsecret") { LinuxLibsecretKeyringStorage() }
+            osName.contains("windows") ->
+                tryProbe("WindowsCredentialManager") { WindowsCredentialManagerKeyringStorage() }
+            // macOS impl lands in a follow-up PR (SecItem* via Panama + Core
+            // Foundation marshalling). Until then macOS gets the file
+            // fallback via NoOp.
             else -> null
         }
         return when {

--- a/client-launcher/src/main/kotlin/hivens/launcher/security/WindowsCredentialManagerKeyringStorage.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/security/WindowsCredentialManagerKeyringStorage.kt
@@ -1,0 +1,290 @@
+package hivens.launcher.security
+
+import hivens.core.security.IKeyringStorage
+import org.slf4j.LoggerFactory
+import java.lang.foreign.Arena
+import java.lang.foreign.FunctionDescriptor
+import java.lang.foreign.Linker
+import java.lang.foreign.MemoryLayout
+import java.lang.foreign.MemorySegment
+import java.lang.foreign.SymbolLookup
+import java.lang.foreign.ValueLayout
+import java.lang.invoke.MethodHandle
+
+/**
+ * Windows-side [IKeyringStorage] backed by **Windows Credential Manager**
+ * (the system service that has shipped with Windows since Vista, 2007).
+ * Implemented with **Project Panama** ([java.lang.foreign], JEP 454),
+ * matching the Linux libsecret peer in [LinuxLibsecretKeyringStorage].
+ *
+ * Under the hood Credential Manager stores each entry encrypted via
+ * **DPAPI** (Data Protection API). The encryption key is derived from
+ * the user's Windows login session — credentials are automatically
+ * available while the user is logged in, and copying `credentials.json`
+ * to another machine doesn't yield anything readable because DPAPI is
+ * machine-bound (and TPM-bound where available).
+ *
+ * advapi32.dll API surface (4 sync calls, no async, no COM):
+ *
+ * ```c
+ * BOOL CredWriteW (PCREDENTIALW Credential, DWORD Flags);
+ * BOOL CredReadW  (LPCWSTR TargetName, DWORD Type, DWORD Flags, PCREDENTIALW *Credential);
+ * BOOL CredDeleteW(LPCWSTR TargetName, DWORD Type, DWORD Flags);
+ * void CredFree   (PVOID Buffer);
+ * ```
+ *
+ * All strings are wide (UTF-16LE) with a `\0\0` terminator. The
+ * CREDENTIAL struct is allocated by us for writes; for reads, Windows
+ * allocates the result buffer and we must release it via [CredFree]
+ * after copying out the bytes.
+ *
+ * `TargetName` carries our `service/account` tuple as a slash-joined
+ * string — Windows uses TargetName as the unique key, so encoding both
+ * parts there is the conventional approach (same as Git Credential
+ * Manager's `git:https://github.com` pattern).
+ *
+ * Persistence: [CRED_PERSIST_LOCAL_MACHINE] (2) — survives reboots,
+ * tied to this Windows user on this machine. Not roaming (which would
+ * sync via Active Directory across machines — undesirable for
+ * launcher creds).
+ */
+internal class WindowsCredentialManagerKeyringStorage : IKeyringStorage {
+
+    private val log = LoggerFactory.getLogger(WindowsCredentialManagerKeyringStorage::class.java)
+
+    private companion object {
+        /** CRED_TYPE_GENERIC from wincred.h — non-domain credential. */
+        const val CRED_TYPE_GENERIC: Int = 1
+
+        /**
+         * CRED_PERSIST_LOCAL_MACHINE from wincred.h — credential survives
+         * reboots, tied to this user on this machine. Don't use
+         * CRED_PERSIST_SESSION (gone on logoff) or CRED_PERSIST_ENTERPRISE
+         * (roams via AD).
+         */
+        const val CRED_PERSIST_LOCAL_MACHINE: Int = 2
+
+        /** CRED_FLAGS_NONE — no special handling. */
+        const val FLAGS_NONE: Int = 0
+
+        /** Library name. JDK resolves `Advapi32` → `Advapi32.dll` automatically on Windows. */
+        const val ADVAPI32 = "Advapi32"
+    }
+
+    private val arena: Arena = Arena.ofShared()
+
+    private val lookup: SymbolLookup? = runCatching {
+        SymbolLookup.libraryLookup(ADVAPI32, arena)
+    }.onFailure {
+        log.info("Advapi32 not loadable on this system: {}", it.message ?: it.javaClass.simpleName)
+    }.getOrNull()
+
+    private val linker: Linker = Linker.nativeLinker()
+
+    /**
+     * CREDENTIALW layout per Win SDK wincred.h. Field offsets (x86_64):
+     *
+     * ```
+     *  0: DWORD Flags                    (4)
+     *  4: DWORD Type                     (4)
+     *  8: LPWSTR TargetName              (8)
+     * 16: LPWSTR Comment                 (8)
+     * 24: FILETIME LastWritten           (8 = 2 DWORDs)
+     * 32: DWORD CredentialBlobSize       (4)
+     * 36: (padding to align next pointer to 8)
+     * 40: LPBYTE CredentialBlob          (8)
+     * 48: DWORD Persist                  (4)
+     * 52: DWORD AttributeCount           (4)
+     * 56: PCREDENTIAL_ATTRIBUTE Attribs  (8)
+     * 64: LPWSTR TargetAlias             (8)
+     * 72: LPWSTR UserName                (8)
+     * 80: total
+     * ```
+     */
+    private val credentialLayout: MemoryLayout = MemoryLayout.structLayout(
+        ValueLayout.JAVA_INT.withName("Flags"),
+        ValueLayout.JAVA_INT.withName("Type"),
+        ValueLayout.ADDRESS.withName("TargetName"),
+        ValueLayout.ADDRESS.withName("Comment"),
+        ValueLayout.JAVA_INT.withName("LastWritten_Low"),
+        ValueLayout.JAVA_INT.withName("LastWritten_High"),
+        ValueLayout.JAVA_INT.withName("CredentialBlobSize"),
+        MemoryLayout.paddingLayout(4),
+        ValueLayout.ADDRESS.withName("CredentialBlob"),
+        ValueLayout.JAVA_INT.withName("Persist"),
+        ValueLayout.JAVA_INT.withName("AttributeCount"),
+        ValueLayout.ADDRESS.withName("Attributes"),
+        ValueLayout.ADDRESS.withName("TargetAlias"),
+        ValueLayout.ADDRESS.withName("UserName"),
+    )
+
+    private val credWriteHandle: MethodHandle? = lookup?.downcall(
+        "CredWriteW",
+        FunctionDescriptor.of(
+            ValueLayout.JAVA_INT,  // BOOL (nonzero = success)
+            ValueLayout.ADDRESS,   // PCREDENTIALW
+            ValueLayout.JAVA_INT,  // DWORD Flags
+        ),
+    )
+
+    private val credReadHandle: MethodHandle? = lookup?.downcall(
+        "CredReadW",
+        FunctionDescriptor.of(
+            ValueLayout.JAVA_INT,  // BOOL
+            ValueLayout.ADDRESS,   // LPCWSTR TargetName
+            ValueLayout.JAVA_INT,  // DWORD Type
+            ValueLayout.JAVA_INT,  // DWORD Flags
+            ValueLayout.ADDRESS,   // PCREDENTIALW *Credential (out)
+        ),
+    )
+
+    private val credDeleteHandle: MethodHandle? = lookup?.downcall(
+        "CredDeleteW",
+        FunctionDescriptor.of(
+            ValueLayout.JAVA_INT,  // BOOL
+            ValueLayout.ADDRESS,   // LPCWSTR TargetName
+            ValueLayout.JAVA_INT,  // DWORD Type
+            ValueLayout.JAVA_INT,  // DWORD Flags
+        ),
+    )
+
+    private val credFreeHandle: MethodHandle? = lookup?.downcall(
+        "CredFree",
+        FunctionDescriptor.ofVoid(ValueLayout.ADDRESS),
+    )
+
+    override fun isAvailable(): Boolean {
+        if (lookup == null || credWriteHandle == null || credDeleteHandle == null) return false
+        // Probe via write+delete on a tagged probe entry — same strategy
+        // as the libsecret peer. CredDeleteW returns FALSE for "no match"
+        // (ERROR_NOT_FOUND), so a bare delete alone can't distinguish
+        // "service alive" from "service dead".
+        return runCatching {
+            val ok = store("io.github.kitty_hivens.AuraLauncher.probe", "isAvailable", "ok")
+            if (ok) clear("io.github.kitty_hivens.AuraLauncher.probe", "isAvailable")
+            ok
+        }.getOrDefault(false)
+    }
+
+    override fun store(service: String, account: String, secret: String): Boolean {
+        require(service.isNotBlank() && account.isNotBlank()) { "service and account must be non-blank" }
+        val handle = credWriteHandle ?: return false
+        return Arena.ofConfined().use { call ->
+            try {
+                val target = call.allocateUtf16LE(targetName(service, account))
+                val userName = call.allocateUtf16LE("") // empty for generic credentials
+                // CredentialBlob is raw bytes — we marshal the secret as UTF-16LE
+                // (without trailing null) and pass the byte length explicitly via
+                // CredentialBlobSize. This matches what other tools (Git CM, etc.)
+                // do for non-ASCII secrets.
+                val secretBytes = secret.toByteArray(Charsets.UTF_16LE)
+                val secretSegment = call.allocate(secretBytes.size.toLong())
+                MemorySegment.copy(secretBytes, 0, secretSegment, ValueLayout.JAVA_BYTE, 0, secretBytes.size)
+
+                val cred = call.allocate(credentialLayout)
+                cred.set(ValueLayout.JAVA_INT, 0,  FLAGS_NONE)
+                cred.set(ValueLayout.JAVA_INT, 4,  CRED_TYPE_GENERIC)
+                cred.set(ValueLayout.ADDRESS,  8,  target)
+                cred.set(ValueLayout.ADDRESS,  16, MemorySegment.NULL)         // Comment
+                cred.set(ValueLayout.JAVA_INT, 24, 0)                           // LastWritten.Low
+                cred.set(ValueLayout.JAVA_INT, 28, 0)                           // LastWritten.High
+                cred.set(ValueLayout.JAVA_INT, 32, secretBytes.size)            // CredentialBlobSize
+                cred.set(ValueLayout.ADDRESS,  40, secretSegment)               // CredentialBlob
+                cred.set(ValueLayout.JAVA_INT, 48, CRED_PERSIST_LOCAL_MACHINE)
+                cred.set(ValueLayout.JAVA_INT, 52, 0)                           // AttributeCount
+                cred.set(ValueLayout.ADDRESS,  56, MemorySegment.NULL)          // Attributes
+                cred.set(ValueLayout.ADDRESS,  64, MemorySegment.NULL)          // TargetAlias
+                cred.set(ValueLayout.ADDRESS,  72, userName)                    // UserName
+
+                val result = handle.invokeExact(cred, FLAGS_NONE) as Int
+                result != 0
+            } catch (t: Throwable) {
+                log.warn("CredWriteW failed for {}/{}: {}", service, account, t.message)
+                false
+            }
+        }
+    }
+
+    override fun retrieve(service: String, account: String): String? {
+        require(service.isNotBlank() && account.isNotBlank()) { "service and account must be non-blank" }
+        val handle = credReadHandle ?: return null
+        val freeHandle = credFreeHandle ?: return null
+        return Arena.ofConfined().use { call ->
+            try {
+                val target = call.allocateUtf16LE(targetName(service, account))
+                // CredReadW writes a pointer-to-CREDENTIALW into our out-param.
+                val outPtr = call.allocate(ValueLayout.ADDRESS)
+
+                val result = handle.invokeExact(target, CRED_TYPE_GENERIC, FLAGS_NONE, outPtr) as Int
+                if (result == 0) {
+                    // GetLastError would give ERROR_NOT_FOUND (1168) typically,
+                    // but null returns are unambiguous enough for our caller.
+                    return@use null
+                }
+
+                val credAddress = outPtr.get(ValueLayout.ADDRESS, 0)
+                if (credAddress.address() == 0L) return@use null
+
+                val cred = credAddress.reinterpret(credentialLayout.byteSize())
+                val blobSize = cred.get(ValueLayout.JAVA_INT, 32)
+                val blobPtr = cred.get(ValueLayout.ADDRESS, 40)
+
+                val value = if (blobSize > 0 && blobPtr.address() != 0L) {
+                    val blob = blobPtr.reinterpret(blobSize.toLong())
+                    val bytes = blob.toArray(ValueLayout.JAVA_BYTE)
+                    String(bytes, Charsets.UTF_16LE)
+                } else {
+                    ""
+                }
+
+                // CredFree owns the buffer and any embedded pointers (TargetName,
+                // CredentialBlob, etc). One call frees the whole graph.
+                freeHandle.invokeExact(credAddress)
+                value
+            } catch (t: Throwable) {
+                log.warn("CredReadW failed for {}/{}: {}", service, account, t.message)
+                null
+            }
+        }
+    }
+
+    override fun clear(service: String, account: String): Boolean {
+        require(service.isNotBlank() && account.isNotBlank()) { "service and account must be non-blank" }
+        val handle = credDeleteHandle ?: return false
+        return Arena.ofConfined().use { call ->
+            try {
+                val target = call.allocateUtf16LE(targetName(service, account))
+                val result = handle.invokeExact(target, CRED_TYPE_GENERIC, FLAGS_NONE) as Int
+                result != 0
+            } catch (t: Throwable) {
+                log.warn("CredDeleteW failed for {}/{}: {}", service, account, t.message)
+                false
+            }
+        }
+    }
+
+    private fun targetName(service: String, account: String) = "$service/$account"
+}
+
+/**
+ * Allocate a UTF-16LE null-terminated string in this arena. Windows
+ * wide-char APIs (`LPWSTR`, `LPCWSTR`) all want exactly this format
+ * with a trailing `\0\0`.
+ */
+private fun Arena.allocateUtf16LE(s: String): MemorySegment {
+    val bytes = s.toByteArray(Charsets.UTF_16LE)
+    val segment = allocate((bytes.size + 2).toLong())
+    MemorySegment.copy(bytes, 0, segment, ValueLayout.JAVA_BYTE, 0, bytes.size)
+    segment.set(ValueLayout.JAVA_BYTE, bytes.size.toLong(), 0)
+    segment.set(ValueLayout.JAVA_BYTE, (bytes.size + 1).toLong(), 0)
+    return segment
+}
+
+/**
+ * Convenience: turn a `find(name)` Optional<MemorySegment> into a
+ * non-variadic downcall MethodHandle, returning null when absent.
+ */
+private fun SymbolLookup.downcall(name: String, descriptor: FunctionDescriptor): MethodHandle? {
+    val symbol = find(name).orElse(null) ?: return null
+    return Linker.nativeLinker().downcallHandle(symbol, descriptor)
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/security/LiveWindowsKeyringProbeTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/security/LiveWindowsKeyringProbeTest.kt
@@ -1,0 +1,100 @@
+package hivens.launcher.security
+
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Tag
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Live probe of [WindowsCredentialManagerKeyringStorage] against the
+ * real Windows Credential Manager service. Tagged `live-windows-keyring`
+ * so it stays out of the regular test set and is opt-in for local
+ * Windows runs.
+ *
+ * Run locally on Windows with:
+ *   ./gradlew :client-launcher:liveWindowsKeyringTest
+ *
+ * Skips with [Assumptions.assumeTrue] when not running on Windows or
+ * when advapi32 isn't loadable — never fails the build because we're
+ * on the wrong platform.
+ *
+ * GH Actions `windows-latest` runners DO have a working Credential
+ * Manager service (DPAPI works for the runner's user account headless),
+ * so this could be wired into CI via the test matrix as a follow-up.
+ */
+@Tag("live-windows-keyring")
+class LiveWindowsKeyringProbeTest {
+
+    private val service = "io.github.kitty_hivens.AuraLauncher.test"
+    private val account = "live-probe-${System.currentTimeMillis()}"
+
+    private val keyring = WindowsCredentialManagerKeyringStorage()
+
+    private fun assumeWindows() {
+        assumeTrue(
+            System.getProperty("os.name", "").lowercase().contains("windows"),
+            "LiveWindowsKeyringProbeTest is Windows-only",
+        )
+        assumeTrue(
+            keyring.isAvailable(),
+            "advapi32 not loadable / Credential Manager unreachable — skipping live probe",
+        )
+    }
+
+    @Test
+    fun `round-trip — CredWriteW then CredReadW returns the same secret`() {
+        assumeWindows()
+        val secret = "round-trip-${System.nanoTime()}"
+        try {
+            assertTrue(keyring.store(service, account, secret), "store should succeed")
+            assertEquals(secret, keyring.retrieve(service, account))
+        } finally {
+            keyring.clear(service, account)
+        }
+    }
+
+    @Test
+    fun `clear removes the entry — subsequent retrieve returns null`() {
+        assumeWindows()
+        val secret = "to-be-cleared-${System.nanoTime()}"
+        keyring.store(service, account, secret)
+        assertTrue(keyring.clear(service, account), "clear should succeed when entry exists")
+        assertNull(keyring.retrieve(service, account), "after clear, retrieve must return null")
+    }
+
+    @Test
+    fun `clear of nonexistent entry returns false (CredDeleteW semantics)`() {
+        assumeWindows()
+        // CredDeleteW returns FALSE with GetLastError = ERROR_NOT_FOUND when
+        // nothing matches. Same shape as libsecret's clear-on-no-match.
+        assertFalse(
+            keyring.clear(service, "definitely-does-not-exist-${System.nanoTime()}"),
+            "clear on absent entry returns false per CredDeleteW spec",
+        )
+    }
+
+    @Test
+    fun `retrieve of unknown account returns null without throwing`() {
+        assumeWindows()
+        assertNull(keyring.retrieve(service, "never-stored-${System.nanoTime()}"))
+    }
+
+    @Test
+    fun `unicode secret round-trips through UTF-16LE encoding`() {
+        assumeWindows()
+        // Verifies the UTF-16LE marshalling we do for CredentialBlob —
+        // CredWriteW takes raw bytes via the blob pointer, we encode as
+        // UTF-16LE before the call. If the encoding were wrong (say UTF-8
+        // or platform default), unicode characters would corrupt.
+        val secret = "пароль-секрет-密码-🔑"
+        try {
+            assertTrue(keyring.store(service, account, secret))
+            assertEquals(secret, keyring.retrieve(service, account))
+        } finally {
+            keyring.clear(service, account)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes the Vault sub-chunk #1 Windows platform gap. Panama bindings to `advapi32.dll` Credential Manager API; mirrors the Linux libsecret peer's shape.

```c
BOOL CredWriteW (PCREDENTIALW Credential, DWORD Flags);
BOOL CredReadW  (LPCWSTR TargetName, DWORD Type, DWORD Flags, PCREDENTIALW *Credential);
BOOL CredDeleteW(LPCWSTR TargetName, DWORD Type, DWORD Flags);
void CredFree   (PVOID Buffer);
```

Under the hood Windows Credential Manager stores each entry encrypted via **DPAPI**, machine-bound and TPM-bound where available. Strictly better than our PBKDF2-of-machine-properties file fallback.

## Implementation notes

- **CREDENTIALW layout** via `MemoryLayout.structLayout` with field offsets pinned in the class kdoc (x86_64 ABI).
- **UTF-16LE marshalling** via `Arena.allocateUtf16LE` helper, with required `\0\0` terminator for `LPCWSTR` params.
- **CredentialBlob** marshalled as raw bytes (UTF-16LE-encoded secret) with explicit size — non-ASCII passwords roundtrip cleanly.
- **Persistence**: `CRED_PERSIST_LOCAL_MACHINE` (2). Survives reboots, tied to this user on this machine. Not `ENTERPRISE` (would sync via AD — undesirable for launcher creds).

## Bonus — BSD support, one-line addition

`KeyringStorageFactory` now selects `LinuxLibsecretKeyringStorage` for `os.name` containing **either `"linux"` OR `"bsd"`**. FreeBSD ports (`security/libsecret` + `gnome-keyring`) and OpenBSD provide the same Secret Service DBus stack — same JNI symbol resolution on ELF, same DBus protocol. The `"Linux"` prefix on the impl class is historical; the impl is Secret Service-based, not OS-tied.

## Tests

- `LiveWindowsKeyringProbeTest` tagged `live-windows-keyring`, skip-on-non-Windows + skip-on-no-advapi32. 5 cases:
  - round-trip store → retrieve returns same secret
  - clear removes the entry
  - clear of nonexistent entry returns false (CredDeleteW semantics)
  - retrieve of unknown account returns null
  - **unicode round-trip** (`пароль-密码-🔑`) — validates UTF-16LE marshalling
- New gradle task `:client-launcher:liveWindowsKeyringTest` mirrors `:liveKeyringTest` for Linux.
- Full unit suite green on Linux (Win live test naturally skipped).

## Live verification deferred

Compile + Panama symbol resolution + struct layout validate at compile-time. Real runtime check needs Windows — developer is setting up a QEMU VM for this. GH Actions `windows-latest` runners DO have working Credential Manager (DPAPI is per-user, headless-OK), so wiring this into a CI matrix entry is a plausible follow-up.

## Still pending

- macOS impl — Security.framework SecItem* via Panama + Core Foundation marshalling. Different shape (no ObjC pain like NSStatusItem, but CF reference counting + global symbol resolution is verbose). Separate sub-chunk.
- Vault #2 — scope-restricted SSL bypass (per-host + expiry).

## Test plan

- [x] `:client-launcher:test` green on Linux
- [x] `:client-launcher:compileKotlin` green (Panama symbol shape valid at compile-time)
- [ ] `:client-launcher:liveWindowsKeyringTest` green on Windows VM (post-merge, developer's QEMU setup)
- [ ] Qodana