### PR TITLE
ci(release): macOS DMG dual-arch matrix + arch-aware UpdateService

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -349,12 +349,32 @@ jobs:
           path: AuraLauncher-${{ env.APP_VERSION }}-x86_64.AppImage
 
   # ─────────────────────────────────────────────────────────────────────────
-  # MACOS — DMG
+  # MACOS — DMG, both architectures
+  #
+  # Compose Desktop's `packageReleaseDmg` produces a host-architecture
+  # DMG. macos-latest runners are Apple Silicon since the GH Actions
+  # migration in 2024-2025, so building only there left Intel Mac users
+  # (pre-2020 hardware) with a binary they literally cannot launch — they
+  # see "not supported on this Mac" before Gatekeeper even fires.
+  #
+  # Dual matrix: macos-latest (Apple Silicon → aarch64) + macos-13 (Intel
+  # → x86_64). Two DMGs ship alongside each other; users pick by their
+  # CPU. Universal-binary path via lipo would be cleaner UX but Compose
+  # Desktop nativeDistributions has no out-of-box support; revisit when
+  # we have a reason to prioritise that.
   # ─────────────────────────────────────────────────────────────────────────
   build-macos:
-    name: macOS (DMG)
-    runs-on: macos-latest
+    name: macOS (DMG, ${{ matrix.arch }})
     needs: changelog
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest    # Apple Silicon (M1+)
+            arch: aarch64
+          - os: macos-13        # Last Intel runner image GH actively maintains
+            arch: x86_64
+    runs-on: ${{ matrix.os }}
     env:
       APP_VERSION: ${{ needs.changelog.outputs.version }}
     steps:
@@ -370,15 +390,17 @@ jobs:
       - name: Build DMG
         run: ./gradlew :client-ui:packageReleaseDmg -PappVersion="$APP_VERSION"
 
-      - name: Rename DMG
+      - name: Rename DMG with architecture suffix
         run: |
           mv client-ui/build/compose/binaries/main-release/dmg/*.dmg \
-             "AuraLauncher-$APP_VERSION.dmg"
+             "AuraLauncher-$APP_VERSION-${{ matrix.arch }}.dmg"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: macos-artifacts
-          path: AuraLauncher-${{ env.APP_VERSION }}.dmg
+          # Per-arch artifact name — actions/upload-artifact v4 refuses to
+          # upload twice under the same name from different matrix jobs.
+          name: macos-artifacts-${{ matrix.arch }}
+          path: AuraLauncher-${{ env.APP_VERSION }}-${{ matrix.arch }}.dmg
 
   # ─────────────────────────────────────────────────────────────────────────
   # RELEASE — collect artifacts, publish with proper changelog body
@@ -401,7 +423,11 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          pattern: '*-artifacts'
+          # Pattern broadened from `*-artifacts` to `*-artifacts*` so the
+          # per-arch macOS suffixes (macos-artifacts-aarch64,
+          # macos-artifacts-x86_64) get pulled in alongside the Win/Linux
+          # ones. merge-multiple flattens them into a single dist/.
+          pattern: '*-artifacts*'
           merge-multiple: true
           path: dist/
 
@@ -432,6 +458,8 @@ jobs:
               *Setup.exe)             plat=windows; kind=installer ;;
               *Windows-Portable.zip)  plat=windows; kind=portable  ;;
               *.AppImage)             plat=linux;   kind=appimage  ;;
+              *aarch64.dmg)           plat=macos;   kind=dmg-arm64 ;;
+              *x86_64.dmg)            plat=macos;   kind=dmg-intel ;;
               *.dmg)                  plat=macos;   kind=dmg       ;;
               *)                      plat=unknown; kind=unknown   ;;
             esac

--- a/client-launcher/src/main/kotlin/hivens/launcher/update/UpdateService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/update/UpdateService.kt
@@ -406,18 +406,36 @@ class UpdateService(
      * Selects the correct installer asset for the current OS.
      *
      * Windows: `.exe`  (Inno Setup — see setup.iss / build_release.yml)
-     * macOS:   `.dmg`
+     * macOS:   `-aarch64.dmg` on Apple Silicon, `-x86_64.dmg` on Intel.
+     *          Falls back to any `.dmg` for legacy pre-dual-arch releases
+     *          (i.e. ≤ 2.2.12 which shipped a single ARM64-only DMG).
      * Linux:   `.AppImage`
      */
     internal fun findAssetForCurrentOS(assets: List<GitHubAsset>): GitHubAsset? {
         val osName = System.getProperty("os.name").lowercase()
-        
+
         return when {
             // FIX: was .msi — CI builds .exe via Inno Setup, not MSI
             osName.contains("windows") -> assets.find {
                 it.name.endsWith(".exe") && it.name.contains("Setup", ignoreCase = true)
             }
-            osName.contains("mac") -> assets.find { it.name.endsWith(".dmg") }
+            osName.contains("mac") -> {
+                // Picking the first .dmg blindly was the bug pre-#89: dual-arch
+                // releases ship both aarch64 and x86_64; whichever came first
+                // alphabetically was returned, leaving Intel users with an
+                // ARM64 DMG that fails with "not supported on this Mac" before
+                // Gatekeeper even fires. Match on arch first.
+                val arch = System.getProperty("os.arch", "").lowercase()
+                val archSuffix = when {
+                    arch.contains("aarch64") || arch.contains("arm64") -> "aarch64.dmg"
+                    else -> "x86_64.dmg"
+                }
+                assets.find { it.name.endsWith(archSuffix) }
+                    // Legacy fallback for releases predating dual-arch
+                    // (single .dmg with no arch suffix). Will return wrong
+                    // arch in degraded cases but better than no update at all.
+                    ?: assets.find { it.name.endsWith(".dmg") }
+            }
             osName.contains("linux") -> assets.find { it.name.endsWith(".AppImage") }
             else -> null
         }

--- a/client-launcher/src/test/kotlin/hivens/launcher/update/UpdateServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/update/UpdateServiceTest.kt
@@ -252,6 +252,77 @@ class UpdateServiceTest {
         }
     }
 
