### PR TITLE
fix(proguard): silence Panama MethodHandle.invokeExact warnings

### DIFF
--- a/client-ui/compose-desktop.pro
+++ b/client-ui/compose-desktop.pro
@@ -94,6 +94,15 @@
 # --- System tray ---
 -keep class dorkbox.** { *; }
 
+# --- Project Panama foreign-function call sites ---
+# Classes that call MethodHandle.invokeExact(...) with java.lang.foreign.*
+# arguments. The method is @PolymorphicSignature — the JVM accepts any
+# descriptor at the call site, but ProGuard sees a concrete signature and
+# can't find it on java.lang.invoke.MethodHandle. List each class explicitly
+# so adding a new Panama caller is a deliberate edit, not silent suppression.
+-dontwarn hivens.launcher.security.LinuxLibsecretKeyringStorage
+-dontwarn hivens.launcher.security.WindowsCredentialManagerKeyringStorage
+
 # --- Suppress Warnings ---
 -dontwarn ch.qos.logback.**
 -dontwarn org.slf4j.**


### PR DESCRIPTION
## Summary
Block on the v2.2.12 release pipeline. ProGuard's Initializer can't resolve `MethodHandle.invokeExact(MemorySegment, ...)` calls in the new Vault keyring impls because the method is `@PolymorphicSignature` — the JVM accepts any descriptor at the call site, but ProGuard sees a concrete signature and aborts:

```
Warning: hivens.launcher.security.LinuxLibsecretKeyringStorage:
  can't find referenced method 'boolean invokeExact(MemorySegment, ...)'
  in library class java.lang.invoke.MethodHandle
Warning: there were 8 unresolved references to library class members.
java.io.IOException: Please correct the above warnings first.
```

## Fix
Add `-dontwarn` for the two Panama call sites explicitly, with a comment that documents WHY (so adding a new Panama caller is a deliberate edit, not silent suppression):

```
-dontwarn hivens.launcher.security.LinuxLibsecretKeyringStorage
-dontwarn hivens.launcher.security.WindowsCredentialManagerKeyringStorage
```

Reproduced locally: `./gradlew :client-ui:proguardReleaseJars` → BUILD SUCCESSFUL after fix.

## Recovery plan
After merge: delete tag `v2.2.12` (no GitHub Release was published — `publish-release` job depends on the build legs that failed), re-tag `v2.2.12` at the new stable HEAD, release pipeline re-runs.

## Test plan
- [x] `./gradlew :client-ui:proguardReleaseJars` green locally.
- [ ] CI release pipeline re-runs after re-tag, all 5 artifacts produced.