### PR TITLE
chore(deps): bump libtray pin c88d51f → 37a8789 for macOS Phase 4 validation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ proguard          = "7.8.2"
 # repositories chain) until libtray cuts its first Maven Central release;
 # pinned to a commit sha rather than a branch so upstream main-branch
 # changes don't silently land in our build.
-libtray           = "37a8789"
+libtray           = "ae96148"
 
 # ── Test ─────────────────────────────────────────────────────────────────────
 mockk             = "1.13.12"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,7 +37,7 @@ proguard          = "7.8.2"
 # repositories chain) until libtray cuts its first Maven Central release;
 # pinned to a commit sha rather than a branch so upstream main-branch
 # changes don't silently land in our build.
-libtray           = "c88d51f"
+libtray           = "37a8789"
 
 # ── Test ─────────────────────────────────────────────────────────────────────
 mockk             = "1.13.12"


### PR DESCRIPTION
Bumps libtray to **37a8789** which contains the full Phase 4 macOS NSStatusItem backend (objc_msgSend Panama bindings, runtime ObjC class registration, NSApplication activation policy, NSStatusItem creation + image/menu wiring).

## Validation status

* **Linux** — unchanged, libtray Linux SNI backend was already shipping in 2.2.13.
* **Windows** — unchanged, libtray Win32 backend was already shipping in 2.2.13.
* **macOS via libtray smoke harness on a CLI** — all backend calls succeed (logs show NSStatusItem created, NSImage decoded, setImage dispatched), but the icon doesn't paint. Diagnosed as the canonical \"JVM CLI process can't register status items with SystemUIServer\" limitation — requires a proper .app bundle with Bundle ID + Info.plist + LaunchServices registration.
* **macOS via Aura .app — pending this PR's validation cycle.** Aura's createReleaseDistributable produces exactly the kind of .app that should let the registration succeed.

## Validation steps

```
git fetch && git checkout chore/bump-libtray-macos-phase4
./gradlew :client-ui:createReleaseDistributable
open client-ui/build/compose/binaries/main-release/app/AuraLauncher.app
```

Expected: tray icon (or fallback \"●\" text title) appears in the menu bar top-right. Clicks + menu work. Close from tray exits cleanly.

## Merge gate

* If green on macOS .app → merge, cut a 2.2.13.1 patch (or roll into 2.2.14 alongside other bumps).
* If not green → don't merge; iterate on libtray, re-bump, re-validate.