+    @Test
+    fun `findAssetForCurrentOS picks aarch64 DMG on Apple Silicon (dual-arch release)`() {
+        val svc = createService("{}")
+        val originalOs = System.getProperty("os.name")
+        val originalArch = System.getProperty("os.arch")
+        try {
+            System.setProperty("os.name", "Mac OS X")
+            System.setProperty("os.arch", "aarch64")
+            val assets = listOf(
+                GitHubAsset("AuraLauncher-3.0.0-aarch64.dmg", "https://example.com/arm", 80_000_000),
+                GitHubAsset("AuraLauncher-3.0.0-x86_64.dmg",  "https://example.com/intel", 80_000_000),
+            )
+            assertEquals(
+                "AuraLauncher-3.0.0-aarch64.dmg",
+                svc.findAssetForCurrentOS(assets)?.name,
+                "Apple Silicon must NOT receive the x86_64 DMG (would fail with 'not supported on this Mac')",
+            )
+        } finally {
+            System.setProperty("os.name", originalOs)
+            System.setProperty("os.arch", originalArch)
+        }
+    }
+
+    @Test
+    fun `findAssetForCurrentOS picks x86_64 DMG on Intel Mac (dual-arch release)`() {
+        val svc = createService("{}")
+        val originalOs = System.getProperty("os.name")
+        val originalArch = System.getProperty("os.arch")
+        try {
+            System.setProperty("os.name", "Mac OS X")
+            System.setProperty("os.arch", "x86_64")
+            val assets = listOf(
+                GitHubAsset("AuraLauncher-3.0.0-aarch64.dmg", "https://example.com/arm", 80_000_000),
+                GitHubAsset("AuraLauncher-3.0.0-x86_64.dmg",  "https://example.com/intel", 80_000_000),
+            )
+            assertEquals(
+                "AuraLauncher-3.0.0-x86_64.dmg",
+                svc.findAssetForCurrentOS(assets)?.name,
+                "Intel Mac must NOT receive the aarch64 DMG (Rosetta only goes x86_64 → arm, not arm → x86_64)",
+            )
+        } finally {
+            System.setProperty("os.name", originalOs)
+            System.setProperty("os.arch", originalArch)
+        }
+    }
+
+    @Test
+    fun `findAssetForCurrentOS falls back to single dmg for legacy pre-dual-arch releases`() {
+        val svc = createService("{}")
+        val originalOs = System.getProperty("os.name")
+        val originalArch = System.getProperty("os.arch")
+        try {
+            System.setProperty("os.name", "Mac OS X")
+            System.setProperty("os.arch", "x86_64")
+            // Legacy release (≤ 2.2.12) shipped a single DMG with no arch suffix —
+            // updater must still find it for backward compatibility, even if the
+            // resulting binary may be wrong-arch on some hosts. Better than no
+            // update at all.
+            val assets = listOf(
+                GitHubAsset("AuraLauncher-2.2.11.dmg", "https://example.com/legacy", 80_000_000),
+            )
+            assertEquals(
+                "AuraLauncher-2.2.11.dmg",
+                svc.findAssetForCurrentOS(assets)?.name,
+            )
+        } finally {
+            System.setProperty("os.name", originalOs)
+            System.setProperty("os.arch", originalArch)
+        }
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // extractChecksum
     // ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/compose-release-body.sh
+++ b/scripts/compose-release-body.sh
@@ -57,7 +57,8 @@ done < "$CHECKSUMS_FILE"
   printf '| Windows Installer | [`AuraLauncher-%s-Setup.exe`](%s/AuraLauncher-%s-Setup.exe) |\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
   printf '| Windows Portable  | [`AuraLauncher-%s-Windows-Portable.zip`](%s/AuraLauncher-%s-Windows-Portable.zip) |\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
   printf '| Linux AppImage    | [`AuraLauncher-%s-x86_64.AppImage`](%s/AuraLauncher-%s-x86_64.AppImage) |\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
-  printf '| macOS             | [`AuraLauncher-%s.dmg`](%s/AuraLauncher-%s.dmg) |\n\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
+  printf '| macOS Apple Silicon | [`AuraLauncher-%s-aarch64.dmg`](%s/AuraLauncher-%s-aarch64.dmg) |\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
+  printf '| macOS Intel       | [`AuraLauncher-%s-x86_64.dmg`](%s/AuraLauncher-%s-x86_64.dmg) |\n\n' "$APP_VERSION" "$REPO_BASE" "$APP_VERSION"
 
   printf '<details>\n<summary>SHA256 Checksums</summary>\n\n'
   printf '| File | SHA256 |\n|---|---|\n'

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -132,11 +132,12 @@ check_asset() {
     fi
 }
 
-check_asset "Setup\.exe$"     "Windows Installer (.exe)"
-check_asset "Portable\.zip$"  "Windows Portable (.zip)"
-check_asset "\.AppImage$"     "Linux AppImage"
-check_asset "\.dmg$"          "macOS DMG"
-check_asset "SHA256SUMS"      "SHA256 checksums file"
+check_asset "Setup\.exe$"      "Windows Installer (.exe)"
+check_asset "Portable\.zip$"   "Windows Portable (.zip)"
+check_asset "\.AppImage$"      "Linux AppImage"
+check_asset "aarch64\.dmg$"    "macOS DMG (Apple Silicon)"
+check_asset "x86_64\.dmg$"     "macOS DMG (Intel)"
+check_asset "SHA256SUMS"       "SHA256 checksums file"
 
 echo ""
 


### PR DESCRIPTION
## Summary

Closes the Intel-Mac gap that has existed since 2.2.7. Previously CI built only on `macos-latest` (= Apple Silicon since the GH Actions runner migration), so the shipped DMG was ARM64-only. Intel Mac users (and Intel-emulated VMs like OSX-KVM) hit "not supported on this Mac" before Gatekeeper even fires — Rosetta 2 only translates the other direction (Apple Silicon → x86_64), not arm → x86_64.

Discovery context: developer set up OSX-KVM to verify our claim of "the only macOS-supporting launcher in the SmartyCraft ecosystem", and v2.2.11 DMG flat-out refused to launch.

## Changes

| File | Change |
|---|---|
| `build_release.yml` | `build-macos` becomes a 2-entry matrix: `macos-latest` (aarch64) + `macos-13` (x86_64). Per-arch upload-artifact name (v4 refuses same-name across matrix). Release job download pattern broadened from `*-artifacts` to `*-artifacts*`. release-manifest.json gains `dmg-arm64` / `dmg-intel` kind values. |
| `UpdateService.findAssetForCurrentOS` | Was picking the first `.dmg` blindly, which on dual-arch releases would non-deterministically hand wrong-arch DMG to half the user base. Now reads `os.arch` and matches `aarch64.dmg` / `x86_64.dmg`. Falls back to bare `.dmg` for legacy pre-2.2.13 releases. |
| `compose-release-body.sh` | Release notes table now lists both DMGs as separate rows ("macOS Apple Silicon" / "macOS Intel"). |
| `verify-release.sh` | Checks for both arch suffixes; fails verification if either is missing. |

## Test coverage

3 new `UpdateServiceTest` cases (52 total now):
- aarch64 host with dual-arch release → picks `aarch64.dmg`
- x86_64 host with dual-arch release → picks `x86_64.dmg`
- legacy single `.dmg` only → fallback works

`System.setProperty/restore` in finally block to simulate both architectures from any test host (no need for actual Mac in CI matrix to validate selection logic).

## NOT in scope (followup task #90)

DMG visual styling refresh. Compose Desktop's default DMG window (folder + dragged Applications icon) is dated per user feedback; that's a separate UX chunk.

## Test plan

- [x] `:client-launcher:test` — 52 UpdateService tests, 3 new for arch selection
- [x] `:client-core:test` — green
- [x] YAML parses, matrix evaluates correctly
- [ ] Real CI run with dual matrix on next tag push (sanity that both Mac runners build successfully)
- [ ] Qodana