### PR TITLE
fix(autosync): catch non-2FA login throws + test wires manifestCache mock

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/AutoSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/AutoSyncService.kt
@@ -122,7 +122,7 @@ class AutoSyncService(
                 totalBytes = 0,
             )
 
-            // Try to obtain a SessionData for this server. Three outcomes:
+            // Try to obtain a SessionData for this server. Four outcomes:
             //   * regular login → use that session directly
             //   * 2FA gate WITH cached manifest → use cached creds + manifest
             //   * 2FA gate WITHOUT cached manifest → mark SKIPPED (not failed)
@@ -130,6 +130,13 @@ class AutoSyncService(
             //     been through 2FA on this machine for this server yet, so
             //     we have nothing to sync against. Red FAILED would imply
             //     "server is broken"; SKIPPED reads as "awaiting user action".
+            //   * any other login throw (network, server reject, etc) →
+            //     mark FAILED for this server and continue. Pre-refactor
+            //     the outer runCatching covered everything; the refactor
+            //     split login + processSession, so non-2FA throws need
+            //     their own catch — without it a single login exception
+            //     terminates syncAll for every later server.
+            var sessionFailed = false
             val session: SessionData? = try {
                 authService.login(creds.playerName, pass, server.assetDir)
             } catch (_: hivens.core.api.TwoFactorRequiredException) {
@@ -145,8 +152,17 @@ class AutoSyncService(
                 } else {
                     creds.copy(fileManifest = cached, serverId = server.assetDir)
                 }
+            } catch (e: Exception) {
+                log.warn("Auto-sync login failed for {}: {}", server.assetDir, e.message)
+                sessionFailed = true
+                null
             }
 
+            if (sessionFailed) {
+                _serverStates.update { it + (server.assetDir to ServerState.FAILED) }
+                failed++
+                continue
+            }
             if (session == null) continue  // SKIPPED above; counters not bumped (it's neither succeeded nor failed)
 
             val ok = runCatching {

--- a/client-launcher/src/test/kotlin/hivens/launcher/AutoSyncServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/AutoSyncServiceTest.kt
@@ -26,6 +26,7 @@ class AutoSyncServiceTest {
     private lateinit var authService: IAuthService
     private lateinit var downloadService: IFileDownloadService
     private lateinit var manifestProcessor: IManifestProcessorService
+    private lateinit var manifestCache: ManifestCache
     private var stubCredentials: SessionData? = null
     private lateinit var service: AutoSyncService
 
@@ -35,6 +36,11 @@ class AutoSyncServiceTest {
         authService = mockk()
         downloadService = mockk()
         manifestProcessor = mockk()
+        // ManifestCache is a final class — relaxed mockk so the
+        // 2FA fallback path's loadManifest call returns null without
+        // a per-test setup. Tests that exercise the cache-hit branch
+        // can override per-test.
+        manifestCache = mockk(relaxed = true)
         stubCredentials = null
 
         every { manifestProcessor.calculateIgnoredFiles(any(), any()) } returns emptySet()
@@ -43,6 +49,7 @@ class AutoSyncServiceTest {
             authService = authService,
             downloadService = downloadService,
             manifestProcessor = manifestProcessor,
+            manifestCache = manifestCache,
             dataDirectory = sandbox,
             credentialsProvider = { stubCredentials },
             optionalModsStateProvider = { emptyMap() },


### PR DESCRIPTION
Hotfix on top of v2.2.13's release pipeline.

## What broke

PR #194 (libtray-integration → stable, merged earlier today) refactored
\`AutoSyncService.syncAll\` to catch \`TwoFactorRequiredException\` separately
from the existing \`runCatching\` block around \`downloadService.processSession\`.
The split narrowed coverage: a non-2FA login throw (network, server reject,
etc) now escapes the new try block entirely and terminates the per-server
loop, instead of marking that server FAILED and continuing.

The v2.2.13 Release workflow caught this on its first pass — the
\`per-server failure does not abort the rest\` test fixture throws
\`RuntimeException(\"auth-fail\")\` for the first server and asserts the
remaining two still process. Post-refactor that throw cascaded out of
the loop.

A second issue caught by the same workflow: \`AutoSyncServiceTest\`'s
constructor call hadn't been updated when PR #194 added the
\`manifestCache: ManifestCache\` parameter — DI in \`Modules.kt\` was
updated, the test fixture wasn't.

## Fix

- **Production**: \`AutoSyncService.syncAll\` adds a \`catch (e: Exception)\`
  branch in the session-resolution try block that mirrors the
  pre-refactor behaviour — mark FAILED, continue. 2FA SKIPPED path
  unchanged.
- **Test**: \`AutoSyncServiceTest\` now wires a relaxed \`mockk()\`
  \`ManifestCache\` into the service constructor.

Verified \`:client-launcher:test\` clean locally. v2.2.13 release
workflow will re-fire once stable advances and the v2.2.13 tag
points at the new HEAD.

## Test plan

- [x] \`./gradlew :client-launcher:test\` clean
- [x] \`per-server failure does not abort the rest\` passes — Industrial FAILED, Galaxy + Create SYNCED
- [ ] After merge: re-tag stable HEAD as v2.2.13 (force-update tag), Release workflow re-runs and produces artifacts