### PR TITLE
fix(boot): launcher.log to platform path + libtray ProGuard -keep for upcall stubs

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/platform/BootstrapConf.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/platform/BootstrapConf.kt
@@ -33,7 +33,11 @@ import java.nio.file.Paths
  * startup, so there's no concurrent-writer scenario to worry about.
  */
 object BootstrapConf {
-    private val log = LoggerFactory.getLogger(BootstrapConf::class.java)
+    // Lazy logger — same rationale as [DataDirMover]: BootstrapConf is
+    // touched during Main.kt's pre-logger bootstrap. Eager init would
+    // open the rolling file at the wrong path. See DataDirMover.kt for
+    // the long-form explanation.
+    private val log by lazy { LoggerFactory.getLogger(BootstrapConf::class.java) }
 
     const val KEY_DATA_DIR = "data-dir"
     const val KEY_PENDING_SOURCE = "data-dir-pending-source"

--- a/client-launcher/src/main/kotlin/hivens/launcher/platform/DataDirMover.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/platform/DataDirMover.kt
@@ -41,7 +41,15 @@ import java.util.stream.Collectors
  *    (retry on next start)
  */
 object DataDirMover {
-    private val log = LoggerFactory.getLogger(DataDirMover::class.java)
+    // Lazy logger — DataDirMover is referenced from Main.kt's bootstrap
+    // path BEFORE `aura.logs.dir` system property gets set. An eager
+    // `LoggerFactory.getLogger(...)` field initialiser would trigger
+    // logback's first init at the wrong moment, causing the rolling
+    // file appender to open `./logs/launcher.log` (in the JVM's working
+    // dir, e.g. `D:\Games\AuraLauncher\logs`) instead of
+    // `paths.logsDir`. Lazy delays init until the first log call —
+    // by which time Main.kt has set the property correctly.
+    private val log by lazy { LoggerFactory.getLogger(DataDirMover::class.java) }
 
     /**
      * UI-side: persist the move intent. Returns true if successfully

--- a/client-ui/compose-desktop.pro
+++ b/client-ui/compose-desktop.pro
@@ -104,12 +104,30 @@
 -dontwarn hivens.launcher.security.LinuxLibsecretKeyringStorage
 -dontwarn hivens.launcher.security.WindowsCredentialManagerKeyringStorage
 -dontwarn hivens.launcher.security.MacOSKeychainStorage
--dontwarn dev.hivens.libtray.linux.SniTrayImpl
--dontwarn dev.hivens.libtray.linux.SniTrayImpl$Companion
--dontwarn dev.hivens.libtray.windows.Win32TrayImpl
--dontwarn dev.hivens.libtray.windows.Win32TrayImpl$Companion
--dontwarn dev.hivens.libtray.macos.AppKitTrayImpl
--dontwarn dev.hivens.libtray.macos.AppKitTrayImpl$Companion
+
+# ── libtray: keep + dontwarn the entire namespace ─────────────────────────
+# CRITICAL: libtray's per-platform backends register Panama upcall stubs
+# via `MethodHandles.lookup().findStatic(class, "wndProcEntry"|"onMenuItemEntry"|…, …)`.
+# These methods have NO direct call sites in source — they're invoked at
+# runtime by the OS through the upcall stub function pointer (Win32 WndProc,
+# Cocoa NSMenuItem target-action, etc). ProGuard's reachability analysis
+# sees the methods as orphaned, removes them, and the next `findStatic` at
+# runtime fails with NoSuchMethodException → Tray.create returns null →
+# user sees "no tray icon".
+#
+# This bit production Win11 users on 2.2.13 (issue #197): launcher.log has
+# repeated `libtray.Win32Tray - WndProc upcall stub creation failed: no
+# such method: dev.hivens.libtray.windows.Win32TrayImpl.wndProcEntry(...)`.
+# The same pattern would fire on macOS (AppKitTrayImpl.onMenuItemEntry) once
+# Phase 4 ships through ProGuard, and probably already breaks Linux SNI's
+# release builds the same way (we just hadn't validated proguardReleaseJars
+# for the libtray pieces specifically).
+#
+# Wildcard `-keep class dev.hivens.libtray.** { *; }` is the right fix:
+# the libtray jar is opaque to us anyway, every backend uses the same
+# upcall pattern, and a single rule covers current + future backends.
+-keep class dev.hivens.libtray.** { *; }
+-dontwarn dev.hivens.libtray.**
 
 # --- Suppress Warnings ---
 -dontwarn ch.qos.logback.**

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -166,21 +166,31 @@ private fun setLinuxXToolkitAppClassName(name: String) {
 
 @OptIn(ExperimentalResourceApi::class)
 fun main() {
-    // BEFORE PlatformPaths resolution: apply any pending data-dir move
-    // scheduled from the Settings UI. If user clicked "Move data
-    // directory" → picker → restart, this is where the relocation
-    // actually happens. Bootstrap conf reads + file ops only; no logger
-    // initialized yet at this point so failures land in stderr.
-    // Operation is idempotent; safe to call on every startup.
-    DataDirMover.applyPending()
-
-    // Resolve logs dir BEFORE any LoggerFactory.getLogger() call so logback.xml
-    // (which reads `${aura.logs.dir}` for its rolling-file appenders) sees the
-    // platform-correct path on its very first init. The first getLogger we
-    // could hit is inside setLinuxXToolkitAppClassName.onFailure below — set
-    // the property before that to keep logback's classpath scan clean.
+    // Resolve logs dir BEFORE any LoggerFactory.getLogger() call so
+    // logback.xml (which reads `${aura.logs.dir}` for its rolling-file
+    // appenders) sees the platform-correct path on its very first init.
+    // PlatformPaths.system() is pure computation — no logger init —
+    // safe to call before the property is set. DataDirMover and
+    // BootstrapConf both have lazy log fields specifically so this
+    // ordering works without their applyPending() / read() touching
+    // logback first; see those files for the long-form rationale.
     val paths = PlatformPaths.system()
     System.setProperty("aura.logs.dir", paths.logsDir.toString())
+
+    // NOW safe to apply any pending data-dir move scheduled from the
+    // Settings UI. If user clicked "Move data directory" → picker →
+    // restart, this is where the relocation actually happens. Operation
+    // is idempotent; safe to call on every startup. The first log line
+    // it produces (only in the actual-move case, no-op otherwise) lands
+    // in `paths.logsDir/launcher.log`, not `./logs/launcher.log`.
+    //
+    // Edge case: if applyPending DOES move the data dir, paths.logsDir
+    // points at the old location and logback opens the file there —
+    // log entries about the move itself stream to the old path right
+    // up until the source dir is deleted. Next startup uses the new
+    // path correctly. The user opted into this two-restart flow when
+    // they clicked Move, so the one-time misdirect is acceptable.
+    DataDirMover.applyPending()
 
     // Pulse: tag every log line in this process with a stable 8-char sessionId
     // so a multi-launch user dump can be sliced per process invocation


### PR DESCRIPTION
Hotfix for 2.2.13.1, two bugs both surfaced via Win11 issue #197.

## Bug 1: launcher.log written to `./logs` instead of platform path

`DataDirMover` is a Kotlin `object` with eager `LoggerFactory.getLogger(...)` field. `Main.main()` references it BEFORE setting `aura.logs.dir` property. Singleton init → field eval → first logback init → file rolls to `./logs/launcher.log` (next to EXE). DiagnosticBundle reads from `paths.logsDir`, finds nothing → empty bundles for users.

Fix: reorder Main.kt (set property first, applyPending second) + lazy log fields in DataDirMover and BootstrapConf as defensive measure.

## Bug 2: libtray tray returns null with NoSuchMethodException

User's launcher.log shows:

```
WARN libtray.Win32Tray - WndProc upcall stub creation failed:
  no such method: dev.hivens.libtray.windows.Win32TrayImpl.wndProcEntry(...)
```

ProGuard removes `wndProcEntry` because there's no direct call site in source — the method is reached at runtime via Panama upcall stub function pointer (OS calls it through the stub). `MethodHandles.findStatic` then can't find the method, Tray.create returns null.

Same pattern would hit `AppKitTrayImpl.onMenuItemEntry` on macOS Phase 4 immediately. Likely already silently broken in SniTrayImpl on Linux release builds (we didn't validate proguardReleaseJars for libtray classes).

PR #194's `-dontwarn dev.hivens.libtray.**` suppresses warnings but does NOT prevent removal. Need `-keep`.

Fix: `-keep class dev.hivens.libtray.** { *; }`. Wildcard because libtray jar is opaque to us, every backend uses the same upcall pattern, single rule covers current + future backends.

## Test plan

- [x] `:client-launcher:compileKotlin :client-ui:compileKotlinDesktop` clean
- [x] `:client-ui:proguardReleaseJars` clean
- [ ] Cut 2.2.13.1, ask @ChoKO-pAYY to retest — tray should appear, `launcher.log` should land in `%LOCALAPPDATA%\AuraLauncher\logs\`