### PR TITLE
fix(proguard): keep org.freedesktop.dbus.** so ServiceLoader finds NativeTransportProvider

### DIFF
--- a/client-ui/compose-desktop.pro
+++ b/client-ui/compose-desktop.pro
@@ -129,6 +129,28 @@
 -keep class dev.hivens.libtray.** { *; }
 -dontwarn dev.hivens.libtray.**
 
+# ── dbus-java: ServiceLoader-resolved transport providers ─────────────────
+# Linux fielded report (file picker silently broken on AppImage): filekit's
+# XdgFilePickerPortal calls `DBusConnectionBuilder.forSessionBus()` which
+# triggers `TransportBuilder.findTransportProvider()` → `ServiceLoader<
+# ITransportProvider>` lookup. The provider class
+# `org.freedesktop.dbus.transport.jre.NativeTransportProvider` is loaded
+# only via META-INF/services — no direct call site in our code or in
+# dbus-java's call graph. ProGuard's reachability sees it as orphaned and
+# strips the class, then runtime ServiceLoader.iterator throws:
+#   ServiceConfigurationError: ITransportProvider: Provider
+#   org.freedesktop.dbus.transport.jre.NativeTransportProvider not found
+#
+# Side effect: filekit falls back to its non-portal LinuxFilePicker path,
+# which on Wayland (Hyprland / Plasma 6 wayland-only) produces no window
+# at all → user clicks "Open folder" / "Pick Java" → nothing happens.
+#
+# `-adaptresourcefilecontents META-INF/services/**` already preserves the
+# service descriptor file contents, but we ALSO need to keep the actual
+# implementation classes the descriptors point at. Wildcard the dbus-java
+# namespace; we don't ship anything else in those packages.
+-keep class org.freedesktop.dbus.** { *; }
+
 # --- Suppress Warnings ---
 -dontwarn ch.qos.logback.**
 -dontwarn org.slf4j.**


### PR DESCRIPTION
Hotfix on top of v2.2.14-rc1.

## What broke

Linux production AppImage on Wayland: every file picker (Open folder, Pick Java executable, Upload skin) silently no-ops. Stack trace from a maintainer's launcher.log:

```
ServiceConfigurationError: org.freedesktop.dbus.spi.transport.ITransportProvider:
Provider org.freedesktop.dbus.transport.jre.NativeTransportProvider not found
```

Filekit's \`XdgFilePickerPortal.isAvailable()\` calls dbus-java's \`TransportBuilder.findTransportProvider()\` → \`ServiceLoader<ITransportProvider>\` lookup. ProGuard removed the implementation class (no direct call site, ServiceLoader-only). Falls back to non-portal LinuxFilePicker which on Wayland produces no window.

## Fix

\`-keep class org.freedesktop.dbus.** { *; }\` — keeps the impl classes. \`-adaptresourcefilecontents META-INF/services/**\` was already preserving descriptor files, but those pointed at classes ProGuard had stripped.

## Same pattern, third namespace

ServiceLoader / reflection-discovered class strip is a recurring pattern in our ProGuard story:

  * 2.2.13: MacOSKeychainStorage Panama callers (warnings only because dontwarn fixed them)
  * v2.2.14-rc1 PR #198: libtray WndProc/NSMenuItem upcall handlers
  * THIS: dbus-java transport provider via ServiceLoader

Worth an audit pass over remaining META-INF/services consumers in a follow-up.

## Test plan

- [x] \`:client-ui:proguardReleaseJars\` clean
- [ ] Post-merge cut v2.2.14-rc2; on Linux AppImage verify file pickers open (Settings → Pick Java → file dialog appears)