### PR TITLE
fix(settings): drop startInTray, default closeAfterStart to false, clarify label

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
@@ -15,15 +15,18 @@ data class SettingsData(
      */
     var memoryMB: Int = 6144,
     var isDarkTheme: Boolean = true,
-    var closeAfterStart: Boolean = true,
+    /** Hide launcher window to tray after the user clicks Play. Off by
+     *  default — most users want the launcher to stay visible after
+     *  launching the game (it's where they go back to switch servers,
+     *  open console, etc). Opt-in for users who specifically want the
+     *  out-of-sight behaviour. */
+    var closeAfterStart: Boolean = false,
     var saveCredentials: Boolean = true,
     var savedFileManifest: FileManifest? = null,
     /** BCP-47 language tag: "ru", "en", "de" */
     var locale: String = "en",
     /** Offline Mode: skip authentication, use cached session */
     var isOfflineMode: Boolean = false,
-    /** Start minimized to tray; hide window on close instead of exiting */
-    var startInTray: Boolean = false,
 
     // ── Experimental features ─────────────────────────────────────────────────
     // Three knobs that opt the user into faster-but-less-stable update behavior.

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -293,8 +293,11 @@ fun main() {
 
         val settings = remember { settingsService.getSettings() }
 
-        // If startInTray — keep hidden until tray is confirmed ready
-        var isWindowVisible by remember { mutableStateOf(!settings.startInTray) }
+        // Window starts visible — `startInTray` was retired in 2.2.14:
+        // it confused users (launcher invisible after first run) and
+        // had no clear use case. Tray is the dock-style fallback for
+        // close-while-game-running, not a launcher hide-by-default mode.
+        var isWindowVisible by remember { mutableStateOf(true) }
 
         var isDarkTheme   by remember { mutableStateOf(settings.isDarkTheme) }
         var currentLocale by remember {
@@ -391,12 +394,10 @@ fun main() {
                 }
 
                 // Tray failed to init — restore the window so the user isn't
-                // stuck with no reachable UI. Two scenarios converge here:
-                //   1. startInTray=true: window was hidden by design, but
-                //      there's now no tray to bring it back. Show it.
-                //   2. startInTray=false but the user clicked the close
-                //      button during the INITIALIZING window (the close
-                //      handler at the bottom of this file uses canBeReady,
+                // stuck with no reachable UI. The scenario is:
+                //   - the user clicked the close button during the
+                //     INITIALIZING window (the close handler at the bottom
+                //     of this file uses canBeReady, not isSupported,
                 //      not isSupported, to avoid killing the launcher
                 //      mid-init). Same outcome — window hidden, no tray
                 //      either. Without this restore the process keeps

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -303,10 +303,6 @@ interface AppStrings {
     val trayServers: String
     val trayNoServers: String
 
-    // --- Settings: Start in tray ---
-    val settingsStartInTray: String
-    val settingsStartInTrayDesc: String
-
     // --- Settings: Experimental features ---
     val settingsSectionExperimental: String
     val settingsExperimentalMaster: String

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -69,7 +69,7 @@ object EnglishStrings : AppStrings {
     override val settingsThemePicker        = "Choose theme"
     override val settingsThemePickerSub     = "Customize the color scheme"
     override val settingsDarkTheme          = "Dark theme"
-    override val settingsCloseAfterLaunch   = "Close launcher after game starts"
+    override val settingsCloseAfterLaunch   = "Hide launcher to tray after server starts"
     override val settingsSaved              = "Settings saved"
     override val settingsLanguage           = "Language"
 
@@ -289,10 +289,6 @@ object EnglishStrings : AppStrings {
     override val trayShow          = "Show launcher"
     override val trayServers       = "Servers"
     override val trayNoServers     = "No servers loaded"
-
-    // --- Settings: Start in tray ---
-    override val settingsStartInTray     = "Start in tray"
-    override val settingsStartInTrayDesc = "Launch minimized; closing the window hides it to tray"
 
     // --- Settings: Experimental features ---
     override val settingsSectionExperimental    = "Experimental features"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -69,7 +69,7 @@ object GermanStrings : AppStrings {
     override val settingsThemePicker        = "Design auswählen"
     override val settingsThemePickerSub     = "Farbschema anpassen"
     override val settingsDarkTheme          = "Dunkles Design"
-    override val settingsCloseAfterLaunch   = "Launcher nach Spielstart schließen"
+    override val settingsCloseAfterLaunch   = "Launcher nach Serverstart in Tray minimieren"
     override val settingsSaved              = "Einstellungen gespeichert"
     override val settingsLanguage           = "Sprache"
 
@@ -289,10 +289,6 @@ object GermanStrings : AppStrings {
     override val trayShow          = "Launcher anzeigen"
     override val trayServers       = "Server"
     override val trayNoServers     = "Keine Server geladen"
-
-    // --- Settings: Start in tray ---
-    override val settingsStartInTray     = "Im Tray starten"
-    override val settingsStartInTrayDesc = "Minimiert starten; Fenster schließen versteckt es im Tray"
 
     // --- Settings: Experimental features ---
     override val settingsSectionExperimental    = "Experimentelle Funktionen"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -69,7 +69,7 @@ object RussianStrings : AppStrings {
     override val settingsThemePicker        = "Выбор темы"
     override val settingsThemePickerSub     = "Кастомизируйте цветовую схему"
     override val settingsDarkTheme          = "Тёмная тема"
-    override val settingsCloseAfterLaunch   = "Закрывать лаунчер после запуска игры"
+    override val settingsCloseAfterLaunch   = "Свернуть лаунчер в трей после запуска сервера"
     override val settingsSaved              = "Настройки сохранены"
     override val settingsLanguage           = "Язык"
 
@@ -290,9 +290,6 @@ object RussianStrings : AppStrings {
     override val trayServers       = "Серверы"
     override val trayNoServers     = "Серверы не загружены"
 
-    // --- Settings: Start in tray ---
-    override val settingsStartInTray     = "Запускать в трее"
-    override val settingsStartInTrayDesc = "Лаунчер стартует свёрнутым; закрытие окна прячет его в трей"
 
     // --- Settings: Experimental features ---
     override val settingsSectionExperimental    = "Экспериментальные функции"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
@@ -52,7 +52,6 @@ fun SettingsScreen(
     val initialSettings        = remember { settingsService.getSettings() }
     var closeAfterStart        by remember { mutableStateOf(initialSettings.closeAfterStart) }
     var isOfflineMode          by remember { mutableStateOf(initialSettings.isOfflineMode) }
-    var startInTray            by remember { mutableStateOf(initialSettings.startInTray) }
     var experimentalEnabled    by remember { mutableStateOf(initialSettings.experimentalFeaturesEnabled) }
     var mandatoryUpdates       by remember { mutableStateOf(initialSettings.mandatoryUpdatesEnabled) }
     var prereleaseChannel      by remember { mutableStateOf(initialSettings.prereleaseChannelEnabled) }
@@ -73,7 +72,6 @@ fun SettingsScreen(
             current.copy(
                 closeAfterStart             = closeAfterStart,
                 isOfflineMode               = isOfflineMode,
-                startInTray                 = startInTray,
                 experimentalFeaturesEnabled = experimentalEnabled,
                 mandatoryUpdatesEnabled     = mandatoryUpdates,
                 prereleaseChannelEnabled    = prereleaseChannel,
@@ -274,51 +272,6 @@ fun SettingsScreen(
                             colors = SwitchDefaults.colors(
                                 checkedThumbColor = CelestiaTheme.colors.error,
                                 checkedTrackColor = CelestiaTheme.colors.error.copy(alpha = 0.5f)
-                            )
-                        )
-                    }
-                    Spacer(Modifier.height(16.dp))
-
-                    // System Tray
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(CelestiaTheme.colors.background.copy(alpha = 0.4f))
-                            .padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Icon(
-                                Icons.Default.Minimize,
-                                null,
-                                tint = CelestiaTheme.colors.primary,
-                                modifier = Modifier.size(24.dp)
-                            )
-                            Spacer(Modifier.width(16.dp))
-                            Column {
-                                Text(
-                                    s.settingsStartInTray,
-                                    color = CelestiaTheme.colors.textPrimary,
-                                    fontWeight = FontWeight.Bold
-                                )
-                                Text(
-                                    s.settingsStartInTrayDesc,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = CelestiaTheme.colors.textSecondary
-                                )
-                            }
-                        }
-                        Switch(
-                            checked = startInTray,
-                            onCheckedChange = { startInTray = it; save() },
-                            colors = SwitchDefaults.colors(
-                                checkedThumbColor = CelestiaTheme.colors.primary,
-                                checkedTrackColor = CelestiaTheme.colors.primary.copy(alpha = 0.5f)
                             )
                         )
                     }


### PR DESCRIPTION
Three small UX fixes prompted by maintainer review of the Settings screen — bundled in one commit since they're all in the same conceptual cluster.

## Changes

* **Drop `startInTray`** — the setting launched the app invisible, only tray icon visible. Real-world feedback: confusing (users think launcher failed), no clear use case (auto-launch is OS-level), ~zero adoption. Removed from data, screen, three i18n tables, and Main.kt bootstrap.
* **`closeAfterStart` default true → false** — most users want launcher visible after Play (where they go back for server switch, console, etc). Hide-to-tray becomes opt-in.
* **Label rename** — \"Close launcher after game starts\" → \"Hide launcher to tray after server starts\" / Russian + German equivalents. Technically accurate (we don't close, we hide).

Setting key stays `closeAfterStart` for back-compat with persisted JSON. Existing `closeAfterStart=true` users keep their behaviour; only default for new installs flips. Removed `startInTray` field silently ignored on JSON load via existing `ignoreUnknownKeys = true`.