### PR TITLE
feat(vault): SSL warning duration picker + Settings bypass list (#2 UI)

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
@@ -206,35 +206,57 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
                     style = MaterialTheme.typography.bodySmall,
                     color = CelestiaTheme.colors.textPrimary.copy(alpha = 0.85f)
                 )
+                // Trust-duration prompt + 3 grant buttons. Each click both
+                // grants the bypass for that duration AND retries login —
+                // single-click UX. Cancel button is on its own row above so
+                // the dangerous actions don't accidentally read as the same
+                // affordance as the safe one.
+                OutlinedButton(
+                    onClick  = { sslWarning = false },
+                    modifier = Modifier.fillMaxWidth(),
+                    shape    = RoundedCornerShape(6.dp)
+                ) {
+                    Text(s.sslWarningCancel, color = CelestiaTheme.colors.textSecondary)
+                }
+                Text(
+                    text  = s.sslWarningTrustPrompt,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = CelestiaTheme.colors.textSecondary,
+                )
+                val acceptColors = ButtonDefaults.buttonColors(containerColor = Color(0xFFF59E0B))
+                fun acceptFor(unit: java.time.temporal.ChronoUnit, amount: Long, label: String) {
+                    // 100-year future for "always" — long enough that no user
+                    // will outlive it, short enough to not overflow ISO-8601
+                    // formatting that a far-future Instant.MAX would.
+                    val until = java.time.Instant.now().plus(amount, unit)
+                    hivens.core.diag.ActionRing.record(
+                        "SSL bypass accepted by user (login retry) — granted: $label",
+                    )
+                    NetworkState.grantBypass(hivens.config.Network.SSL_BYPASS_HOST, until)
+                    doLogin(insecureAuthService)
+                }
                 Row(
                     modifier              = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
-                    OutlinedButton(
-                        onClick  = { sslWarning = false },
-                        modifier = Modifier.weight(1f),
-                        shape    = RoundedCornerShape(6.dp)
-                    ) {
-                        Text(s.sslWarningCancel, color = CelestiaTheme.colors.textSecondary)
-                    }
                     Button(
-                        onClick = {
-                            // 30-day default grant. Full "trust until: 1h / 30d / always"
-                            // picker UI is a followup chunk; this PR ships the per-host +
-                            // expiry plumbing so the followup is pure UI work.
-                            val until = java.time.Instant.now().plus(30, java.time.temporal.ChronoUnit.DAYS)
-                            hivens.core.diag.ActionRing.record("SSL bypass accepted by user (login retry) — granted for 30 days")
-                            NetworkState.grantBypass(hivens.config.Network.SSL_BYPASS_HOST, until)
-                            doLogin(insecureAuthService)
-                        },
+                        onClick  = { acceptFor(java.time.temporal.ChronoUnit.HOURS, 1, "1 hour") },
                         modifier = Modifier.weight(1f),
                         shape    = RoundedCornerShape(6.dp),
-                        colors   = ButtonDefaults.buttonColors(
-                            containerColor = Color(0xFFF59E0B)
-                        )
-                    ) {
-                        Text(s.sslWarningConnectAnyway, color = Color.Black)
-                    }
+                        colors   = acceptColors,
+                    ) { Text(s.sslWarningTrustHour, color = Color.Black) }
+                    Button(
+                        onClick  = { acceptFor(java.time.temporal.ChronoUnit.DAYS, 30, "30 days") },
+                        modifier = Modifier.weight(1f),
+                        shape    = RoundedCornerShape(6.dp),
+                        colors   = acceptColors,
+                    ) { Text(s.sslWarningTrust30Days, color = Color.Black) }
+                    Button(
+                        onClick  = { acceptFor(java.time.temporal.ChronoUnit.DAYS, 36500, "always (100y)") },
+                        modifier = Modifier.weight(1f),
+                        shape    = RoundedCornerShape(6.dp),
+                        colors   = acceptColors,
+                    ) { Text(s.sslWarningTrustAlways, color = Color.Black) }
                 }
             }
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -341,6 +341,18 @@ interface AppStrings {
     val sslWarningBody: String
     val sslWarningConnectAnyway: String
     val sslWarningCancel: String
+    val sslWarningTrustPrompt: String
+    val sslWarningTrustHour: String
+    val sslWarningTrust30Days: String
+    val sslWarningTrustAlways: String
+
+    // --- SSL Bypass list (Settings → Network) ---
+    val settingsSectionNetwork: String
+    val sslBypassListTitle: String
+    val sslBypassNoEntries: String
+    val sslBypassRevoke: String
+    /** Receives a pre-formatted local date/time string. */
+    fun sslBypassExpiresAt(formatted: String): String
 
     // ═══════════════════════════════════════════════════════════════════════
     // JVM Args Builder dialog

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -339,6 +339,16 @@ object EnglishStrings : AppStrings {
     override val sslWarningBody         = "The server's SSL certificate has expired. Your connection may be insecure — server identity cannot be verified. Proceed at your own risk?"
     override val sslWarningConnectAnyway = "Connect anyway"
     override val sslWarningCancel       = "Cancel"
+    override val sslWarningTrustPrompt  = "Trust this host for:"
+    override val sslWarningTrustHour    = "1 hour"
+    override val sslWarningTrust30Days  = "30 days"
+    override val sslWarningTrustAlways  = "Always"
+
+    override val settingsSectionNetwork = "Network"
+    override val sslBypassListTitle     = "Active SSL bypasses"
+    override val sslBypassNoEntries     = "No active bypasses"
+    override val sslBypassRevoke        = "Revoke"
+    override fun sslBypassExpiresAt(formatted: String) = "Expires: $formatted"
 
     // ── JVM Args Builder ────────────────────────────────────────────────
     override val jvmTitle    = "JVM Args Builder"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -339,6 +339,16 @@ object GermanStrings : AppStrings {
     override val sslWarningBody         = "Das SSL-Zertifikat des Servers ist abgelaufen. Die Verbindung ist möglicherweise unsicher — die Identität des Servers kann nicht verifiziert werden. Auf eigenes Risiko fortfahren?"
     override val sslWarningConnectAnyway = "Trotzdem verbinden"
     override val sslWarningCancel       = "Abbrechen"
+    override val sslWarningTrustPrompt  = "Diesem Server vertrauen für:"
+    override val sslWarningTrustHour    = "1 Stunde"
+    override val sslWarningTrust30Days  = "30 Tage"
+    override val sslWarningTrustAlways  = "Immer"
+
+    override val settingsSectionNetwork = "Netzwerk"
+    override val sslBypassListTitle     = "Aktive SSL-Bypässe"
+    override val sslBypassNoEntries     = "Keine aktiven Bypässe"
+    override val sslBypassRevoke        = "Widerrufen"
+    override fun sslBypassExpiresAt(formatted: String) = "Läuft ab: $formatted"
 
     // ── JVM Args Builder ────────────────────────────────────────────────
     override val jvmTitle    = "JVM-Argument-Builder"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -339,6 +339,16 @@ object RussianStrings : AppStrings {
     override val sslWarningBody         = "Сертификат сервера истёк. Соединение может быть небезопасным — данные передаются без проверки подлинности сервера. Продолжить на свой страх и риск?"
     override val sslWarningConnectAnyway = "Всё равно подключиться"
     override val sslWarningCancel       = "Отмена"
+    override val sslWarningTrustPrompt  = "Доверять серверу:"
+    override val sslWarningTrustHour    = "1 час"
+    override val sslWarningTrust30Days  = "30 дней"
+    override val sslWarningTrustAlways  = "Постоянно"
+
+    override val settingsSectionNetwork = "Сеть"
+    override val sslBypassListTitle     = "Активные SSL-исключения"
+    override val sslBypassNoEntries     = "Нет активных исключений"
+    override val sslBypassRevoke        = "Отозвать"
+    override fun sslBypassExpiresAt(formatted: String) = "Истекает: $formatted"
 
     // ── JVM Args Builder ────────────────────────────────────────────────
     override val jvmTitle    = "Конструктор JVM-аргументов"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
@@ -315,6 +315,85 @@ fun SettingsScreen(
                     }
                 }
 
+                // ── Network ───────────────────────────────────────────────────
+                //
+                // Currently surfaces just the SSL-bypass list (Vault #2 followup).
+                // Future: proxy override, channel routing toggles, etc. live
+                // here under one section so users have a single place to look
+                // for "things that affect how Aura talks to the network".
+                item {
+                    SettingsSectionTitle(s.settingsSectionNetwork)
+
+                    // Live snapshot — re-reads every 1s. Sufficient for a
+                    // settings screen (no rapid-fire updates expected). Avoids
+                    // setting up a Flow purely for this single read site.
+                    val bypasses = androidx.compose.runtime.produceState(initialValue = hivens.launcher.NetworkState.listBypasses()) {
+                        while (true) {
+                            value = hivens.launcher.NetworkState.listBypasses()
+                            kotlinx.coroutines.delay(1_000)
+                        }
+                    }.value
+                    val dateFormatter = java.time.format.DateTimeFormatter
+                        .ofLocalizedDateTime(java.time.format.FormatStyle.MEDIUM)
+                        .withZone(java.time.ZoneId.systemDefault())
+
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(CelestiaTheme.colors.background.copy(alpha = 0.4f))
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text       = s.sslBypassListTitle,
+                            color      = CelestiaTheme.colors.textPrimary,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        if (bypasses.isEmpty()) {
+                            Text(
+                                text  = s.sslBypassNoEntries,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = CelestiaTheme.colors.textSecondary,
+                            )
+                        } else {
+                            bypasses.forEach { entry ->
+                                Row(
+                                    modifier              = Modifier.fillMaxWidth(),
+                                    verticalAlignment     = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                ) {
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(
+                                            text       = entry.host,
+                                            color      = CelestiaTheme.colors.textPrimary,
+                                            fontWeight = FontWeight.SemiBold,
+                                        )
+                                        Text(
+                                            text  = s.sslBypassExpiresAt(
+                                                dateFormatter.format(java.time.Instant.parse(entry.expiresAt)),
+                                            ),
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = CelestiaTheme.colors.textSecondary,
+                                        )
+                                    }
+                                    OutlinedButton(
+                                        onClick = {
+                                            hivens.core.diag.ActionRing.record(
+                                                "SSL bypass revoked by user from Settings: ${entry.host}",
+                                            )
+                                            hivens.launcher.NetworkState.revokeBypass(entry.host)
+                                        },
+                                        shape = RoundedCornerShape(6.dp),
+                                    ) {
+                                        Text(s.sslBypassRevoke, color = CelestiaTheme.colors.textSecondary)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // ── Experimental features ─────────────────────────────────────
                 item {
                     SettingsSectionTitle(s.settingsSectionExperimental)


### PR DESCRIPTION
## Summary

Vault #2 followup. Closes the user-facing surface left as TODO in the plumbing PR (#142). Two UI deliverables:

### 1. Duration picker in SSL warning banner

Was: single «Connect anyway» button hardcoding a 30-day grant.
Now:

```
[Cancel]
Trust this host for: [1 hour] [30 days] [Always]
```

Single-click UX — each duration button both grants the bypass for that window AND retries login (no separate Confirm). Cancel is on its own row above so the safe action doesn't visually conflate with the three dangerous ones.

«Always» maps to a 100-year future Instant — long enough that no user will outlive it, short enough that ISO-8601 formatting stays clean.

### 2. Settings → Network section with bypass list

New section between Behavior and Experimental:

```
Active SSL bypasses
─────────────────
www.smartycraft.ru                          [Revoke]
Expires: May 31, 2026, 8:30 PM
```

Empty-state message when there are no entries. Live-snapshot polled once per second (sufficient for a settings screen — no Flow setup overhead for a single read site).

## i18n

9 new keys in AppStrings + RU/EN/DE locales. `sslBypassExpiresAt` is a function (not val) so the formatted date string can be inserted into locale-specific phrasing — RU «Истекает: ...», DE «Läuft ab: ...», EN «Expires: ...».

## ActionRing entries

Now record the granted duration in human-readable form:
- `"SSL bypass accepted by user (login retry) — granted: 1 hour"`
- `"SSL bypass revoked by user from Settings: www.smartycraft.ru"`

Diagnostic bundles get enough context for the maintainer to reconstruct what the user actually did.

## Test plan

- [x] `:client-launcher:test` + `:client-core:test` — green (pure UI work, no NetworkState API surface change)
- [x] `:client-ui:compileKotlinDesktop` — green
- [ ] Manual UX verification — next time launcher runs from source
- [ ] Qodana