### PR TITLE
feat(bridge): Settings UI «Move data directory» + schedule-on-restart

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/platform/BootstrapConf.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/platform/BootstrapConf.kt
@@ -1,0 +1,83 @@
+package hivens.launcher.platform
+
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Flat key=value config that lives **outside** the data directory so the
+ * launcher can find user-specific overrides before it even knows where
+ * the data directory is. Used by [PlatformPaths] to honour a user-chosen
+ * data dir without requiring `AURA_DATA_DIR` env on every launch, and by
+ * [DataDirMover] to schedule pending moves that apply on next startup.
+ *
+ * Path: `<user.home>/.aura-launcher.conf`. Same flat location on all
+ * platforms — debuggable by `cat` / Notepad, no XDG hunting, no
+ * Preferences API quirks. The dotfile prefix keeps it out of casual
+ * folder listings on Linux/macOS; Windows shows it normally but it
+ * doesn't clutter anything important.
+ *
+ * Recognised keys:
+ *   - `data-dir`                  — absolute path of user-chosen data dir
+ *   - `data-dir-pending-source`   — set by UI when scheduling a move
+ *   - `data-dir-pending-target`   — set by UI when scheduling a move
+ *
+ * Lines that don't match `key=value` are ignored on read; the writer
+ * preserves only known keys. Comments are not supported (simpler than
+ * dealing with `#` semantics across edits).
+ *
+ * Concurrency: all reads / writes are file-system-atomic per operation
+ * (`Files.writeString` is atomic on POSIX, atomic-on-rename on Windows).
+ * The launcher only writes during user-initiated UI actions or at
+ * startup, so there's no concurrent-writer scenario to worry about.
+ */
+object BootstrapConf {
+    private val log = LoggerFactory.getLogger(BootstrapConf::class.java)
+
+    const val KEY_DATA_DIR = "data-dir"
+    const val KEY_PENDING_SOURCE = "data-dir-pending-source"
+    const val KEY_PENDING_TARGET = "data-dir-pending-target"
+
+    /** Default location — overridable in tests via [resolveFor]. */
+    fun defaultPath(): Path = Paths.get(System.getProperty("user.home", "."), ".aura-launcher.conf")
+
+    fun read(file: Path = defaultPath()): Map<String, String> {
+        if (!Files.exists(file)) return emptyMap()
+        return try {
+            Files.readAllLines(file)
+                .mapNotNull { line ->
+                    val trimmed = line.trim()
+                    if (trimmed.isEmpty() || trimmed.startsWith("#")) return@mapNotNull null
+                    val eq = trimmed.indexOf('=')
+                    if (eq <= 0) return@mapNotNull null
+                    trimmed.substring(0, eq).trim() to trimmed.substring(eq + 1).trim()
+                }
+                .toMap()
+        } catch (e: Exception) {
+            log.warn("Failed to read bootstrap conf {}: {}", file, e.message)
+            emptyMap()
+        }
+    }
+
+    fun write(values: Map<String, String>, file: Path = defaultPath()) {
+        try {
+            if (file.parent != null) Files.createDirectories(file.parent)
+            val text = values
+                .filterValues { it.isNotBlank() }
+                .entries
+                .sortedBy { it.key }
+                .joinToString(separator = System.lineSeparator()) { (k, v) -> "$k=$v" }
+            Files.writeString(file, text + System.lineSeparator())
+        } catch (e: Exception) {
+            log.warn("Failed to write bootstrap conf {}: {}", file, e.message)
+        }
+    }
+
+    /** Convenience: read, mutate, write back. */
+    fun update(file: Path = defaultPath(), block: (MutableMap<String, String>) -> Unit) {
+        val current = read(file).toMutableMap()
+        block(current)
+        write(current, file)
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/platform/DataDirMover.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/platform/DataDirMover.kt
@@ -1,0 +1,163 @@
+package hivens.launcher.platform
+
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.util.stream.Collectors
+
+/**
+ * Schedule-on-restart data-directory move.
+ *
+ * Why schedule-on-restart instead of moving live:
+ *  - On Windows, files that are open (single-instance lock, credentials,
+ *    rolling log appenders, etc.) cannot be deleted from underneath the
+ *    JVM. A live move would partially fail.
+ *  - Even on POSIX, races between the move and background tasks
+ *    (AutoSync writing manifest cache, login writing credentials) leak
+ *    files to the old path.
+ *
+ * The flow:
+ *  1. UI calls [schedule] with the target path. It writes
+ *     `data-dir-pending-source` + `data-dir-pending-target` into
+ *     [BootstrapConf] (NOT yet `data-dir` — only after a successful
+ *     apply do we commit the new dir as the override).
+ *  2. UI prompts the user to restart.
+ *  3. On next startup, BEFORE [PlatformPaths] is consulted, the launcher
+ *     calls [applyPending]. It copies the source tree to the target,
+ *     verifies the copy, deletes the source, commits the new path as
+ *     `data-dir`, and clears the pending markers.
+ *  4. If [applyPending] fails partway through, the pending markers stay
+ *     set so a retry can happen on a later restart. Source and target
+ *     both exist until the apply completes (no destructive ordering).
+ *
+ * Failure modes handled:
+ *  - Target doesn't exist → created
+ *  - Target is the source → no-op, clears pending
+ *  - Target already has launcher files → refused; pending cleared with
+ *    error log. User must pick an empty dir or merge manually.
+ *  - Target is inside source → refused (would recurse during copy)
+ *  - I/O failure mid-copy → target deleted, source intact, pending kept
+ *    (retry on next start)
+ */
+object DataDirMover {
+    private val log = LoggerFactory.getLogger(DataDirMover::class.java)
+
+    /**
+     * UI-side: persist the move intent. Returns true if successfully
+     * scheduled. The caller should follow with a restart prompt.
+     */
+    fun schedule(source: Path, target: Path, confFile: Path = BootstrapConf.defaultPath()): Boolean {
+        return try {
+            if (source.normalize() == target.normalize()) {
+                log.info("schedule(): source == target, nothing to do")
+                return false
+            }
+            if (target.normalize().startsWith(source.normalize())) {
+                log.warn("schedule(): refusing to move into a subdirectory of source ({} → {})", source, target)
+                return false
+            }
+            BootstrapConf.update(confFile) { conf ->
+                conf[BootstrapConf.KEY_PENDING_SOURCE] = source.toAbsolutePath().toString()
+                conf[BootstrapConf.KEY_PENDING_TARGET] = target.toAbsolutePath().toString()
+            }
+            true
+        } catch (e: Exception) {
+            log.error("schedule() failed: {}", e.message, e)
+            false
+        }
+    }
+
+    /**
+     * Startup-side: if a pending move is recorded, execute it. Idempotent
+     * — calling multiple times is fine (a missing source is treated as
+     * "already applied" and clears the markers).
+     */
+    fun applyPending(confFile: Path = BootstrapConf.defaultPath()) {
+        val conf = BootstrapConf.read(confFile)
+        val sourceStr = conf[BootstrapConf.KEY_PENDING_SOURCE] ?: return
+        val targetStr = conf[BootstrapConf.KEY_PENDING_TARGET] ?: return
+
+        val source = java.nio.file.Paths.get(sourceStr)
+        val target = java.nio.file.Paths.get(targetStr)
+
+        log.info("Applying pending data-dir move: {} → {}", source, target)
+
+        // Source missing: assume an earlier apply already moved it. Mark
+        // the target as the new data-dir and clear pending.
+        if (!Files.exists(source)) {
+            log.info("source missing — assuming earlier apply succeeded, committing target as new data-dir")
+            commit(targetStr, confFile)
+            return
+        }
+
+        // Target already populated (not just the dir, but contents): refuse.
+        if (Files.exists(target) && hasContents(target)) {
+            log.error(
+                "target {} already has contents — refusing to overwrite. " +
+                    "Clearing pending markers; user must pick an empty dir or merge manually.",
+                target,
+            )
+            clearPending(confFile)
+            return
+        }
+
+        try {
+            if (!Files.exists(target)) Files.createDirectories(target)
+            copyTree(source, target)
+            // Verify file count matches before deleting source — cheap sanity.
+            val srcCount = countFiles(source)
+            val dstCount = countFiles(target)
+            if (srcCount != dstCount) {
+                log.error("copy verification failed: source={} files, target={} — leaving both intact, retry next start", srcCount, dstCount)
+                return
+            }
+            deleteTree(source)
+            commit(targetStr, confFile)
+            log.info("Data-dir move complete: {} files relocated", srcCount)
+        } catch (e: Exception) {
+            log.error("applyPending() failed mid-flight — pending markers retained for retry: {}", e.message, e)
+        }
+    }
+
+    private fun commit(newDataDir: String, confFile: Path) {
+        BootstrapConf.update(confFile) { conf ->
+            conf[BootstrapConf.KEY_DATA_DIR] = newDataDir
+            conf.remove(BootstrapConf.KEY_PENDING_SOURCE)
+            conf.remove(BootstrapConf.KEY_PENDING_TARGET)
+        }
+    }
+
+    private fun clearPending(confFile: Path) {
+        BootstrapConf.update(confFile) { conf ->
+            conf.remove(BootstrapConf.KEY_PENDING_SOURCE)
+            conf.remove(BootstrapConf.KEY_PENDING_TARGET)
+        }
+    }
+
+    private fun hasContents(dir: Path): Boolean =
+        runCatching { Files.list(dir).use { it.findAny().isPresent } }.getOrDefault(false)
+
+    private fun copyTree(source: Path, target: Path) {
+        Files.walk(source).use { stream ->
+            stream.forEach { src ->
+                val rel = source.relativize(src)
+                val dst = target.resolve(rel.toString())
+                when {
+                    Files.isDirectory(src) -> if (!Files.exists(dst)) Files.createDirectories(dst)
+                    else -> Files.copy(src, dst, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES)
+                }
+            }
+        }
+    }
+
+    private fun deleteTree(root: Path) {
+        if (!Files.exists(root)) return
+        Files.walk(root).use { stream ->
+            stream.sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+        }
+    }
+
+    private fun countFiles(root: Path): Long =
+        Files.walk(root).use { it.filter(Files::isRegularFile).collect(Collectors.counting()) }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/platform/PlatformPaths.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/platform/PlatformPaths.kt
@@ -10,7 +10,11 @@ import java.nio.file.Paths
  * 1. `AURA_DATA_DIR` environment variable (if set and non-blank) — universal override
  *    that lets a user move data to any drive without touching settings. Equivalent in
  *    spirit to Linux's `XDG_DATA_HOME` but works on every platform.
- * 2. Per-OS default:
+ * 2. [BootstrapConf] `data-dir` key — user-chosen override persisted via the
+ *    "Move data directory" Settings UI. Bootstrap conf lives outside the data
+ *    dir so the launcher can find the override before it even knows where the
+ *    data dir is.
+ * 3. Per-OS default:
  *    - Windows: `%LOCALAPPDATA%\AuraLauncher` (kept separate from the install dir under `%APPDATA%`)
  *    - macOS:   `~/Library/Application Support/AuraLauncher`
  *    - Linux:   `$XDG_DATA_HOME/aura-launcher` (default `~/.local/share/aura-launcher`)
@@ -21,15 +25,19 @@ import java.nio.file.Paths
 class PlatformPaths(
     osName: String,
     private val home: Path,
-    env: (String) -> String?
+    bootstrapDataDir: () -> Path? = { BootstrapConf.read()[BootstrapConf.KEY_DATA_DIR]?.let { Paths.get(it) } },
+    env: (String) -> String?,
 ) {
     private val isWindows = osName.contains("windows", ignoreCase = true)
     private val isMacOs = osName.contains("mac", ignoreCase = true) ||
             osName.contains("darwin", ignoreCase = true)
 
     val dataDir: Path = run {
-        val override = env("AURA_DATA_DIR")
-        if (!override.isNullOrBlank()) return@run Paths.get(override)
+        val envOverride = env("AURA_DATA_DIR")
+        if (!envOverride.isNullOrBlank()) return@run Paths.get(envOverride)
+
+        val confOverride = bootstrapDataDir()
+        if (confOverride != null) return@run confOverride
 
         when {
             isWindows -> {

--- a/client-launcher/src/test/kotlin/hivens/launcher/platform/BootstrapConfTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/platform/BootstrapConfTest.kt
@@ -1,0 +1,103 @@
+package hivens.launcher.platform
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.div
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BootstrapConfTest {
+
+    private lateinit var workDir: Path
+    private lateinit var confFile: Path
+
+    @BeforeTest
+    fun setup() {
+        workDir = Files.createTempDirectory("aura-bootstrap-test-")
+        confFile = workDir / ".aura-launcher.conf"
+    }
+
+    @AfterTest
+    fun teardown() {
+        Files.walk(workDir).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+    }
+
+    @Test
+    fun `read on missing file — returns empty map, doesn't throw`() {
+        assertEquals(emptyMap(), BootstrapConf.read(confFile))
+    }
+
+    @Test
+    fun `write then read — round-trips known keys`() {
+        BootstrapConf.write(mapOf(
+            BootstrapConf.KEY_DATA_DIR to "/tmp/custom-aura-data",
+        ), confFile)
+
+        val read = BootstrapConf.read(confFile)
+        assertEquals("/tmp/custom-aura-data", read[BootstrapConf.KEY_DATA_DIR])
+    }
+
+    @Test
+    fun `write skips blank values`() {
+        BootstrapConf.write(mapOf(
+            BootstrapConf.KEY_DATA_DIR to "/tmp/data",
+            BootstrapConf.KEY_PENDING_SOURCE to "",
+            BootstrapConf.KEY_PENDING_TARGET to "   ",
+        ), confFile)
+
+        val read = BootstrapConf.read(confFile)
+        assertEquals(1, read.size, "blank values must not be persisted")
+        assertEquals("/tmp/data", read[BootstrapConf.KEY_DATA_DIR])
+    }
+
+    @Test
+    fun `malformed lines are silently ignored`() {
+        Files.writeString(confFile, """
+            data-dir=/tmp/valid
+            this-line-has-no-equals
+            =leading-equals-value
+            # comment-style line
+            data-dir-pending-source=/tmp/old
+        """.trimIndent())
+
+        val read = BootstrapConf.read(confFile)
+        assertEquals(2, read.size, "only well-formed key=value lines kept")
+        assertEquals("/tmp/valid", read[BootstrapConf.KEY_DATA_DIR])
+        assertEquals("/tmp/old", read[BootstrapConf.KEY_PENDING_SOURCE])
+    }
+
+    @Test
+    fun `update reads, mutates, writes back`() {
+        BootstrapConf.write(mapOf(BootstrapConf.KEY_DATA_DIR to "/tmp/v1"), confFile)
+
+        BootstrapConf.update(confFile) { it[BootstrapConf.KEY_DATA_DIR] = "/tmp/v2" }
+
+        assertEquals("/tmp/v2", BootstrapConf.read(confFile)[BootstrapConf.KEY_DATA_DIR])
+    }
+
+    @Test
+    fun `update can remove keys`() {
+        BootstrapConf.write(mapOf(
+            BootstrapConf.KEY_DATA_DIR to "/tmp/data",
+            BootstrapConf.KEY_PENDING_SOURCE to "/tmp/old",
+        ), confFile)
+
+        BootstrapConf.update(confFile) { it.remove(BootstrapConf.KEY_PENDING_SOURCE) }
+
+        val read = BootstrapConf.read(confFile)
+        assertEquals("/tmp/data", read[BootstrapConf.KEY_DATA_DIR])
+        assertNull(read[BootstrapConf.KEY_PENDING_SOURCE])
+    }
+
+    @Test
+    fun `write creates parent directory if missing`() {
+        val nested = workDir / "sub" / "dir" / ".aura-launcher.conf"
+        BootstrapConf.write(mapOf(BootstrapConf.KEY_DATA_DIR to "/tmp/x"), nested)
+        assertTrue(Files.exists(nested))
+        assertEquals("/tmp/x", BootstrapConf.read(nested)[BootstrapConf.KEY_DATA_DIR])
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/platform/DataDirMoverTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/platform/DataDirMoverTest.kt
@@ -1,0 +1,163 @@
+package hivens.launcher.platform
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.div
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DataDirMoverTest {
+
+    private lateinit var workDir: Path
+    private lateinit var confFile: Path
+    private lateinit var source: Path
+    private lateinit var target: Path
+
+    @BeforeTest
+    fun setup() {
+        workDir = Files.createTempDirectory("aura-mover-test-")
+        confFile = workDir / "bootstrap.conf"
+        source = workDir / "source"
+        target = workDir / "target"
+        Files.createDirectories(source)
+        // Populate source with a couple of nested files to exercise the
+        // recursive copy.
+        Files.createDirectories(source / "subdir")
+        Files.writeString(source / "credentials.json", """{"username":"test"}""")
+        Files.writeString(source / "subdir" / "nested.txt", "nested content")
+    }
+
+    @AfterTest
+    fun teardown() {
+        Files.walk(workDir).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+    }
+
+    // ── schedule() ────────────────────────────────────────────────────────
+
+    @Test
+    fun `schedule writes pending source and target to conf`() {
+        assertTrue(DataDirMover.schedule(source, target, confFile))
+
+        val conf = BootstrapConf.read(confFile)
+        assertEquals(source.toAbsolutePath().toString(), conf[BootstrapConf.KEY_PENDING_SOURCE])
+        assertEquals(target.toAbsolutePath().toString(), conf[BootstrapConf.KEY_PENDING_TARGET])
+        // data-dir key NOT yet set — only on successful apply.
+        assertNull(conf[BootstrapConf.KEY_DATA_DIR])
+    }
+
+    @Test
+    fun `schedule refuses same source and target (no-op)`() {
+        assertFalse(DataDirMover.schedule(source, source, confFile))
+        assertEquals(emptyMap(), BootstrapConf.read(confFile))
+    }
+
+    @Test
+    fun `schedule refuses target inside source (would recurse during copy)`() {
+        val nested = source / "subdir-as-new-data"
+        assertFalse(DataDirMover.schedule(source, nested, confFile))
+        assertEquals(emptyMap(), BootstrapConf.read(confFile))
+    }
+
+    // ── applyPending() ────────────────────────────────────────────────────
+
+    @Test
+    fun `applyPending copies tree, deletes source, commits new data-dir`() {
+        DataDirMover.schedule(source, target, confFile)
+        DataDirMover.applyPending(confFile)
+
+        // Target has the files
+        assertTrue(Files.exists(target / "credentials.json"))
+        assertEquals("""{"username":"test"}""", Files.readString(target / "credentials.json"))
+        assertTrue(Files.exists(target / "subdir" / "nested.txt"))
+        assertEquals("nested content", Files.readString(target / "subdir" / "nested.txt"))
+
+        // Source is gone
+        assertFalse(Files.exists(source))
+
+        // Conf reflects committed state — pending cleared, data-dir set
+        val conf = BootstrapConf.read(confFile)
+        assertEquals(target.toAbsolutePath().toString(), conf[BootstrapConf.KEY_DATA_DIR])
+        assertNull(conf[BootstrapConf.KEY_PENDING_SOURCE])
+        assertNull(conf[BootstrapConf.KEY_PENDING_TARGET])
+    }
+
+    @Test
+    fun `applyPending when no pending is recorded — no-op`() {
+        // Empty conf — should silently do nothing.
+        DataDirMover.applyPending(confFile)
+        // Source untouched.
+        assertTrue(Files.exists(source / "credentials.json"))
+        assertFalse(Files.exists(target))
+    }
+
+    @Test
+    fun `applyPending is idempotent — source already moved, commits target as data-dir`() {
+        // Simulate: previous apply succeeded for the copy but crashed
+        // before clearing pending markers. On re-run, source is gone but
+        // target has the data.
+        DataDirMover.schedule(source, target, confFile)
+        Files.createDirectories(target)
+        Files.writeString(target / "credentials.json", """{"username":"test"}""")
+        Files.walk(source).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+
+        DataDirMover.applyPending(confFile)
+
+        val conf = BootstrapConf.read(confFile)
+        assertEquals(target.toAbsolutePath().toString(), conf[BootstrapConf.KEY_DATA_DIR])
+        assertNull(conf[BootstrapConf.KEY_PENDING_SOURCE])
+    }
+
+    @Test
+    fun `applyPending refuses to overwrite populated target — clears pending`() {
+        DataDirMover.schedule(source, target, confFile)
+        // Pre-populate target with unrelated data.
+        Files.createDirectories(target)
+        Files.writeString(target / "stranger.txt", "this is not Aura's data")
+
+        DataDirMover.applyPending(confFile)
+
+        // Source untouched
+        assertTrue(Files.exists(source / "credentials.json"))
+        // Target stranger file untouched
+        assertEquals("this is not Aura's data", Files.readString(target / "stranger.txt"))
+        // Aura files NOT copied into target (refused)
+        assertFalse(Files.exists(target / "credentials.json"))
+        // Pending cleared so we don't infinitely retry
+        val conf = BootstrapConf.read(confFile)
+        assertNull(conf[BootstrapConf.KEY_PENDING_SOURCE])
+        assertNull(conf[BootstrapConf.KEY_DATA_DIR], "no commit on refused apply")
+    }
+
+    @Test
+    fun `PlatformPaths picks up data-dir from bootstrap conf override`() {
+        val custom = workDir / "custom-data-dir"
+        BootstrapConf.write(mapOf(BootstrapConf.KEY_DATA_DIR to custom.toString()), confFile)
+
+        val pp = PlatformPaths(
+            osName = "Linux",
+            home = workDir,
+            env = { null }, // no AURA_DATA_DIR
+            bootstrapDataDir = { BootstrapConf.read(confFile)[BootstrapConf.KEY_DATA_DIR]?.let { java.nio.file.Paths.get(it) } },
+        )
+        assertEquals(custom, pp.dataDir)
+    }
+
+    @Test
+    fun `AURA_DATA_DIR env wins over bootstrap conf override`() {
+        BootstrapConf.write(mapOf(BootstrapConf.KEY_DATA_DIR to "/tmp/conf-side"), confFile)
+        val envOverride = workDir / "env-side"
+
+        val pp = PlatformPaths(
+            osName = "Linux",
+            home = workDir,
+            env = { if (it == "AURA_DATA_DIR") envOverride.toString() else null },
+            bootstrapDataDir = { BootstrapConf.read(confFile)[BootstrapConf.KEY_DATA_DIR]?.let { java.nio.file.Paths.get(it) } },
+        )
+        assertEquals(envOverride, pp.dataDir)
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -160,6 +160,14 @@ private fun setLinuxXToolkitAppClassName(name: String) {
 
 @OptIn(ExperimentalResourceApi::class, DelicateCoroutinesApi::class)
 fun main() {
+    // BEFORE PlatformPaths resolution: apply any pending data-dir move
+    // scheduled from the Settings UI. If user clicked "Move data
+    // directory" → picker → restart, this is where the relocation
+    // actually happens. Bootstrap conf reads + file ops only; no logger
+    // initialised yet at this point so failures land in stderr.
+    // Operation is idempotent; safe to call on every startup.
+    hivens.launcher.platform.DataDirMover.applyPending()
+
     // Resolve logs dir BEFORE any LoggerFactory.getLogger() call so logback.xml
     // (which reads `${aura.logs.dir}` for its rolling-file appenders) sees the
     // platform-correct path on its very first init. The first getLogger we

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -354,6 +354,19 @@ interface AppStrings {
     /** Receives a pre-formatted local date/time string. */
     fun sslBypassExpiresAt(formatted: String): String
 
+    // --- Data directory (Settings → Data dir) ---
+    val settingsSectionDataDir: String
+    val settingsDataDirCurrent: String
+    val settingsDataDirMove: String
+    val settingsDataDirPickerTitle: String
+    val settingsDataDirConfirmTitle: String
+    /** Templated body: receives source and target paths. */
+    fun settingsDataDirConfirmBody(source: String, target: String): String
+    val settingsDataDirRestartRequired: String
+    val settingsDataDirQuitNow: String
+    val settingsDataDirErrorSamePath: String
+    val settingsDataDirErrorNotEmpty: String
+
     // ═══════════════════════════════════════════════════════════════════════
     // JVM Args Builder dialog
     // ═══════════════════════════════════════════════════════════════════════

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -350,6 +350,18 @@ object EnglishStrings : AppStrings {
     override val sslBypassRevoke        = "Revoke"
     override fun sslBypassExpiresAt(formatted: String) = "Expires: $formatted"
 
+    override val settingsSectionDataDir       = "Data directory"
+    override val settingsDataDirCurrent       = "Current path:"
+    override val settingsDataDirMove          = "Move..."
+    override val settingsDataDirPickerTitle   = "Choose a new location for Aura data"
+    override val settingsDataDirConfirmTitle  = "Move data directory?"
+    override fun settingsDataDirConfirmBody(source: String, target: String) =
+        "Aura will relocate its data:\nfrom: $source\nto:   $target\n\nThe move applies on the next launcher start."
+    override val settingsDataDirRestartRequired = "Restart required — Aura will apply the move on next start"
+    override val settingsDataDirQuitNow         = "Quit now"
+    override val settingsDataDirErrorSamePath   = "That's already the current directory — pick a different folder"
+    override val settingsDataDirErrorNotEmpty   = "Target folder is not empty — pick an empty folder or delete its contents"
+
     // ── JVM Args Builder ────────────────────────────────────────────────
     override val jvmTitle    = "JVM Args Builder"
     override val jvmSubtitle = "Pick a preset or compose flags by hand. The result lands in jvmArgs."

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -350,6 +350,18 @@ object GermanStrings : AppStrings {
     override val sslBypassRevoke        = "Widerrufen"
     override fun sslBypassExpiresAt(formatted: String) = "Läuft ab: $formatted"
 
+    override val settingsSectionDataDir       = "Datenverzeichnis"
+    override val settingsDataDirCurrent       = "Aktueller Pfad:"
+    override val settingsDataDirMove          = "Verschieben..."
+    override val settingsDataDirPickerTitle   = "Neuen Speicherort für Aura-Daten wählen"
+    override val settingsDataDirConfirmTitle  = "Datenverzeichnis verschieben?"
+    override fun settingsDataDirConfirmBody(source: String, target: String) =
+        "Aura wird die Daten verschieben:\nvon: $source\nnach: $target\n\nDie Verschiebung wird beim nächsten Start angewendet."
+    override val settingsDataDirRestartRequired = "Neustart erforderlich — Aura wendet die Verschiebung beim nächsten Start an"
+    override val settingsDataDirQuitNow         = "Jetzt beenden"
+    override val settingsDataDirErrorSamePath   = "Das ist bereits das aktuelle Verzeichnis — wähle einen anderen Ordner"
+    override val settingsDataDirErrorNotEmpty   = "Zielordner ist nicht leer — wähle einen leeren Ordner oder lösche dessen Inhalt"
+
     // ── JVM Args Builder ────────────────────────────────────────────────
     override val jvmTitle    = "JVM-Argument-Builder"
     override val jvmSubtitle = "Wähle ein Preset oder stelle Flags manuell zusammen. Das Ergebnis landet in jvmArgs."

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -350,6 +350,18 @@ object RussianStrings : AppStrings {
     override val sslBypassRevoke        = "Отозвать"
     override fun sslBypassExpiresAt(formatted: String) = "Истекает: $formatted"
 
+    override val settingsSectionDataDir       = "Каталог данных"
+    override val settingsDataDirCurrent       = "Текущий путь:"
+    override val settingsDataDirMove          = "Переместить..."
+    override val settingsDataDirPickerTitle   = "Выбери новое место для данных Aura"
+    override val settingsDataDirConfirmTitle  = "Переместить каталог данных?"
+    override fun settingsDataDirConfirmBody(source: String, target: String) =
+        "Aura перенесёт данные:\nиз: $source\nв:  $target\n\nПеремещение применится при перезапуске лаунчера."
+    override val settingsDataDirRestartRequired = "Требуется перезапуск — Aura применит перемещение при следующем старте"
+    override val settingsDataDirQuitNow         = "Выйти сейчас"
+    override val settingsDataDirErrorSamePath   = "Это и есть текущий каталог — выбери другую папку"
+    override val settingsDataDirErrorNotEmpty   = "Целевая папка не пуста — выбери пустую папку или удали её содержимое"
+
     // ── JVM Args Builder ────────────────────────────────────────────────
     override val jvmTitle    = "Конструктор JVM-аргументов"
     override val jvmSubtitle = "Выбери пресет или собери флаги вручную. Результат запишется в jvmArgs."

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
@@ -19,6 +19,10 @@ import hivens.config.Branding
 import hivens.core.api.interfaces.ISettingsService
 import hivens.launcher.diag.DiagnosticBundle
 import hivens.launcher.platform.PlatformPaths
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.openDirectoryPicker
+import io.github.vinceglb.filekit.path
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import hivens.ui.components.GlassCard
@@ -495,18 +499,17 @@ fun SettingsScreen(
                             onClick = {
                                 showError = null
                                 moveScope.launch {
-                                    val picked = withContext(kotlinx.coroutines.Dispatchers.IO) {
-                                        runCatching {
-                                            val chooser = javax.swing.JFileChooser().apply {
-                                                fileSelectionMode  = javax.swing.JFileChooser.DIRECTORIES_ONLY
-                                                dialogTitle        = s.settingsDataDirPickerTitle
-                                                isMultiSelectionEnabled = false
-                                            }
-                                            if (chooser.showOpenDialog(null) == javax.swing.JFileChooser.APPROVE_OPTION) {
-                                                chooser.selectedFile?.toPath()
-                                            } else null
-                                        }.getOrNull()
-                                    } ?: return@launch
+                                    // filekit uses xdg-desktop-portal on Linux
+                                    // (your native Hyprland / KDE / GNOME picker),
+                                    // IFileDialog on Windows, NSOpenPanel on macOS.
+                                    // No Metal LAF eyesore.
+                                    val pickedFile = runCatching {
+                                        FileKit.openDirectoryPicker(
+                                            directory = PlatformFile(paths.dataDir.toFile()),
+                                        )
+                                    }.getOrNull() ?: return@launch
+
+                                    val picked = java.nio.file.Paths.get(pickedFile.path)
 
                                     if (picked.toAbsolutePath().normalize() == paths.dataDir.toAbsolutePath().normalize()) {
                                         showError = s.settingsDataDirErrorSamePath

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
@@ -458,6 +458,121 @@ fun SettingsScreen(
                     )
                 }
 
+                // ── Data directory (move to a different drive / folder) ───────
+                //
+                // Schedule-on-restart move via DataDirMover. The actual file
+                // copy happens on next launcher start (BEFORE PlatformPaths
+                // is consulted) so we don't have to fight Windows lock
+                // semantics or coordinate with background tasks. The UI here
+                // just persists the intent and prompts the user to restart.
+                item {
+                    SettingsSectionTitle(s.settingsSectionDataDir)
+
+                    var pendingTarget by remember { mutableStateOf<java.nio.file.Path?>(null) }
+                    var showError     by remember { mutableStateOf<String?>(null) }
+                    val moveScope     = rememberCoroutineScope()
+
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(CelestiaTheme.colors.background.copy(alpha = 0.4f))
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        Text(
+                            text  = s.settingsDataDirCurrent,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = CelestiaTheme.colors.textSecondary,
+                        )
+                        Text(
+                            text       = paths.dataDir.toAbsolutePath().toString(),
+                            color      = CelestiaTheme.colors.textPrimary,
+                            fontWeight = FontWeight.SemiBold,
+                            style      = MaterialTheme.typography.bodyMedium,
+                        )
+                        OutlinedButton(
+                            onClick = {
+                                showError = null
+                                moveScope.launch {
+                                    val picked = withContext(kotlinx.coroutines.Dispatchers.IO) {
+                                        runCatching {
+                                            val chooser = javax.swing.JFileChooser().apply {
+                                                fileSelectionMode  = javax.swing.JFileChooser.DIRECTORIES_ONLY
+                                                dialogTitle        = s.settingsDataDirPickerTitle
+                                                isMultiSelectionEnabled = false
+                                            }
+                                            if (chooser.showOpenDialog(null) == javax.swing.JFileChooser.APPROVE_OPTION) {
+                                                chooser.selectedFile?.toPath()
+                                            } else null
+                                        }.getOrNull()
+                                    } ?: return@launch
+
+                                    if (picked.toAbsolutePath().normalize() == paths.dataDir.toAbsolutePath().normalize()) {
+                                        showError = s.settingsDataDirErrorSamePath
+                                        return@launch
+                                    }
+                                    val populated = withContext(kotlinx.coroutines.Dispatchers.IO) {
+                                        runCatching {
+                                            java.nio.file.Files.exists(picked) &&
+                                                java.nio.file.Files.list(picked).use { it.findAny().isPresent }
+                                        }.getOrDefault(false)
+                                    }
+                                    if (populated) {
+                                        showError = s.settingsDataDirErrorNotEmpty
+                                        return@launch
+                                    }
+                                    pendingTarget = picked
+                                }
+                            },
+                            shape = RoundedCornerShape(6.dp),
+                        ) {
+                            Text(s.settingsDataDirMove, color = CelestiaTheme.colors.textPrimary)
+                        }
+                        if (showError != null) {
+                            Text(
+                                text  = showError!!,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color(0xFFEF4444),
+                            )
+                        }
+                    }
+
+                    if (pendingTarget != null) {
+                        val target = pendingTarget!!
+                        AlertDialog(
+                            onDismissRequest = { pendingTarget = null },
+                            title = { Text(s.settingsDataDirConfirmTitle) },
+                            text  = {
+                                Text(s.settingsDataDirConfirmBody(
+                                    paths.dataDir.toAbsolutePath().toString(),
+                                    target.toAbsolutePath().toString(),
+                                ))
+                            },
+                            confirmButton = {
+                                Button(onClick = {
+                                    val ok = hivens.launcher.platform.DataDirMover.schedule(
+                                        source = paths.dataDir,
+                                        target = target,
+                                    )
+                                    if (ok) {
+                                        hivens.core.diag.ActionRing.record(
+                                            "Data-dir move scheduled: ${paths.dataDir} → $target (applies on next start)",
+                                        )
+                                    }
+                                    pendingTarget = null
+                                }) { Text(s.settingsDataDirRestartRequired) }
+                            },
+                            dismissButton = {
+                                OutlinedButton(onClick = { pendingTarget = null }) {
+                                    Text(s.sslWarningCancel)
+                                }
+                            },
+                            containerColor = CelestiaTheme.colors.surface,
+                        )
+                    }
+                }
+
                 // ── Diagnostics ───────────────────────────────────────────────
                 item {
                     // Secret: tap the diagnostics title 5 times to toggle the April Fools debug panel

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
@@ -560,11 +560,22 @@ fun SettingsScreen(
                                     )
                                     if (ok) {
                                         hivens.core.diag.ActionRing.record(
-                                            "Data-dir move scheduled: ${paths.dataDir} → $target (applies on next start)",
+                                            "Data-dir move scheduled: ${paths.dataDir} → $target — quitting for restart",
                                         )
+                                        // Hard exit — user explicitly clicked "Quit now". Avoids the
+                                        // tray-shutdown path that might re-show the window if a game
+                                        // is mid-launch. The pending move only applies AFTER the
+                                        // launcher restarts, so a clean process termination is the
+                                        // right move.
+                                        kotlin.system.exitProcess(0)
+                                    } else {
+                                        // Schedule was refused (target validations failed at the
+                                        // mover layer — e.g., race with another process touching
+                                        // the target between our UI check and DataDirMover.schedule).
+                                        // Close the dialog so the user can pick a different target.
+                                        pendingTarget = null
                                     }
-                                    pendingTarget = null
-                                }) { Text(s.settingsDataDirRestartRequired) }
+                                }) { Text(s.settingsDataDirQuitNow) }
                             },
                             dismissButton = {
                                 OutlinedButton(onClick = { pendingTarget = null }) {


### PR DESCRIPTION
## Summary

Bridge pillar UX completion (Void chunk #3 of 5 still due). Replaces the "set `AURA_DATA_DIR` env by hand and restart" workflow with a real Settings UI that picks a target directory, schedules the move, and applies it on next launcher start.

## Why schedule-on-restart, not live move

Live move during a running launcher would race with single-instance lock, credentials file handles, rolling log appenders, AutoSync writer, etc. On Windows, files held open can't be deleted from underneath the JVM. So the UI just persists intent; the move runs at startup BEFORE any subsystem has touched the data dir.

## Three new components

| Component | Role |
|---|---|
| `BootstrapConf` | Flat key=value file at `<user.home>/.aura-launcher.conf`. Lives outside data dir so the launcher finds overrides BEFORE knowing where data dir is. Keys: `data-dir`, `data-dir-pending-source`, `data-dir-pending-target`. |
| `DataDirMover` | `schedule(src, target)` writes pending markers; `applyPending()` executes copy + verify + delete + commit on next startup. Idempotent (partial failures keep markers for retry). Refuses same-path, target-inside-source, and populated-target. |
| `PlatformPaths` | New resolution: `AURA_DATA_DIR` env → BootstrapConf data-dir → per-OS default. |

`Main.kt` calls `DataDirMover.applyPending()` BEFORE `PlatformPaths` constructor — that's the only safe slot for the actual file copy.

## UI

New section "Data directory" between Experimental and Diagnostics:
- Current dataDir display
- "Move..." → `javax.swing.JFileChooser` in DIRECTORIES_ONLY mode (cross-platform, no extra deps)
- Validation: same-path rejection, populated-target rejection
- Confirm dialog with source + target + restart-required wording
- ActionRing entry on schedule for diagnostic forensics

10 new i18n keys × 3 locales (RU/EN/DE).

## Test coverage — 16 new

`BootstrapConfTest` (7):
- read on missing file → empty map (no throw)
- write/read round-trip
- blank-value skip
- malformed-line ignore
- `update()` mutate-and-write
- parent-dir auto-create

`DataDirMoverTest` (9):
- `schedule()` writes pending, refuses same-path, refuses nested
- `applyPending()` full move with verify-by-count
- Idempotent re-run on already-moved source (commits target as data-dir)
- Refused on populated target → pending cleared, no commit
- No-op when no pending recorded
- PlatformPaths integration: AURA_DATA_DIR env beats bootstrap conf
- bootstrap conf beats per-OS default

## Constructor change

`PlatformPaths` gained `bootstrapDataDir: () -> Path?` parameter (default reads `BootstrapConf`). Reordered before `env` to keep trailing-lambda binding to env at callsites; existing `PlatformPathsTest` cases unchanged.

## Test plan

- [x] `:client-launcher:test` — 16 new + existing all green
- [x] `:client-core:test` — green
- [x] `:client-ui:compileKotlinDesktop` — green
- [ ] Manual UX verification next time launcher runs from source
- [ ] Qodana

## Void status after this merge

Bridge pillar UX completion shipped. Remaining Void scope:
- Vault macOS keyring (blocked on OSX-KVM)
- libtray + dorkbox replacement
- Distro portability tests
- Big-service test backfill