### PR TITLE
ci(release): soft-fail macOS x86_64 leg

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -362,6 +362,14 @@ jobs:
   # CPU. Universal-binary path via lipo would be cleaner UX but Compose
   # Desktop nativeDistributions has no out-of-box support; revisit when
   # we have a reason to prioritise that.
+  #
+  # x86_64 is best-effort on free tier: macos-13 is the last Intel image
+  # GH still maintains and its concurrency pool is shrinking — queue
+  # times of 12+ hours have been observed during US workday peaks. We
+  # set `continue-on-error: true` for that arm so the release publishes
+  # with the aarch64 DMG (plus Win/Linux) even when x86_64 starves; the
+  # missing Intel build can be added later via a manual workflow run
+  # once the runner is available. aarch64 stays hard-required.
   # ─────────────────────────────────────────────────────────────────────────
   build-macos:
     name: macOS (DMG, ${{ matrix.arch }})
@@ -375,6 +383,7 @@ jobs:
           - os: macos-13        # Last Intel runner image GH actively maintains
             arch: x86_64
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.arch == 'x86_64' }}
     env:
       APP_VERSION: ${{ needs.changelog.outputs.version }}
     steps:


### PR DESCRIPTION
## Summary
Unblocks v2.2.12 publish. macos-13 (last Intel runner image GitHub still maintains) sits 12+ hours in queue on free-tier during US workday peaks. Currently blocking the v2.2.12 release pipeline behind it — all other 9 jobs green, just x86_64 starving.

## Fix
One line: `continue-on-error: ${{ matrix.arch == 'x86_64' }}` on the build-macos job. With this:
- aarch64 stays hard-required — failure blocks publish.
- x86_64 failure (or starvation cancellation) is "ignored" by the matrix's overall conclusion.
- Release publishes with whatever artifacts arrived: aarch64 DMG + Windows EXE/ZIP + Linux AppImage.
- Intel DMG can be added retroactively via manual workflow run once macos-13 frees up (or next release once monthly minutes reset).

## Recovery sequence after merge
1. Delete tag v2.2.12.
2. Re-tag v2.2.12 at new stable HEAD.
3. Pipeline re-runs. macos-13 will likely starve again, but publish-release won't wait for it — release ships with 4 artifacts.
4. After macOS x86_64 minute pool resets (or runner availability returns), trigger workflow_dispatch on build_release.yml manually for tag v2.2.12 to add the Intel DMG to the existing release.

## Test plan
- [ ] CI re-runs after re-tag.
- [ ] Release publishes with at least 4 artifacts (Win .exe, Win .zip, Linux AppImage, macOS aarch64 DMG).
- [ ] Intel DMG added later — separate operation, not blocking.