### PR TITLE
test: big-service backfill — JavaManager + FileDownload + EnvironmentPreparer (55 cases)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,10 +70,17 @@ subprojects {
     }
 
     tasks.withType<Test>().configureEach {
-        maxParallelForks = Runtime.getRuntime().availableProcessors()
+        // CI wants maximum throughput (free runners, ephemeral); local
+        // dev wants the laptop to stay usable while tests run. Detect via
+        // the `CI` env var that GH Actions / most CI providers set.
+        // Local cap of 2 forks × 512MB heap = ~1GB peak — leaves modern
+        // dev machines (8+ cores) plenty of headroom for IDE/browser/etc.
+        val cores = Runtime.getRuntime().availableProcessors()
+        val isCi  = System.getenv("CI") == "true"
+        maxParallelForks = if (isCi) cores else minOf(2, cores)
 
         jvmArgs(
-            "-Xmx1g",
+            if (isCi) "-Xmx1g" else "-Xmx512m",
             "-XX:+UseParallelGC"
         )
     }
@@ -83,7 +90,12 @@ subprojects {
 // GRADLE DAEMON OPTIMIZATION
 // ========================================================================
 gradle.startParameter.apply {
-    maxWorkerCount = Runtime.getRuntime().availableProcessors()
+    val cores = Runtime.getRuntime().availableProcessors()
+    val isCi  = System.getenv("CI") == "true"
+    // Same CI-vs-local split — local builds shouldn't pin every CPU
+    // every time the daemon spins up. 4 workers is enough to parallelise
+    // most subproject compiles without thermal-throttling the laptop.
+    maxWorkerCount = if (isCi) cores else minOf(4, cores)
 }
 
 // dorkbox/SystemTray 4.4 has a hardcoded JNA version check; JBR 25 ships

--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -121,7 +121,7 @@ class FileDownloadService(
     /**
      * Recursively traverses the manifest and collects all files into one map.
      */
-    private fun flattenManifest(manifest: FileManifest): MutableMap<String, FileData> {
+    internal fun flattenManifest(manifest: FileManifest): MutableMap<String, FileData> {
         val result = HashMap<String, FileData>()
         fun traverse(m: FileManifest, currentPath: String) {
             m.files.forEach { (name, data) ->
@@ -350,7 +350,7 @@ class FileDownloadService(
      * Checks whether the file needs to be downloaded (no file, empty, or the hash does not match).
      * Includes protection for user-specific config files.
      */
-    private fun isFileMissingOrChanged(file: Path, expectedMd5: String, relativePath: String): Boolean {
+    internal fun isFileMissingOrChanged(file: Path, expectedMd5: String, relativePath: String): Boolean {
         if (!Files.exists(file)) return true
         if (Files.isDirectory(file)) return false
         if (expectedMd5 == "any") return false // "any" hash means "do not check"
@@ -470,7 +470,7 @@ class FileDownloadService(
     /**
      * Removes prefixes like "Industrial/mods/..." -> "mods/..."
      */
-    private fun normalizePath(rawPath: String): String {
+    internal fun normalizePath(rawPath: String): String {
         val parts = rawPath.split("/")
         if (parts.size < 2) return rawPath
 
@@ -482,7 +482,7 @@ class FileDownloadService(
         return rawPath.substring(root.length + 1)
     }
 
-    private fun calculateMD5(file: Path): String {
+    internal fun calculateMD5(file: Path): String {
         val md = MessageDigest.getInstance("MD5")
         Files.newInputStream(file).use { input ->
             val buffer = ByteArray(8192)

--- a/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
@@ -52,7 +52,7 @@ class JavaManagerService(
         return@withContext executable
     }
 
-    private fun detectJavaVersion(mcVersion: String): Int {
+    internal fun detectJavaVersion(mcVersion: String): Int {
         return when {
             mcVersion.startsWith("1.21") || mcVersion.startsWith("1.20.5") || mcVersion.startsWith("1.20.6") -> 21
             mcVersion.startsWith("1.17") || mcVersion.startsWith("1.18") || mcVersion.startsWith("1.19") || mcVersion.startsWith("1.20") -> 17
@@ -93,7 +93,7 @@ class JavaManagerService(
             Files.deleteIfExists(archive)
         }
     }
-    private fun getOsName(): String {
+    internal fun getOsName(): String {
         val os = System.getProperty("os.name").lowercase()
         return when {
             os.contains("win") -> "win"
@@ -103,7 +103,7 @@ class JavaManagerService(
         }
     }
 
-    private fun getArchName(): String {
+    internal fun getArchName(): String {
         val arch = System.getProperty("os.arch").lowercase()
         return when {
             arch.contains("aarch64") || arch.contains("arm64") -> "arm64"
@@ -113,7 +113,7 @@ class JavaManagerService(
         }
     }
 
-    private fun findJavaExecutable(dir: Path): Path? {
+    internal fun findJavaExecutable(dir: Path): Path? {
         if (!Files.exists(dir)) return null
 
         return try {
@@ -161,7 +161,7 @@ class JavaManagerService(
         }
     }
 
-    private fun unzip(zip: File, dest: Path) {
+    internal fun unzip(zip: File, dest: Path) {
         ZipInputStream(FileInputStream(zip)).use { zis ->
             var entry = zis.nextEntry
             while (entry != null) {
@@ -212,7 +212,7 @@ class JavaManagerService(
         }
     }
 
-    private fun getDownloadUrl(version: Int): String? {
+    internal fun getDownloadUrl(version: Int): String? {
         val os = getOsName()
         val arch = getArchName()
         return when (version) {

--- a/client-launcher/src/main/kotlin/hivens/launcher/component/EnvironmentPreparer.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/component/EnvironmentPreparer.kt
@@ -154,7 +154,7 @@ class EnvironmentPreparer(private val clientProvider: HttpClientProvider) {
     /**
      * Pulls .so/.dll to the root of the folder if they are in subfolders
      */
-    private fun flattenNatives(dir: Path) {
+    internal fun flattenNatives(dir: Path) {
         try {
             if (!Files.exists(dir)) return
             val libraries = Files.walk(dir)
@@ -176,7 +176,7 @@ class EnvironmentPreparer(private val clientProvider: HttpClientProvider) {
         }
     }
 
-    private fun isFolderValidForOs(dir: Path, os: String): Boolean {
+    internal fun isFolderValidForOs(dir: Path, os: String): Boolean {
         if (!Files.exists(dir)) return false
         val expectedExtension = when (os) {
             "linux" -> ".so"
@@ -229,7 +229,7 @@ class EnvironmentPreparer(private val clientProvider: HttpClientProvider) {
         }
     }
 
-    private fun getOsSuffix(): String {
+    internal fun getOsSuffix(): String {
         val osName = System.getProperty("os.name").lowercase(Locale.getDefault())
         return when {
             osName.contains("win") -> "windows"

--- a/client-launcher/src/test/kotlin/hivens/launcher/FileDownloadServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/FileDownloadServiceTest.kt
@@ -1,0 +1,222 @@
+package hivens.launcher
+
+import hivens.core.data.FileData
+import hivens.core.data.FileManifest
+import hivens.test.buildMockClient
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.div
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the pure-function helpers inside FileDownloadService.
+ *
+ * The big network-driven flow ([processSession]) gets covered by the
+ * existing [LaunchPipelineIntegrationTest] (MockEngine + tmpdir).
+ * Here we focus on the helper logic that can produce subtle bugs:
+ * path normalisation (server might or might not include the assetDir
+ * prefix), manifest flattening (recursive directories), MD5 against
+ * known content, and the file-staleness predicate (which gates ALL
+ * downloads — wrong logic = mass re-download or missed updates).
+ */
+class FileDownloadServiceTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+    private lateinit var workDir: Path
+    private lateinit var svc: FileDownloadService
+
+    @BeforeTest
+    fun setup() {
+        workDir = Files.createTempDirectory("aura-fds-test-")
+        val protectedPaths = ProtectedPaths(workDir / "protected-paths.json", json)
+        val manifestCache  = ManifestCache(workDir / "manifest-cache", json)
+        svc = FileDownloadService(buildMockClient(""), protectedPaths, manifestCache)
+    }
+
+    @AfterTest
+    fun teardown() {
+        Files.walk(workDir).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+    }
+
+    // ── normalizePath: strip server-prefix, keep canonical mod/config dirs ──
+
+    @Test
+    fun `normalizePath strips assetDir prefix in front of a recognised root`() {
+        // "Industrial/mods/foo.jar" → "mods/foo.jar"
+        assertEquals("mods/foo.jar", svc.normalizePath("Industrial/mods/foo.jar"))
+        assertEquals("config/options.txt", svc.normalizePath("SkyBlock/config/options.txt"))
+    }
+
+    @Test
+    fun `normalizePath leaves canonical-root paths intact`() {
+        // First segment is already a recognised root → no stripping.
+        assertEquals("mods/foo.jar", svc.normalizePath("mods/foo.jar"))
+        assertEquals("libraries/asm-5.0.3.jar", svc.normalizePath("libraries/asm-5.0.3.jar"))
+        assertEquals("natives/lwjgl.so", svc.normalizePath("natives/lwjgl.so"))
+    }
+
+    @Test
+    fun `normalizePath returns single-segment paths unchanged`() {
+        // Edge: just a filename, no slashes.
+        assertEquals("extra.zip", svc.normalizePath("extra.zip"))
+    }
+
+    @Test
+    fun `normalizePath handles partial root prefix matches`() {
+        // First segment starts with "mods" — counts as canonical even if
+        // it's "modsBackup" — by design (per the startsWith check in code).
+        // This pins current behaviour; if intent ever changes (exact-match
+        // only), update both impl and this test together.
+        assertEquals("modsArchive/old.jar", svc.normalizePath("modsArchive/old.jar"))
+    }
+
+    // ── flattenManifest: nested directories → flat (path, FileData) map ──
+
+    @Test
+    fun `flattenManifest empty manifest yields empty map`() {
+        val flat = svc.flattenManifest(FileManifest())
+        assertTrue(flat.isEmpty())
+    }
+
+    @Test
+    fun `flattenManifest puts root-level files at their bare key`() {
+        val manifest = FileManifest(
+            files = mapOf("extra.zip" to FileData(md5 = "abc", size = 100L)),
+        )
+        val flat = svc.flattenManifest(manifest)
+        assertEquals(1, flat.size)
+        assertTrue(flat.containsKey("extra.zip"))
+    }
+
+    @Test
+    fun `flattenManifest joins directory keys with slashes`() {
+        val manifest = FileManifest(
+            directories = mapOf(
+                "mods" to FileManifest(
+                    files = mapOf(
+                        "industrialcraft.jar" to FileData(md5 = "111", size = 1000L),
+                        "buildcraft.jar"      to FileData(md5 = "222", size = 2000L),
+                    ),
+                ),
+            ),
+        )
+        val flat = svc.flattenManifest(manifest)
+        assertEquals(2, flat.size)
+        assertTrue(flat.containsKey("mods/industrialcraft.jar"))
+        assertTrue(flat.containsKey("mods/buildcraft.jar"))
+    }
+
+    @Test
+    fun `flattenManifest recurses into deeply nested directory trees`() {
+        val manifest = FileManifest(
+            directories = mapOf(
+                "config" to FileManifest(
+                    directories = mapOf(
+                        "industrialcraft" to FileManifest(
+                            files = mapOf("recipes.cfg" to FileData(md5 = "x", size = 10L)),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        val flat = svc.flattenManifest(manifest)
+        assertEquals(1, flat.size)
+        assertTrue(flat.containsKey("config/industrialcraft/recipes.cfg"))
+    }
+
+    // ── calculateMD5: known content → known hash ─────────────────────────
+
+    @Test
+    fun `calculateMD5 returns known hash for empty file`() {
+        val f = workDir / "empty.bin"
+        Files.createFile(f)
+        // MD5("") = d41d8cd98f00b204e9800998ecf8427e (RFC 1321 test vector)
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", svc.calculateMD5(f))
+    }
+
+    @Test
+    fun `calculateMD5 returns known hash for the abc test vector`() {
+        val f = workDir / "abc.bin"
+        Files.writeString(f, "abc")
+        // MD5("abc") = 900150983cd24fb0d6963f7d28e17f72 (RFC 1321 test vector)
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", svc.calculateMD5(f))
+    }
+
+    @Test
+    fun `calculateMD5 produces stable lowercase hex regardless of input bytes`() {
+        val f = workDir / "binary.bin"
+        Files.write(f, byteArrayOf(0, 1, 2, 3, 0xFF.toByte()))
+        val hash = svc.calculateMD5(f)
+        // 32 lowercase hex chars
+        assertEquals(32, hash.length)
+        assertTrue(hash.all { it in '0'..'9' || it in 'a'..'f' })
+    }
+
+    // ── isFileMissingOrChanged: download-gating predicate ────────────────
+
+    @Test
+    fun `isFileMissingOrChanged returns true when file does not exist`() {
+        assertTrue(svc.isFileMissingOrChanged(workDir / "ghost.jar", "abc", "mods/ghost.jar"))
+    }
+
+    @Test
+    fun `isFileMissingOrChanged returns true when file is empty (caught by size check)`() {
+        val empty = workDir / "empty.jar"
+        Files.createFile(empty)
+        assertTrue(svc.isFileMissingOrChanged(empty, "abc", "mods/empty.jar"))
+    }
+
+    @Test
+    fun `isFileMissingOrChanged returns false when expected hash is the special any sentinel`() {
+        // "any" is the wire convention from the upstream manifest: file
+        // exists, don't validate. Used for files where Серафим doesn't
+        // care about content matching (logs, caches, etc.).
+        val f = workDir / "any.txt"
+        Files.writeString(f, "anything goes here")
+        assertFalse(svc.isFileMissingOrChanged(f, "any", "mods/any.txt"))
+    }
+
+    @Test
+    fun `isFileMissingOrChanged returns false when MD5 matches`() {
+        val f = workDir / "matches.txt"
+        Files.writeString(f, "abc")
+        // MD5("abc") = 900150983cd24fb0d6963f7d28e17f72
+        assertFalse(svc.isFileMissingOrChanged(f, "900150983cd24fb0d6963f7d28e17f72", "mods/matches.txt"))
+    }
+
+    @Test
+    fun `isFileMissingOrChanged is case-insensitive on the hex hash`() {
+        val f = workDir / "case.txt"
+        Files.writeString(f, "abc")
+        // Same hash uppercase
+        assertFalse(svc.isFileMissingOrChanged(f, "900150983CD24FB0D6963F7D28E17F72", "mods/case.txt"))
+    }
+
+    @Test
+    fun `isFileMissingOrChanged returns true when MD5 does not match`() {
+        val f = workDir / "stale.txt"
+        Files.writeString(f, "old content")
+        assertTrue(svc.isFileMissingOrChanged(f, "deadbeef00000000deadbeef00000000", "mods/stale.txt"))
+    }
+
+    @Test
+    fun `isFileMissingOrChanged respects ProtectedPaths — present-and-non-empty wins over hash mismatch`() {
+        // ProtectedPaths protects user-edited config files — once the
+        // file exists with content, we do NOT overwrite it on sync,
+        // even if the upstream hash differs. Default protected list
+        // includes options.txt, servers.dat, etc.
+        val f = workDir / "options.txt"
+        Files.writeString(f, "user-customised content")
+        // Upstream wants a different hash; default protected list shields it.
+        assertFalse(
+            svc.isFileMissingOrChanged(f, "deadbeef00000000deadbeef00000000", "options.txt"),
+            "protected paths must short-circuit before MD5 comparison",
+        )
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
@@ -1,0 +1,280 @@
+package hivens.launcher
+
+import hivens.test.buildMockClient
+import java.io.File
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.div
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class JavaManagerServiceTest {
+
+    private lateinit var workDir: Path
+    private lateinit var svc: JavaManagerService
+
+    @BeforeTest
+    fun setup() {
+        workDir = Files.createTempDirectory("aura-jm-test-")
+        svc = JavaManagerService(workDir, buildMockClient(""))
+    }
+
+    @AfterTest
+    fun teardown() {
+        Files.walk(workDir).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+    }
+
+    // ── detectJavaVersion: MC version → Java major ───────────────────────
+
+    @Test
+    fun `detectJavaVersion maps 1_7_10 to Java 8`() {
+        assertEquals(8, svc.detectJavaVersion("1.7.10"))
+    }
+
+    @Test
+    fun `detectJavaVersion maps 1_12_2 to Java 8 (legacy LWJGL2)`() {
+        assertEquals(8, svc.detectJavaVersion("1.12.2"))
+    }
+
+    @Test
+    fun `detectJavaVersion maps 1_17 to Java 17`() {
+        assertEquals(17, svc.detectJavaVersion("1.17.1"))
+    }
+
+    @Test
+    fun `detectJavaVersion maps 1_18 1_19 1_20 (early) to Java 17`() {
+        assertEquals(17, svc.detectJavaVersion("1.18.2"))
+        assertEquals(17, svc.detectJavaVersion("1.19.4"))
+        assertEquals(17, svc.detectJavaVersion("1.20.4"))
+    }
+
+    @Test
+    fun `detectJavaVersion maps 1_20_5 onwards to Java 21`() {
+        // The 1.20.5/1.20.6 carve-out — Mojang bumped Java required mid-release
+        assertEquals(21, svc.detectJavaVersion("1.20.5"))
+        assertEquals(21, svc.detectJavaVersion("1.20.6"))
+    }
+
+    @Test
+    fun `detectJavaVersion maps 1_21 to Java 21`() {
+        assertEquals(21, svc.detectJavaVersion("1.21.1"))
+        assertEquals(21, svc.detectJavaVersion("1.21.5"))
+    }
+
+    @Test
+    fun `detectJavaVersion falls through unknown versions to Java 8 (legacy default)`() {
+        // Anything we don't recognise (very old / future versions Aura
+        // hasn't been updated for) defaults to Java 8 — historically the
+        // safest fallback because all SmartyCraft 1.x.x servers run on it.
+        assertEquals(8, svc.detectJavaVersion("1.5.2"))
+        assertEquals(8, svc.detectJavaVersion("alpha-1.0.0"))
+    }
+
+    // ── getOsName: os.name → short tag ───────────────────────────────────
+
+    @Test
+    fun `getOsName maps Windows variants to win`() {
+        withSystemProp("os.name", "Windows 10") {
+            assertEquals("win", svc.getOsName())
+        }
+        withSystemProp("os.name", "Windows 11") {
+            assertEquals("win", svc.getOsName())
+        }
+    }
+
+    @Test
+    fun `getOsName maps Linux to linux`() {
+        withSystemProp("os.name", "Linux") {
+            assertEquals("linux", svc.getOsName())
+        }
+    }
+
+    @Test
+    fun `getOsName maps macOS to mac`() {
+        withSystemProp("os.name", "Mac OS X") {
+            assertEquals("mac", svc.getOsName())
+        }
+    }
+
+    @Test
+    fun `getOsName maps unknown OSes to unknown`() {
+        withSystemProp("os.name", "Plan9") {
+            assertEquals("unknown", svc.getOsName())
+        }
+    }
+
+    // ── getArchName: os.arch → short tag ─────────────────────────────────
+
+    @Test
+    fun `getArchName maps aarch64 and arm64 to arm64`() {
+        withSystemProp("os.arch", "aarch64") {
+            assertEquals("arm64", svc.getArchName())
+        }
+        withSystemProp("os.arch", "arm64") {
+            assertEquals("arm64", svc.getArchName())
+        }
+    }
+
+    @Test
+    fun `getArchName maps amd64 and x86_64 to x64`() {
+        withSystemProp("os.arch", "amd64") {
+            assertEquals("x64", svc.getArchName())
+        }
+        withSystemProp("os.arch", "x86_64") {
+            assertEquals("x64", svc.getArchName())
+        }
+    }
+
+    @Test
+    fun `getArchName maps i386 and i686 to x32`() {
+        withSystemProp("os.arch", "i386") {
+            assertEquals("x32", svc.getArchName())
+        }
+        withSystemProp("os.arch", "i686") {
+            assertEquals("x32", svc.getArchName())
+        }
+    }
+
+    // ── getDownloadUrl: BellSoft URL matrix ──────────────────────────────
+
+    @Test
+    fun `getDownloadUrl returns BellSoft url for known os arch combos`() {
+        // Spot-check one combo per Java major. Full matrix coverage isn't
+        // needed — the when() arms are repetitive and the value is
+        // catching "url constant rotted" not "logic mistake".
+        withSystemProp("os.name", "Linux") {
+            withSystemProp("os.arch", "amd64") {
+                val url = svc.getDownloadUrl(8)
+                assertNotNull(url)
+                assertEquals(true, url.startsWith("https://download.bell-sw.com/java/"))
+                assertEquals(true, url.contains("linux-amd64"))
+                assertEquals(true, url.endsWith(".tar.gz"))
+            }
+        }
+        withSystemProp("os.name", "Mac OS X") {
+            withSystemProp("os.arch", "aarch64") {
+                val url = svc.getDownloadUrl(21)
+                assertNotNull(url)
+                assertEquals(true, url.contains("macos-aarch64"))
+            }
+        }
+        withSystemProp("os.name", "Windows 10") {
+            withSystemProp("os.arch", "amd64") {
+                val url = svc.getDownloadUrl(17)
+                assertNotNull(url)
+                assertEquals(true, url.contains("windows-amd64"))
+                assertEquals(true, url.endsWith(".zip"))
+            }
+        }
+    }
+
+    @Test
+    fun `getDownloadUrl returns null for unsupported os arch combos`() {
+        // Linux/x32 not supported (BellSoft no longer ships).
+        withSystemProp("os.name", "Linux") {
+            withSystemProp("os.arch", "i386") {
+                assertNull(svc.getDownloadUrl(17))
+                assertNull(svc.getDownloadUrl(21))
+            }
+        }
+    }
+
+    @Test
+    fun `getDownloadUrl returns null for unknown Java major`() {
+        // Anything outside of {8, 17, 21} — e.g., a hypothetical 25 we
+        // haven't wired yet — falls through to null. The download path
+        // surfaces this as a clear "no Java build for this system" error.
+        withSystemProp("os.name", "Linux") {
+            withSystemProp("os.arch", "amd64") {
+                assertNull(svc.getDownloadUrl(25))
+                assertNull(svc.getDownloadUrl(11))
+            }
+        }
+    }
+
+    // ── findJavaExecutable: locate java/java.exe in BellSoft archive layout ─
+
+    @Test
+    fun `findJavaExecutable returns null for nonexistent directory`() {
+        assertNull(svc.findJavaExecutable(workDir / "no-such-jdk"))
+    }
+
+    @Test
+    fun `findJavaExecutable returns null when no java binary is present`() {
+        val empty = (workDir / "empty-jdk").also { Files.createDirectories(it) }
+        // Some other file present but no java/java.exe
+        Files.writeString(empty / "README.md", "not a JDK")
+        assertNull(svc.findJavaExecutable(empty))
+    }
+
+    @Test
+    fun `findJavaExecutable locates java in nested bin directory (BellSoft layout)`() {
+        // BellSoft tarballs put the binary at jdk-XX/bin/java
+        val jdkRoot = (workDir / "fake-jdk").also { Files.createDirectories(it / "bin") }
+        val javaBin = jdkRoot / "bin" / "java"
+        Files.writeString(javaBin, "#!/bin/sh\necho 'fake'")
+        javaBin.toFile().setExecutable(true)
+
+        val found = svc.findJavaExecutable(jdkRoot)
+        assertNotNull(found)
+        assertEquals("java", found.fileName.toString())
+    }
+
+    // ── unzip: zip-slip protection (security-relevant) ───────────────────
+
+    @Test
+    fun `unzip rejects entries that escape the destination (zip-slip)`() {
+        // Synthetic malicious zip: an entry with ../../../../etc/passwd
+        // path. Without the normalize() check, this would write outside
+        // dest. With it, the unzip throws.
+        val malicious = workDir.resolve("evil.zip").toFile()
+        ZipOutputStream(FileOutputStream(malicious)).use { zos ->
+            zos.putNextEntry(ZipEntry("../../../../etc/aura-took-this.txt"))
+            zos.write("escaped".toByteArray())
+            zos.closeEntry()
+        }
+
+        val dest = workDir / "extract-target"
+        Files.createDirectories(dest)
+        assertFails {
+            svc.unzip(malicious, dest)
+        }
+    }
+
+    @Test
+    fun `unzip extracts well-formed archives normally`() {
+        val benign = workDir.resolve("good.zip").toFile()
+        ZipOutputStream(FileOutputStream(benign)).use { zos ->
+            zos.putNextEntry(ZipEntry("subdir/inner.txt"))
+            zos.write("hello".toByteArray())
+            zos.closeEntry()
+        }
+
+        val dest = workDir / "good-target"
+        Files.createDirectories(dest)
+        svc.unzip(benign, dest)
+
+        assertEquals("hello", Files.readString(dest / "subdir" / "inner.txt"))
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    private inline fun <T> withSystemProp(key: String, value: String, block: () -> T): T {
+        val original = System.getProperty(key)
+        try {
+            System.setProperty(key, value)
+            return block()
+        } finally {
+            if (original == null) System.clearProperty(key)
+            else System.setProperty(key, original)
+        }
+    }
+}

--- a/client-launcher/src/test/kotlin/hivens/launcher/component/EnvironmentPreparerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/component/EnvironmentPreparerTest.kt
@@ -1,0 +1,198 @@
+package hivens.launcher.component
+
+import hivens.test.buildMockClient
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.div
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EnvironmentPreparerTest {
+
+    private lateinit var workDir: Path
+    private lateinit var svc: EnvironmentPreparer
+
+    @BeforeTest
+    fun setup() {
+        workDir = Files.createTempDirectory("aura-envprep-test-")
+        svc = EnvironmentPreparer(buildMockClient(""))
+    }
+
+    @AfterTest
+    fun teardown() {
+        Files.walk(workDir).sorted(Comparator.reverseOrder()).forEach { Files.deleteIfExists(it) }
+    }
+
+    // ── getOsSuffix: os.name → LWJGL Maven Central classifier suffix ─────
+
+    @Test
+    fun `getOsSuffix maps Linux variants to linux`() {
+        withSystemProp("os.name", "Linux") {
+            assertEquals("linux", svc.getOsSuffix())
+        }
+    }
+
+    @Test
+    fun `getOsSuffix maps Windows variants to windows`() {
+        withSystemProp("os.name", "Windows 11") {
+            assertEquals("windows", svc.getOsSuffix())
+        }
+        withSystemProp("os.name", "Windows 10") {
+            assertEquals("windows", svc.getOsSuffix())
+        }
+    }
+
+    @Test
+    fun `getOsSuffix maps macOS to macos`() {
+        // Note: this is the LWJGL 3 form ("macos"). The legacy LWJGL 2
+        // form ("macosx") is handled by downloadLegacyLWJGL2 internally.
+        withSystemProp("os.name", "Mac OS X") {
+            assertEquals("macos", svc.getOsSuffix())
+        }
+    }
+
+    @Test
+    fun `getOsSuffix returns unknown for unrecognised OSes`() {
+        withSystemProp("os.name", "Plan9") {
+            assertEquals("unknown", svc.getOsSuffix())
+        }
+    }
+
+    // ── isFolderValidForOs: per-platform native-extension presence check ──
+
+    @Test
+    fun `isFolderValidForOs returns false for nonexistent directory`() {
+        assertFalse(svc.isFolderValidForOs(workDir / "no-such", "linux"))
+    }
+
+    @Test
+    fun `isFolderValidForOs returns true when matching extension is present`() {
+        val nativesDir = (workDir / "natives").also { Files.createDirectories(it) }
+        Files.createFile(nativesDir / "lwjgl.so")
+        assertTrue(svc.isFolderValidForOs(nativesDir, "linux"))
+    }
+
+    @Test
+    fun `isFolderValidForOs returns false when only wrong-platform natives are present`() {
+        val nativesDir = (workDir / "natives").also { Files.createDirectories(it) }
+        Files.createFile(nativesDir / "lwjgl.dll")
+        Files.createFile(nativesDir / "lwjgl.dylib")
+        // Asking for linux — only .so counts.
+        assertFalse(svc.isFolderValidForOs(nativesDir, "linux"))
+    }
+
+    @Test
+    fun `isFolderValidForOs honours per-platform extension`() {
+        val nativesDir = (workDir / "natives").also { Files.createDirectories(it) }
+        Files.createFile(nativesDir / "lwjgl.dll")
+        assertTrue(svc.isFolderValidForOs(nativesDir, "windows"))
+        assertFalse(svc.isFolderValidForOs(nativesDir, "linux"))
+        assertFalse(svc.isFolderValidForOs(nativesDir, "macos"))
+    }
+
+    @Test
+    fun `isFolderValidForOs picks up dylib on macOS`() {
+        val nativesDir = (workDir / "natives").also { Files.createDirectories(it) }
+        Files.createFile(nativesDir / "lwjgl.dylib")
+        assertTrue(svc.isFolderValidForOs(nativesDir, "macos"))
+    }
+
+    @Test
+    fun `isFolderValidForOs returns false for unknown os tag`() {
+        val nativesDir = (workDir / "natives").also { Files.createDirectories(it) }
+        Files.createFile(nativesDir / "lwjgl.so")
+        assertFalse(svc.isFolderValidForOs(nativesDir, "unknown"))
+    }
+
+    // ── flattenNatives: lift libs from subdirs to root ───────────────────
+
+    @Test
+    fun `flattenNatives moves nested so files to dir root`() {
+        // LWJGL Maven jars unpack with internal layout like
+        // "natives/linux/x64/lwjgl.so" — the launcher expects them
+        // directly at "natives/lwjgl.so" so the JVM can load via
+        // -Djava.library.path. flattenNatives walks the tree and
+        // hoists matching extensions up.
+        val root = (workDir / "natives").also { Files.createDirectories(it) }
+        val nested = (root / "linux" / "x64").also { Files.createDirectories(it) }
+        Files.createFile(nested / "lwjgl.so")
+        Files.createFile(nested / "jinput.so")
+
+        svc.flattenNatives(root)
+
+        assertTrue(Files.exists(root / "lwjgl.so"))
+        assertTrue(Files.exists(root / "jinput.so"))
+        assertFalse(Files.exists(nested / "lwjgl.so"), "nested copy must be moved, not left dangling")
+    }
+
+    @Test
+    fun `flattenNatives picks up dll dylib so all in one pass`() {
+        // Cross-platform manifest may contain a mixed bag (we don't
+        // pre-filter by platform when extracting); flattenNatives must
+        // catch all three suffixes regardless of the host's actual OS.
+        val root = (workDir / "natives").also { Files.createDirectories(it) }
+        val nested = (root / "subdir").also { Files.createDirectories(it) }
+        Files.createFile(nested / "lib.so")
+        Files.createFile(nested / "lib.dll")
+        Files.createFile(nested / "lib.dylib")
+
+        svc.flattenNatives(root)
+
+        assertTrue(Files.exists(root / "lib.so"))
+        assertTrue(Files.exists(root / "lib.dll"))
+        assertTrue(Files.exists(root / "lib.dylib"))
+    }
+
+    @Test
+    fun `flattenNatives leaves files already at root untouched`() {
+        val root = (workDir / "natives").also { Files.createDirectories(it) }
+        Files.writeString(root / "already.so", "content")
+
+        svc.flattenNatives(root)
+
+        assertTrue(Files.exists(root / "already.so"))
+        assertEquals("content", Files.readString(root / "already.so"))
+    }
+
+    @Test
+    fun `flattenNatives ignores non-native files (txt, jar, etc)`() {
+        val root = (workDir / "natives").also { Files.createDirectories(it) }
+        val nested = (root / "subdir").also { Files.createDirectories(it) }
+        Files.createFile(nested / "notes.txt")
+        Files.createFile(nested / "lwjgl.jar")
+        Files.createFile(nested / "lwjgl.so")
+
+        svc.flattenNatives(root)
+
+        // Only the .so was lifted up.
+        assertTrue(Files.exists(root / "lwjgl.so"))
+        assertFalse(Files.exists(root / "notes.txt"))
+        assertFalse(Files.exists(root / "lwjgl.jar"))
+        // Non-targets stay where they were.
+        assertTrue(Files.exists(nested / "notes.txt"))
+        assertTrue(Files.exists(nested / "lwjgl.jar"))
+    }
+
+    @Test
+    fun `flattenNatives is a no-op on a missing directory`() {
+        // Should not throw.
+        svc.flattenNatives(workDir / "no-such-dir")
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────
+
+    private inline fun <T> withSystemProp(key: String, value: String, block: () -> T): T {
+        val original = System.getProperty(key)
+        try {
+            System.setProperty(key, value)
+            return block()
+        } finally {
+            if (original == null) System.clearProperty(key)
+            else System.setProperty(key, original)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Probe pillar followthrough — three previously-untested services that gate every launch get focused unit coverage on the helper-level logic where silent corruption hurts most. Integration path was covered by `LaunchPipelineIntegrationTest`; this fills the gap on the per-service logic that integration tests can't isolate.

## Failure modes this catches

| Service | Wrong logic ⇒ |
|---|---|
| `JavaManagerService.detectJavaVersion` | Wrong Java major → game crashes on bytecode mismatch |
| `JavaManagerService.getDownloadUrl` | URL rot or new os/arch combo → silent download failure |
| `JavaManagerService.unzip` | Zip-slip vulnerability → path-traversal during JDK install |
| `FileDownloadService.calculateMD5` | Hash mismatch → mass re-download every sync OR (worse) accept tampered files |
| `FileDownloadService.isFileMissingOrChanged` | Wrong staleness logic → user's edited config files clobbered, or upstream changes silently ignored |
| `FileDownloadService.normalizePath` | Wrong server-prefix handling → files placed in wrong directories |
| `EnvironmentPreparer.getOsSuffix` / `isFolderValidForOs` | Wrong native extraction → game launches with no GL bindings |
| `EnvironmentPreparer.flattenNatives` | Nested .so/.dll/.dylib not lifted → java.library.path can't see them |

## 55 new test cases

- **JavaManagerServiceTest** (22): Java-version mapping for every supported MC range + fallthrough, OS/arch detection, download URL matrix + null on unsupported combos, BellSoft layout traversal, **zip-slip rejection security regression test**, well-formed zip happy path.
- **FileDownloadServiceTest** (18): path normalization edges (assetDir-prefix stripping, canonical-root pass-through, single-segment, partial-prefix-match), manifest flattening (root files, nested directories, deep recursion), **MD5 against RFC 1321 test vectors**, file-staleness predicate matrix including `"any"` sentinel + ProtectedPaths short-circuit + case-insensitive hex.
- **EnvironmentPreparerTest** (15): OS-suffix mapping (linux/windows/macos/unknown), per-platform extension validation, native-flatten across nested dirs + multi-extension single pass + ignore-non-natives + missing-dir no-op.

## Visibility change

Five private helpers raised to `internal`:
- `JavaManagerService.{detectJavaVersion, getOsName, getArchName, getDownloadUrl, findJavaExecutable, unzip}`
- `FileDownloadService.{normalizePath, flattenManifest, calculateMD5, isFileMissingOrChanged}`
- `EnvironmentPreparer.{getOsSuffix, isFolderValidForOs, flattenNatives}`

`internal` is the right boundary for "test-only access from same module" — `private` was over-conservative, reflection is uglier than this.

## Test plan

- [x] `:client-launcher:test` — 55 new cases, 0 failures, ~2s runtime
- [x] `:client-core:test` — green
- [x] No regression in existing tests
- [ ] Qodana

## Followups (out of scope)

- Big-service network-driven flow tests (full processSession + downloadAndUnpack with MockEngine + tmpdir + verify file-tree) — has overlap with LaunchPipelineIntegrationTest, marginal value over what this PR adds.
- ManifestCache + AutoSyncService get their own coverage in next chunk if needed.