### PR TITLE
feat(tray): replace dorkbox/SystemTray with libtray + 2FA cached-session fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,13 @@ val appVersion = providers.gradleProperty("appVersion")
 allprojects {
     repositories {
         mavenCentral()
+        // libtray ships from local Maven cache during the integration
+        // window — published via `./gradlew publishToMavenLocal` in the
+        // sibling repo. Switches to mavenCentral coordinates once libtray
+        // cuts its first tagged release. Dev-only repo at the bottom of
+        // the resolution chain so a stale local copy can't shadow a real
+        // central artifact.
+        mavenLocal()
     }
     version = appVersion
     group = "hivens"
@@ -98,14 +105,8 @@ gradle.startParameter.apply {
     maxWorkerCount = if (isCi) cores else minOf(4, cores)
 }
 
-// dorkbox/SystemTray 4.4 has a hardcoded JNA version check; JBR 25 ships
-// JNA 7.x natively. Pin the global resolution to whatever the catalog says.
-val pinnedJnaVersion = libs.versions.jna.get()
-configurations.all {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "net.java.dev.jna") {
-            useVersion(pinnedJnaVersion)
-            because("dorkbox/SystemTray requires exactly JNA $pinnedJnaVersion")
-        }
-    }
-}
+// JNA pin removed alongside dorkbox/SystemTray (replaced by libtray, the
+// pure-Panama tray library at github.com/Kitty-Hivens/libtray). The
+// pin existed only to satisfy dorkbox's hardcoded JNA version check;
+// libtray uses java.lang.foreign and never pulls in net.java.dev.jna.
+// JBR 25's bundled JNA 7.x can resolve naturally now.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,13 +32,12 @@ val appVersion = providers.gradleProperty("appVersion")
 allprojects {
     repositories {
         mavenCentral()
-        // libtray ships from local Maven cache during the integration
-        // window — published via `./gradlew publishToMavenLocal` in the
-        // sibling repo. Switches to mavenCentral coordinates once libtray
-        // cuts its first tagged release. Dev-only repo at the bottom of
-        // the resolution chain so a stale local copy can't shadow a real
-        // central artifact.
-        mavenLocal()
+        // libtray (Kitty-Hivens/libtray) is consumed via JitPack until it
+        // cuts a real Maven Central release. Pinned by commit sha in
+        // libs.versions.toml so an upstream main-branch break doesn't
+        // silently drift the build. Switches to mavenCentral coordinates
+        // once libtray ships 0.1.0 + verifies its sonatype namespace.
+        maven { url = uri("https://jitpack.io") }
     }
     version = appVersion
     group = "hivens"

--- a/client-launcher/src/main/kotlin/hivens/launcher/AutoSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/AutoSyncService.kt
@@ -122,23 +122,34 @@ class AutoSyncService(
                 totalBytes = 0,
             )
 
-            val ok = runCatching {
-                val session = try {
-                    authService.login(creds.playerName, pass, server.assetDir)
-                } catch (_: hivens.core.api.TwoFactorRequiredException) {
-                    // 2FA account — fall back to the cached manifest from
-                    // the last successful online sync. Auto-sync is best-
-                    // effort: serving stale-but-valid data on a 2FA account
-                    // is strictly better than failing every server every
-                    // launcher start (which would also trigger a 2FA
-                    // prompt the user didn't ask for). If no cache yet,
-                    // skip this server — the runCatching captures it as a
-                    // sync failure, which is the right signal for the
-                    // dashboard.
-                    val cached = manifestCache.loadManifest(server.assetDir)
-                        ?: throw IllegalStateException("2FA account, no cached manifest for ${server.assetDir}")
+            // Try to obtain a SessionData for this server. Three outcomes:
+            //   * regular login → use that session directly
+            //   * 2FA gate WITH cached manifest → use cached creds + manifest
+            //   * 2FA gate WITHOUT cached manifest → mark SKIPPED (not failed)
+            //     and move on. This isn't a failure — the account just hasn't
+            //     been through 2FA on this machine for this server yet, so
+            //     we have nothing to sync against. Red FAILED would imply
+            //     "server is broken"; SKIPPED reads as "awaiting user action".
+            val session: SessionData? = try {
+                authService.login(creds.playerName, pass, server.assetDir)
+            } catch (_: hivens.core.api.TwoFactorRequiredException) {
+                val cached = manifestCache.loadManifest(server.assetDir)
+                if (cached == null) {
+                    log.info(
+                        "Auto-sync skipped for {}: 2FA + no cached manifest yet, awaiting manual login",
+                        server.assetDir,
+                    )
+                    ActionRing.record("Auto-sync skipped: ${server.assetDir} needs manual 2FA login")
+                    _serverStates.update { it + (server.assetDir to ServerState.SKIPPED) }
+                    null
+                } else {
                     creds.copy(fileManifest = cached, serverId = server.assetDir)
                 }
+            }
+
+            if (session == null) continue  // SKIPPED above; counters not bumped (it's neither succeeded nor failed)
+
+            val ok = runCatching {
                 val userState = optionalModsStateProvider(server.assetDir)
                 val ignoredFiles = manifestProcessor.calculateIgnoredFiles(server, userState)
                 val clientDir = dataDirectory.resolve("clients").resolve(server.assetDir)

--- a/client-launcher/src/main/kotlin/hivens/launcher/AutoSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/AutoSyncService.kt
@@ -36,6 +36,7 @@ class AutoSyncService(
     private val authService: IAuthService,
     private val downloadService: IFileDownloadService,
     private val manifestProcessor: IManifestProcessorService,
+    private val manifestCache: ManifestCache,
     private val dataDirectory: Path,
     /**
      * Loads cached credentials. Lambda-injected (rather than holding a
@@ -122,7 +123,22 @@ class AutoSyncService(
             )
 
             val ok = runCatching {
-                val session = authService.login(creds.playerName, pass, server.assetDir)
+                val session = try {
+                    authService.login(creds.playerName, pass, server.assetDir)
+                } catch (_: hivens.core.api.TwoFactorRequiredException) {
+                    // 2FA account — fall back to the cached manifest from
+                    // the last successful online sync. Auto-sync is best-
+                    // effort: serving stale-but-valid data on a 2FA account
+                    // is strictly better than failing every server every
+                    // launcher start (which would also trigger a 2FA
+                    // prompt the user didn't ask for). If no cache yet,
+                    // skip this server — the runCatching captures it as a
+                    // sync failure, which is the right signal for the
+                    // dashboard.
+                    val cached = manifestCache.loadManifest(server.assetDir)
+                        ?: throw IllegalStateException("2FA account, no cached manifest for ${server.assetDir}")
+                    creds.copy(fileManifest = cached, serverId = server.assetDir)
+                }
                 val userState = optionalModsStateProvider(server.assetDir)
                 val ignoredFiles = manifestProcessor.calculateIgnoredFiles(server, userState)
                 val clientDir = dataDirectory.resolve("clients").resolve(server.assetDir)

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -317,6 +317,7 @@ val appModule = module {
             authService = get(),
             downloadService = get(),
             manifestProcessor = get(),
+            manifestCache = get(),
             dataDirectory = dataDir,
             credentialsProvider = { credentials.load() },
             optionalModsStateProvider = { serverId ->

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -58,12 +58,8 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.swing)
                 implementation(libs.kotlinx.coroutines.slf4j)
                 implementation(libs.logback.classic)
-                implementation(libs.dorkbox.systemtray)
+                implementation(libs.libtray)
                 implementation(libs.ktor.client.core)
-
-                // Windows-only explicit pin: see libs.versions.toml comment on jnaWindows.
-                implementation(libs.jna)
-                implementation(libs.jna.platform)
             }
         }
     }
@@ -206,11 +202,10 @@ compose.desktop {
             "-XX:MaxMetaspaceSize=256m",
             "-XX:ReservedCodeCacheSize=128m",
 
-            // Security
+            // Security — libtray's Panama bindings need access to native
+            // memory + downcall stubs. Same flag also enables the
+            // macOS keyring + libsecret bindings shipped in 2.2.13.
             "--enable-native-access=ALL-UNNAMED",
-
-            // prevent JNA native lib version conflict
-            "-Djna.nosys=true",
 
             // ── Wayland-Native trial flag ─────────────────────────────────
             //

--- a/client-ui/compose-desktop.pro
+++ b/client-ui/compose-desktop.pro
@@ -92,7 +92,8 @@
 }
 
 # --- System tray ---
--keep class dorkbox.** { *; }
+# dorkbox removed in 2.2.14 (libtray swap). The libtray Panama callers
+# below take its place; the dorkbox keep rule was retired with the dep.
 
 # --- Project Panama foreign-function call sites ---
 # Classes that call MethodHandle.invokeExact(...) with java.lang.foreign.*
@@ -102,6 +103,13 @@
 # so adding a new Panama caller is a deliberate edit, not silent suppression.
 -dontwarn hivens.launcher.security.LinuxLibsecretKeyringStorage
 -dontwarn hivens.launcher.security.WindowsCredentialManagerKeyringStorage
+-dontwarn hivens.launcher.security.MacOSKeychainStorage
+-dontwarn dev.hivens.libtray.linux.SniTrayImpl
+-dontwarn dev.hivens.libtray.linux.SniTrayImpl$Companion
+-dontwarn dev.hivens.libtray.windows.Win32TrayImpl
+-dontwarn dev.hivens.libtray.windows.Win32TrayImpl$Companion
+-dontwarn dev.hivens.libtray.macos.AppKitTrayImpl
+-dontwarn dev.hivens.libtray.macos.AppKitTrayImpl$Companion
 
 # --- Suppress Warnings ---
 -dontwarn ch.qos.logback.**

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -17,6 +17,7 @@ import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import hivens.config.Branding
 import hivens.config.Protocol
 import hivens.core.api.AuthException
+import hivens.core.api.TwoFactorRequiredException
 import hivens.core.api.interfaces.IAuthService
 import hivens.core.api.interfaces.IServerListService
 import hivens.core.api.interfaces.ISettingsService
@@ -626,6 +627,24 @@ fun AppRoot(
                         val server  = profileManager.lastServerId ?: Protocol.DEFAULT_SERVER_ID
                         val session = authService.login(saved.playerName, saved.cachedPassword!!, server)
                         AppState.Authenticated(session)
+                    } catch (e: TwoFactorRequiredException) {
+                        // 2FA accounts already paid the 2FA cost when they
+                        // got the cached accessToken. Re-validating with
+                        // login() just re-triggers the gate on every
+                        // launcher startup — which is what the cached
+                        // accessToken is supposed to prevent. Trust the
+                        // cache: promote `saved` straight to Authenticated.
+                        // If the token is actually stale, the server will
+                        // reject it at game launch and the user re-logs in
+                        // from the credentials form — same recovery path
+                        // as a server-side logout. Fix for the "double
+                        // login on every launch with 2FA" report.
+                        hivens.core.diag.ActionRing.record(
+                            "Auto-login: 2FA account, trusting cached accessToken (uid=${e.uid?.take(8) ?: "<missing>"})"
+                        )
+                        AppState.Authenticated(
+                            saved.copy(serverId = profileManager.lastServerId),
+                        )
                     } catch (e: AuthException) {
                         if (e.isSslError) {
                             // Auto-grant on cached-credential cert error gets the same

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -424,11 +424,20 @@ fun main() {
                         val credentials = credentialsManager.load()
                         if (credentials?.cachedPassword != null) {
                             try {
-                                val session = authService.login(
-                                    credentials.playerName,
-                                    credentials.cachedPassword!!,
-                                    server.assetDir
-                                )
+                                val session = try {
+                                    authService.login(
+                                        credentials.playerName,
+                                        credentials.cachedPassword!!,
+                                        server.assetDir,
+                                    )
+                                } catch (_: TwoFactorRequiredException) {
+                                    // Tray-launched 2FA accounts: same trust-the-cache
+                                    // policy as the auto-login path. controller.launch
+                                    // augments the session with a cached manifest if
+                                    // needed (and reports cleanly when the cache is
+                                    // empty, which is its job).
+                                    credentials.copy(serverId = server.assetDir)
+                                }
                                 controller.launch(session, server)
                                 SwingUtilities.invokeLater { GameConsoleService.show() }
                             } catch (e: Exception) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -284,8 +284,8 @@ object EnglishStrings : AppStrings {
     override val spawnResetError   = "Server error"
 
     // --- Tray ---
-    override val trayStatusIdle    = "● Idle"
-    override val trayStatusRunning = "▶ Game running"
+    override val trayStatusIdle    = "Idle"
+    override val trayStatusRunning = "Game running"
     override val trayShow          = "Show launcher"
     override val trayServers       = "Servers"
     override val trayNoServers     = "No servers loaded"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -284,8 +284,8 @@ object GermanStrings : AppStrings {
     override val spawnResetError   = "Serverfehler"
 
     // --- Tray ---
-    override val trayStatusIdle    = "● Wartend"
-    override val trayStatusRunning = "▶ Spiel läuft"
+    override val trayStatusIdle    = "Wartend"
+    override val trayStatusRunning = "Spiel läuft"
     override val trayShow          = "Launcher anzeigen"
     override val trayServers       = "Server"
     override val trayNoServers     = "Keine Server geladen"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -284,8 +284,8 @@ object RussianStrings : AppStrings {
     override val spawnResetError   = "Ошибка сервера"
 
     // --- Tray ---
-    override val trayStatusIdle    = "● Ожидание"
-    override val trayStatusRunning = "▶ Игра запущена"
+    override val trayStatusIdle    = "Ожидание"
+    override val trayStatusRunning = "Игра запущена"
     override val trayShow          = "Открыть лаунчер"
     override val trayServers       = "Серверы"
     override val trayNoServers     = "Серверы не загружены"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LauncherController.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LauncherController.kt
@@ -107,10 +107,16 @@ class LauncherController : KoinComponent {
                             session = session.copy(fileManifest = cached)
                             ActionRing.record("Launch: 2FA account, using cached manifest for $targetServerId")
                         } else {
-                            // No cached manifest and no fresh login → first time
-                            // launching this server on a 2FA account. Surface
-                            // clearly so user knows to re-login from the form.
-                            GameConsoleService.append(s.stateAuthFail + " (2FA — manual login required)", LogType.WARN)
+                            // No cached manifest and no fresh login. Continuing
+                            // hits "File manifest is empty!" deep in
+                            // processSession — cryptic for the user. Throw
+                            // with the same string the 2FA dialog uses so the
+                            // outer LaunchState.Error renders an actionable
+                            // message ("re-login from the form"), not a
+                            // misleading internal one. Caught by the
+                            // top-level handler at the bottom of this fn.
+                            ActionRing.record("Launch: 2FA + no cached manifest for $targetServerId — re-login required")
+                            throw IllegalStateException(s.auth2faExpired)
                         }
                     } catch (e: Exception) {
                         GameConsoleService.append("${s.stateAuthFail}: ${e.message}", LogType.WARN)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LauncherController.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/logic/LauncherController.kt
@@ -95,6 +95,23 @@ class LauncherController : KoinComponent {
                         } else {
                             GameConsoleService.append(s.stateNoPassword, LogType.WARN)
                         }
+                    } catch (_: hivens.core.api.TwoFactorRequiredException) {
+                        // 2FA account — refusing to prompt the user for a code
+                        // every time they click Play. The cached accessToken
+                        // in `session` is from a previous successful 2FA flow
+                        // and is what the game uses anyway. Augment it with a
+                        // cached manifest (same path the offline branch
+                        // takes) so processSession has something to walk.
+                        val cached = manifestCache.loadManifest(targetServerId)
+                        if (cached != null) {
+                            session = session.copy(fileManifest = cached)
+                            ActionRing.record("Launch: 2FA account, using cached manifest for $targetServerId")
+                        } else {
+                            // No cached manifest and no fresh login → first time
+                            // launching this server on a 2FA account. Surface
+                            // clearly so user knows to re-login from the form.
+                            GameConsoleService.append(s.stateAuthFail + " (2FA — manual login required)", LogType.WARN)
+                        }
                     } catch (e: Exception) {
                         GameConsoleService.append("${s.stateAuthFail}: ${e.message}", LogType.WARN)
                         // If auth fails and we're NOT in offline mode, we still try to continue

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
@@ -113,7 +113,15 @@ object TrayManager {
             val builder = TrayBuilder(
                 title = appName,
                 iconBytes = iconBytes,
-                tooltip = "$appName — ${strings.statusIdle}",
+                // Just the status — NO `appName` prefix. Modern tray
+                // hosts (Plasma, waybar with default templates, GNOME
+                // SNI extensions) resolve the application name from the
+                // SNI Id by looking up the matching `.desktop` file and
+                // render it themselves; if libtray ALSO prefixes, the
+                // user sees "Aura Launcher — Aura Launcher — status".
+                // Hosts that don't resolve still get a meaningful
+                // tooltip ("● Idle"); the icon identifies the app.
+                tooltip = strings.statusIdle,
                 menu = buildMenu(strings, servers, gameRunning, gameServerName),
             )
             val t = Tray.create(builder) ?: run {
@@ -169,6 +177,7 @@ object TrayManager {
         gameRunning = running
         gameServerName = serverName
         rebuildMenu()
+        // No appName prefix here either — same reasoning as in [init].
         val tooltipLabel = when {
             running && serverName != null -> "▶  $serverName"
             running -> strings?.statusRunning ?: "▶  Running"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
@@ -87,7 +87,6 @@ object TrayManager {
     // events; "server:<assetDir>" for the per-server entries so the
     // dispatch can recover the asset id on click.
 
-    private const val ID_STATUS  = "_status"
     private const val ID_SERVERS = "_servers"
     private const val ID_NOSERVERS = "_noservers"
     private const val ID_SHOW    = "show"
@@ -188,21 +187,15 @@ object TrayManager {
     private fun buildMenu(
         s: Strings,
         servers: List<ServerProfile>,
-        running: Boolean,
-        serverName: String?,
+        @Suppress("UNUSED_PARAMETER") running: Boolean,
+        @Suppress("UNUSED_PARAMETER") serverName: String?,
     ): TrayMenu {
         val items = mutableListOf<TrayMenuItem>()
 
-        // Status line — disabled, acts as a label that reflects current
-        // game state. Hosts render disabled items in muted colour so the
-        // user reads it as informational rather than clickable.
-        val statusLabel = when {
-            running && serverName != null -> serverName
-            running -> s.statusRunning
-            else    -> s.statusIdle
-        }
-        items += TrayMenuItem.Standard(id = ID_STATUS, label = statusLabel, enabled = false)
-        items += TrayMenuItem.Separator
+        // Status used to live as the first (disabled) menu entry too, but
+        // the same string is already in the SNI tooltip — the menu line
+        // was pure duplication. Removed; running/serverName params are
+        // kept on the signature so callers don't have to change shape.
         items += TrayMenuItem.Standard(id = ID_SHOW,    label = s.show)
         items += TrayMenuItem.Standard(id = ID_CONSOLE, label = s.console)
         items += TrayMenuItem.Separator

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
@@ -115,15 +115,7 @@ object TrayManager {
             val builder = TrayBuilder(
                 title = appName,
                 iconBytes = iconBytes,
-                // Compose the full "App — status" here ourselves. libtray
-                // intentionally doesn't compose (it'd double up on hosts
-                // that resolve .desktop names from the SNI Id), and the
-                // hosts we actually ship to (waybar, Hyprland tray
-                // helpers, GNOME minimal SNI consumers) don't do that
-                // resolution either — they just print Title verbatim.
-                // So the prefix has to live on the caller side or it's
-                // gone from the tooltip entirely.
-                tooltip = "$appName — ${strings.statusIdle}",
+                tooltip = "$appName | ${strings.statusIdle}",
                 menu = buildMenu(strings, servers, gameRunning, gameServerName),
             )
             val t = Tray.create(builder) ?: run {
@@ -181,13 +173,11 @@ object TrayManager {
         rebuildMenu()
         val s = strings
         val statusPart = when {
-            running && serverName != null -> "▶  $serverName"
-            running -> s?.statusRunning ?: "▶  Running"
-            else    -> s?.statusIdle ?: "●  Ready"
+            running && serverName != null -> serverName
+            running -> s?.statusRunning ?: "Running"
+            else    -> s?.statusIdle ?: "Ready"
         }
-        // Same prefix policy as [init] — see the comment on TrayBuilder
-        // construction. appName is what we passed as `title` at init time.
-        tray?.setTooltip("$appName — $statusPart")
+        tray?.setTooltip("$appName | $statusPart")
     }
 
     private fun rebuildMenu() {
@@ -207,7 +197,7 @@ object TrayManager {
         // game state. Hosts render disabled items in muted colour so the
         // user reads it as informational rather than clickable.
         val statusLabel = when {
-            running && serverName != null -> "▶  $serverName"
+            running && serverName != null -> serverName
             running -> s.statusRunning
             else    -> s.statusIdle
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
@@ -46,6 +46,7 @@ object TrayManager {
 
     private var tray: Tray? = null
     private var strings: Strings? = null
+    private var appName: String = "Aura Launcher"
     private var unsubscribe: (() -> Unit)? = null
 
     @Volatile private var servers: List<ServerProfile> = emptyList()
@@ -105,6 +106,7 @@ object TrayManager {
      */
     fun init(iconStream: InputStream, strings: Strings, appName: String) {
         this.strings = strings
+        this.appName = appName
         if (state != State.NOT_STARTED) return
 
         state = State.INITIALIZING
@@ -113,15 +115,15 @@ object TrayManager {
             val builder = TrayBuilder(
                 title = appName,
                 iconBytes = iconBytes,
-                // Just the status — NO `appName` prefix. Modern tray
-                // hosts (Plasma, waybar with default templates, GNOME
-                // SNI extensions) resolve the application name from the
-                // SNI Id by looking up the matching `.desktop` file and
-                // render it themselves; if libtray ALSO prefixes, the
-                // user sees "Aura Launcher — Aura Launcher — status".
-                // Hosts that don't resolve still get a meaningful
-                // tooltip ("● Idle"); the icon identifies the app.
-                tooltip = strings.statusIdle,
+                // Compose the full "App — status" here ourselves. libtray
+                // intentionally doesn't compose (it'd double up on hosts
+                // that resolve .desktop names from the SNI Id), and the
+                // hosts we actually ship to (waybar, Hyprland tray
+                // helpers, GNOME minimal SNI consumers) don't do that
+                // resolution either — they just print Title verbatim.
+                // So the prefix has to live on the caller side or it's
+                // gone from the tooltip entirely.
+                tooltip = "$appName — ${strings.statusIdle}",
                 menu = buildMenu(strings, servers, gameRunning, gameServerName),
             )
             val t = Tray.create(builder) ?: run {
@@ -177,13 +179,15 @@ object TrayManager {
         gameRunning = running
         gameServerName = serverName
         rebuildMenu()
-        // No appName prefix here either — same reasoning as in [init].
-        val tooltipLabel = when {
+        val s = strings
+        val statusPart = when {
             running && serverName != null -> "▶  $serverName"
-            running -> strings?.statusRunning ?: "▶  Running"
-            else    -> strings?.statusIdle ?: "●  Ready"
+            running -> s?.statusRunning ?: "▶  Running"
+            else    -> s?.statusIdle ?: "●  Ready"
         }
-        tray?.setTooltip(tooltipLabel)
+        // Same prefix policy as [init] — see the comment on TrayBuilder
+        // construction. appName is what we passed as `title` at init time.
+        tray?.setTooltip("$appName — $statusPart")
     }
 
     private fun rebuildMenu() {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/tray/TrayManager.kt
@@ -1,41 +1,42 @@
 package hivens.ui.tray
 
-import dorkbox.systemTray.Menu
-import dorkbox.systemTray.MenuItem
-import dorkbox.systemTray.Separator
-import dorkbox.systemTray.SystemTray
+import dev.hivens.libtray.Tray
+import dev.hivens.libtray.TrayBuilder
+import dev.hivens.libtray.TrayEvent
+import dev.hivens.libtray.TrayMenu
+import dev.hivens.libtray.TrayMenuItem
 import hivens.core.api.model.ServerProfile
 import org.slf4j.LoggerFactory
 import java.io.InputStream
 
 /**
- * System tray manager backed by dorkbox/SystemTray 4.4.
+ * System tray manager backed by libtray (`dev.hivens:libtray`),
+ * a Project-Panama-only replacement for dorkbox/SystemTray. Host renders
+ * the menu via DBusMenu on Linux / Shell_NotifyIcon menu on Windows /
+ * NSMenu on macOS — we publish the layout, the desktop draws it.
  *
- * All callbacks are invoked on the AWT thread by dorkbox.
- * Must be initialized once from Main.kt after Koin is ready.
+ * Lifecycle:
+ *   - `init(iconStream, strings, appName)` once from Main.kt after Koin
+ *     is ready and the localised strings are resolved.
+ *   - `setGameStatus` and `updateServers` may fire any time; they push a
+ *     fresh menu/tooltip via libtray's setters.
+ *   - `shutdown` on application exit. Idempotent.
+ *
+ * State machine still distinguishes NOT_STARTED / INITIALIZING / READY /
+ * FAILED so the close-request handler in Main.kt can prefer "hide to
+ * tray" over "exit application" while libtray is still bringing up the
+ * D-Bus / Shell_NotifyIcon registration.
  */
 object TrayManager {
 
     private val logger = LoggerFactory.getLogger("TrayManager")
 
-    private var tray: SystemTray? = null
-    private var statusItem: MenuItem? = null
-    private var serversSubmenu: Menu? = null
-    private val serverItems = mutableListOf<MenuItem>()
-    private var noServersItem: MenuItem? = null
-    private var strings: Strings? = null
-
     /**
      * Lifecycle state of the tray. Distinguishes "init has not even started"
-     * from "init is running but hasn't completed yet" — critical because
-     * dorkbox's `SystemTray.get()` can stall for up to ~60s on Linux setups
-     * with broken/missing GTK libraries before falling back to Swing. During
-     * that window the user might close the launcher window expecting the
-     * standard "minimize-to-tray" behavior; without this state we'd see
-     * `isSupported == false` and call `exitApplication()` instead, killing
-     * the launcher (and any game launch in progress).
-     *
-     * Volatile because [init] runs on Dispatchers.IO and the close-request
+     * from "init is running but hasn't completed yet" so the window's
+     * close-request handler can prefer "minimize to tray" while libtray
+     * is still bringing up the D-Bus / Shell_NotifyIcon side. Volatile
+     * because [init] runs on Dispatchers.IO and the close-request
      * callbacks in Main.kt read state from the AWT thread.
      */
     enum class State { NOT_STARTED, INITIALIZING, READY, FAILED }
@@ -43,10 +44,15 @@ object TrayManager {
     @Volatile
     private var state: State = State.NOT_STARTED
 
-    /**
-     * True only when the tray is fully registered. Use this when a code
-     * path needs to *act* on the tray right now (e.g. update menu items).
-     */
+    private var tray: Tray? = null
+    private var strings: Strings? = null
+    private var unsubscribe: (() -> Unit)? = null
+
+    @Volatile private var servers: List<ServerProfile> = emptyList()
+    @Volatile private var gameRunning: Boolean = false
+    @Volatile private var gameServerName: String? = null
+
+    /** True only when libtray has a live tray icon. */
     val isSupported: Boolean get() = state == State.READY
 
     /**
@@ -54,7 +60,7 @@ object TrayManager {
      * initializing. Use this for close-request handlers: if the tray
      * might still come up, prefer "hide to tray" over "exit application",
      * since the user's intent is "minimize" and we don't want to kill the
-     * launcher because dorkbox's GTK probe is slow.
+     * launcher because libtray is taking its time to register on D-Bus.
      */
     val canBeReady: Boolean get() = state == State.INITIALIZING || state == State.READY
 
@@ -65,27 +71,37 @@ object TrayManager {
         val console: String,
         val servers: String,
         val noServers: String,
-        val exit: String
+        val exit: String,
     )
 
     // ── Callbacks ─────────────────────────────────────────────────────────
 
-    var onShowWindow:   (() -> Unit)? = null
-    var onExit:         (() -> Unit)? = null
-    var onShowConsole:  (() -> Unit)? = null
+    var onShowWindow: (() -> Unit)? = null
+    var onExit: (() -> Unit)? = null
+    var onShowConsole: (() -> Unit)? = null
     var onLaunchServer: ((ServerProfile) -> Unit)? = null
+
+    // ── Menu item ids — internal protocol with dispatchMenu ──────────────
+    // Prefixed with `_` for items that shouldn't surface as launchable
+    // events; "server:<assetDir>" for the per-server entries so the
+    // dispatch can recover the asset id on click.
+
+    private const val ID_STATUS  = "_status"
+    private const val ID_SERVERS = "_servers"
+    private const val ID_NOSERVERS = "_noservers"
+    private const val ID_SHOW    = "show"
+    private const val ID_CONSOLE = "console"
+    private const val ID_EXIT    = "exit"
+    private const val ID_SERVER_PREFIX = "server:"
 
     // ── Lifecycle ─────────────────────────────────────────────────────────
 
     /**
-     * @param iconStream Tray icon bytes (PNG).
+     * @param iconStream Tray icon bytes (PNG). Read once into memory for libtray.
      * @param strings    Localised menu labels.
-     * @param appName    The actual AppIndicator title — what KDE/GNOME show
-     *                   on hover. dorkbox's [SystemTray.get] no-arg overload
-     *                   hardcodes this to "SystemTray", so pass an explicit
-     *                   name. Setting it via `setTooltip()` does NOT work:
-     *                   AppIndicator's `app_indicator_set_title()` only
-     *                   reads the value supplied at construction time.
+     * @param appName    The tray-host-visible title — what KDE/GNOME/Win11
+     *                   tooltip resolves to when the user hovers. Stored as
+     *                   the libtray Tray identifier for life of the icon.
      */
     fun init(iconStream: InputStream, strings: Strings, appName: String) {
         this.strings = strings
@@ -93,97 +109,129 @@ object TrayManager {
 
         state = State.INITIALIZING
         try {
-            SystemTray.DEBUG = false
-            val t = SystemTray.get(appName) ?: run {
-                logger.warn("SystemTray not supported on this platform")
+            val iconBytes = iconStream.readAllBytes()
+            val builder = TrayBuilder(
+                title = appName,
+                iconBytes = iconBytes,
+                tooltip = "$appName — ${strings.statusIdle}",
+                menu = buildMenu(strings, servers, gameRunning, gameServerName),
+            )
+            val t = Tray.create(builder) ?: run {
+                logger.warn("libtray Tray.create returned null — no tray host reachable on this session")
                 state = State.FAILED
                 return
             }
             tray = t
-            t.setImage(iconStream)
-            buildMenu(t.menu, strings)
+            unsubscribe = t.onEvent { event ->
+                when (event) {
+                    // Left click → restore window. Matches the previous
+                    // dorkbox default and what every other tray-icon app
+                    // does on every desktop.
+                    is TrayEvent.Activated -> onShowWindow?.invoke()
+                    is TrayEvent.MenuItemSelected -> dispatchMenu(event.id)
+                    else -> Unit
+                }
+            }
             state = State.READY
-            logger.info("TrayManager initialized ({})", t.javaClass.simpleName)
+            logger.info("TrayManager initialized via libtray (title='{}')", appName)
         } catch (t: Throwable) {
             state = State.FAILED
             logger.error("Failed to initialize TrayManager", t)
         }
     }
 
-    private fun buildMenu(menu: Menu, s: Strings) {
-        // Status line — disabled, acts as label
-        val status = MenuItem(s.statusIdle)
-        status.setEnabled(false)
-        menu.add(status)
-        statusItem = status
-
-        menu.add(Separator())
-
-        menu.add(MenuItem(s.show) { onShowWindow?.invoke() })
-        menu.add(MenuItem(s.console) { onShowConsole?.invoke() })
-
-        menu.add(Separator())
-
-        // Servers submenu
-        val sub = Menu(s.servers)
-        val noServers = MenuItem(s.noServers)
-        noServers.setEnabled(false)
-        sub.add(noServers)
-        noServersItem = noServers
-        serversSubmenu = sub
-        menu.add(sub)
-
-        menu.add(Separator())
-
-        menu.add(MenuItem(s.exit) { onExit?.invoke() })
-    }
-
-    // ── State updates ──────────────────────────────────────────────────────
-
-    fun updateServers(servers: List<ServerProfile>) {
-        val sub = serversSubmenu ?: return
-
-        serverItems.forEach { sub.remove(it) }
-        serverItems.clear()
-
-        if (servers.isEmpty()) {
-            if (noServersItem == null) {
-                val placeholder = MenuItem("—")
-                placeholder.setEnabled(false)
-                sub.add(placeholder)
-                noServersItem = placeholder
-            }
-            return
-        }
-
-        noServersItem?.let { sub.remove(it) }
-        noServersItem = null
-
-        servers.forEach { server ->
-            val item = MenuItem(server.title ?: server.name) {
+    private fun dispatchMenu(id: String) {
+        when {
+            id == ID_SHOW    -> onShowWindow?.invoke()
+            id == ID_CONSOLE -> onShowConsole?.invoke()
+            id == ID_EXIT    -> onExit?.invoke()
+            id.startsWith(ID_SERVER_PREFIX) -> {
+                val assetDir = id.removePrefix(ID_SERVER_PREFIX)
+                val server = servers.firstOrNull { it.assetDir == assetDir } ?: return
                 onShowWindow?.invoke()
                 onLaunchServer?.invoke(server)
             }
-            sub.add(item)
-            serverItems.add(item)
+            // _status / _noservers / _servers are non-clickable surfaces
+            // (disabled items + the submenu parent itself); the host
+            // shouldn't fire MenuItemSelected for them, but ignore
+            // defensively in case it does.
         }
     }
 
+    // ── State updates ─────────────────────────────────────────────────────
+
+    fun updateServers(newServers: List<ServerProfile>) {
+        servers = newServers
+        rebuildMenu()
+    }
+
     fun setGameStatus(running: Boolean, serverName: String? = null) {
-        statusItem?.setText(when {
+        gameRunning = running
+        gameServerName = serverName
+        rebuildMenu()
+        val tooltipLabel = when {
             running && serverName != null -> "▶  $serverName"
             running -> strings?.statusRunning ?: "▶  Running"
             else    -> strings?.statusIdle ?: "●  Ready"
-        })
+        }
+        tray?.setTooltip(tooltipLabel)
+    }
+
+    private fun rebuildMenu() {
+        val s = strings ?: return
+        tray?.setMenu(buildMenu(s, servers, gameRunning, gameServerName))
+    }
+
+    private fun buildMenu(
+        s: Strings,
+        servers: List<ServerProfile>,
+        running: Boolean,
+        serverName: String?,
+    ): TrayMenu {
+        val items = mutableListOf<TrayMenuItem>()
+
+        // Status line — disabled, acts as a label that reflects current
+        // game state. Hosts render disabled items in muted colour so the
+        // user reads it as informational rather than clickable.
+        val statusLabel = when {
+            running && serverName != null -> "▶  $serverName"
+            running -> s.statusRunning
+            else    -> s.statusIdle
+        }
+        items += TrayMenuItem.Standard(id = ID_STATUS, label = statusLabel, enabled = false)
+        items += TrayMenuItem.Separator
+        items += TrayMenuItem.Standard(id = ID_SHOW,    label = s.show)
+        items += TrayMenuItem.Standard(id = ID_CONSOLE, label = s.console)
+        items += TrayMenuItem.Separator
+
+        // Servers submenu — non-empty fallback so the parent is never an
+        // empty submenu (dbusmenu spec rejects that, libtray's
+        // TrayMenuItem.Submenu init enforces it too).
+        val serverItems: List<TrayMenuItem> = if (servers.isEmpty()) {
+            listOf(TrayMenuItem.Standard(id = ID_NOSERVERS, label = s.noServers, enabled = false))
+        } else {
+            servers.map { srv ->
+                TrayMenuItem.Standard(
+                    id = "$ID_SERVER_PREFIX${srv.assetDir}",
+                    label = srv.title ?: srv.name,
+                )
+            }
+        }
+        items += TrayMenuItem.Submenu(id = ID_SERVERS, label = s.servers, items = serverItems)
+        items += TrayMenuItem.Separator
+        items += TrayMenuItem.Standard(id = ID_EXIT, label = s.exit)
+
+        return TrayMenu(items)
     }
 
     fun shutdown() {
-        runCatching { tray?.shutdown() }
+        runCatching { unsubscribe?.invoke() }
+        runCatching { tray?.close() }
         tray = null
-        serverItems.clear()
-        serversSubmenu = null
-        statusItem = null
-        noServersItem = null
+        unsubscribe = null
+        servers = emptyList()
+        gameRunning = false
+        gameServerName = null
         state = State.NOT_STARTED
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@
 # ── Toolchain & language plugins ─────────────────────────────────────────────
 # Kotlin held at 2.3.20-RC3 (next release-line bump is 2.4.0-Beta2, skipped —
 # beta of a new major). Compose moved alpha04 → rc01 of the same 1.11.0 line.
-kotlin            = "2.3.20-RC3"
+kotlin            = "2.3.21"
 compose           = "1.11.0-alpha04"
 buildconfigPlugin = "6.0.9"
 versionsPlugin    = "0.54.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,14 +30,13 @@ logback           = "1.5.32"
 
 # ── Misc runtime ─────────────────────────────────────────────────────────────
 commonsCompress   = "1.28.0"
-systemTray        = "4.4"
 proguard          = "7.8.2"
 
-# ── JNA — must stay 6.1.6 globally for dorkbox/SystemTray's hardcoded
-# version check; client-ui additionally declares 5.18.1 explicitly to keep
-# Windows happy. See root build.gradle.kts resolutionStrategy. ───────────────
-jna               = "6.1.6"
-jnaWindows        = "5.18.1"
+# Pure-Panama tray library (Kitty-Hivens/libtray) — replaces dorkbox/SystemTray
+# for the native tray icon. Local SNAPSHOT consumed via `mavenLocal()` in the
+# root build script during the integration window; switches to mavenCentral
+# coordinates once libtray cuts its first tagged release.
+libtray           = "0.1.0-SNAPSHOT"
 
 # ── Test ─────────────────────────────────────────────────────────────────────
 mockk             = "1.13.12"
@@ -82,11 +81,10 @@ filekit-dialogs-compose         = { group = "io.github.vinceglb", name = "fileki
 
 # Misc
 commons-compress                = { group = "org.apache.commons", name = "commons-compress", version.ref = "commonsCompress" }
-dorkbox-systemtray               = { group = "com.dorkbox",        name = "SystemTray",        version.ref = "systemTray" }
+libtray                          = { group = "dev.hivens",         name = "libtray",           version.ref = "libtray" }
 
-# JNA (Windows-only explicit pin in client-ui)
-jna                              = { group = "net.java.dev.jna", name = "jna",          version.ref = "jnaWindows" }
-jna-platform                     = { group = "net.java.dev.jna", name = "jna-platform", version.ref = "jnaWindows" }
+# JNA dropped — was only present for dorkbox/SystemTray. libtray is
+# pure java.lang.foreign (Project Panama) and pulls no JNA transitively.
 
 # Test
 mockk                            = { group = "io.mockk", name = "mockk", version.ref = "mockk" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,10 +33,11 @@ commonsCompress   = "1.28.0"
 proguard          = "7.8.2"
 
 # Pure-Panama tray library (Kitty-Hivens/libtray) — replaces dorkbox/SystemTray
-# for the native tray icon. Local SNAPSHOT consumed via `mavenLocal()` in the
-# root build script during the integration window; switches to mavenCentral
-# coordinates once libtray cuts its first tagged release.
-libtray           = "0.1.0-SNAPSHOT"
+# for the native tray icon. Pulled via JitPack (root build.gradle.kts
+# repositories chain) until libtray cuts its first Maven Central release;
+# pinned to a commit sha rather than a branch so upstream main-branch
+# changes don't silently land in our build.
+libtray           = "c88d51f"
 
 # ── Test ─────────────────────────────────────────────────────────────────────
 mockk             = "1.13.12"
@@ -81,7 +82,7 @@ filekit-dialogs-compose         = { group = "io.github.vinceglb", name = "fileki
 
 # Misc
 commons-compress                = { group = "org.apache.commons", name = "commons-compress", version.ref = "commonsCompress" }
-libtray                          = { group = "dev.hivens",         name = "libtray",           version.ref = "libtray" }
+libtray                          = { group = "com.github.Kitty-Hivens", name = "libtray",      version.ref = "libtray" }
 
 # JNA dropped — was only present for dorkbox/SystemTray. libtray is
 # pure java.lang.foreign (Project Panama) and pulls no JNA transitively.


### PR DESCRIPTION
## Summary

- Swaps **dorkbox/SystemTray** (unmaintained since 2023, JNA-pinned, javassist runtime patching, `-Djna.nosys` workaround) for **[Kitty-Hivens/libtray](https://github.com/Kitty-Hivens/libtray)** — a pure Project-Panama tray binding maintained alongside Aura.
- Fixes the long-standing **2FA double-login** bug: cached accessToken was earned by going through 2FA once, but every subsequent `login()` call (auto-login, autosync, Play, tray Play) re-triggered the gate. Now caught at all four entry points; cached session is trusted, manifest cache fills the gap when needed.
- Polishes the tray surface: tooltip restored under `NOTIFYICON_VERSION_4`, status item removed from the right-click menu (was duplicated in the tooltip), Russian-style `Aura Launcher | Ожидание` separator instead of ASCII em-dash + bullet glyphs.
- Bumps Kotlin to the freshly-released `2.3.21` stable (was `2.3.20-RC3`).

## Key changes

### Tray backend
- `client-ui/.../tray/TrayManager.kt` rewritten on top of `dev.hivens.libtray.Tray`. State machine (NOT_STARTED / INITIALIZING / READY / FAILED), callback surface (onShowWindow / onExit / onShowConsole / onLaunchServer), and `canBeReady` semantics preserved so Main.kt close-handlers keep working unchanged.
- Root `build.gradle.kts`: JNA `resolutionStrategy.eachDependency` pin removed — libtray is FFM-only and never pulls JNA transitively. JBR 25's bundled JNA 7.x can resolve naturally now.
- `client-ui/build.gradle.kts`: dorkbox.systemtray + jna + jna-platform deps gone, `-Djna.nosys=true` JVM arg removed.
- `gradle/libs.versions.toml`: libtray pinned to JitPack commit `c88d51f` (group `com.github.Kitty-Hivens`). mavenLocal removed from the resolver chain.

### 2FA flow
- `Main.kt` auto-login: catches `TwoFactorRequiredException` separately from generic `AuthException`, promotes cached `SessionData` straight to `AppState.Authenticated`. The cached accessToken was earned by a previous successful 2FA pass; re-validating with `login()` just re-prompts.
- `LauncherController.launch`: same catch on the Play path, falls back to `manifestCache.loadManifest(serverId)` (the offline-mode codepath). When no cached manifest exists either, throws `IllegalStateException(s.auth2faExpired)` so the UI surfaces \"Сессия 2FA истекла. Пожалуйста, войдите заново.\" instead of the cryptic \"File manifest is empty!\" buried inside processSession.
- `AutoSyncService.syncAll`: same catch per server. With cached manifest → uses it. Without → marks the server `SKIPPED` (not `FAILED`); a 2FA account that hasn't been through 2FA on this machine yet is awaiting user action, not broken.
- `Main.kt` tray Play: same catch.

### Dashboard / strings polish
- Tray tooltip: `Aura Launcher | <status>` (vertical bar separator). Removed `●` / `▶` glyphs from EN / DE / RU `trayStatusIdle` / `trayStatusRunning` strings.
- Right-click menu: status entry removed (was duplicated by the tooltip on hover).

## Known gaps

- **macOS regression (libtray Phase 4 pending)**: libtray's NSStatusItem backend isn't implemented yet. On macOS, `Tray.create` returns null, `TrayManager.canBeReady` is false, and the close-after-Play handler falls through to `exitApplication()` instead of hide-to-tray. Linux + Windows users see no behavioural change vs dorkbox; macOS users lose the tray icon and the launcher exits after launching the game (game itself runs as a separate process and is unaffected). Follow-up tracked in libtray, will land in a 2.2.x patch once Phase 4 is in.
- **JitPack as interim distribution**: libtray will move to a tagged Maven Central coordinate (`dev.hivens:libtray:0.1.0`) once Sonatype namespace verification + GPG signing are set up. This PR uses JitPack-pinned-to-sha as a stable bridge until then; cached after the first build, ~10s response on warm hits.

## Test plan

- [x] `./gradlew :client-core:test :client-launcher:test --continue` clean
- [x] `./gradlew :client-ui:run` on Linux Hyprland: tray icon appears via libtray's SNI backend, tooltip shows `Aura Launcher | Ожидание`, left-click restores window, right-click menu shows servers + Exit
- [x] AutoSync: 6/7 installed packs sync via cached creds; SkyBlock (2FA-only on tester account) marked SKIPPED with clean log line, not FAILED
- [x] Click Play on a 2FA-required server → no \"2FA required for X\" error in launcher console; game launches via cached manifest path
- [x] libtray smoke harness `gradlew.bat runSmoke` on Win10 x86_64: icon + left-click + right-click menu + tooltip all functional (validated by community tester + maintainer's VM)
- [x] macOS — tray fall-through to exitApplication after Play. Documented above; deferred to libtray Phase 4 follow-up
