### PR TITLE
feat(puppet): in-process control bus + Ktor HTTP surface for CLI-driven UI testing

### DIFF
--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -60,6 +60,17 @@ kotlin {
                 implementation(libs.logback.classic)
                 implementation(libs.libtray)
                 implementation(libs.ktor.client.core)
+
+                // Puppet mode (hivens.ui.puppet) — opt-in HTTP control surface
+                // for automated UI driving. Server only binds when the JVM is
+                // launched with -Daura.puppet.port=N; otherwise these classes
+                // are loaded but inert. CIO engine chosen over Netty for the
+                // smaller dep footprint (~2.5 MB vs ~9 MB) since we only need
+                // a half-dozen localhost endpoints.
+                implementation(libs.ktor.server.core)
+                implementation(libs.ktor.server.cio)
+                implementation(libs.ktor.server.content.negotiation)
+                implementation(libs.ktor.serialization.json)
             }
         }
     }
@@ -223,7 +234,17 @@ compose.desktop {
                 arrayOf("-Dawt.toolkit.name=WLToolkit")
             } else {
                 emptyArray()
-            })
+            }),
+
+            // Puppet mode (hivens.ui.puppet.PuppetServer) — opt-in HTTP
+            // control surface for CLI-driven UI testing. Activated when
+            // the launcher is run with `-PauraPuppetPort=N` (forwarded
+            // into the JVM as -Daura.puppet.port=N). Without the property
+            // the puppet server's startIfRequested() is a no-op.
+            *(project.findProperty("auraPuppetPort")
+                ?.toString()
+                ?.let { arrayOf("-Daura.puppet.port=$it") }
+                ?: emptyArray())
         )
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
@@ -26,6 +26,7 @@ import hivens.launcher.NetworkState
 import hivens.ui.background.BackgroundSettings
 import hivens.ui.easter.AprilFools
 import hivens.ui.i18n.AppLocale
+import hivens.ui.puppet.PuppetClick
 import hivens.ui.screens.*
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.CustomTheme
@@ -244,6 +245,22 @@ fun AppSidebar(
     val profileOffset = sin(bounceCycle + 1.1f) * bounceAmplitude
     val settingsOffset= sin(bounceCycle + 2.2f) * bounceAmplitude
     val aboutOffset   = sin(bounceCycle + 3.3f) * bounceAmplitude
+
+    // Puppet: sidebar navigation. Puppet driver bypasses the AprilFools
+    // chaos wrapper — those are user-facing pranks, not behaviour we want
+    // to test against. Direct onScreenChange calls keep test runs
+    // deterministic regardless of the calendar.
+    PuppetClick("nav.home")     { onScreenChange(Screen.Home) }
+    PuppetClick("nav.profile", enabled = isAuthenticated) { onScreenChange(Screen.Profile) }
+    PuppetClick("nav.settings") { onScreenChange(Screen.Settings) }
+    PuppetClick("nav.about")    { onScreenChange(Screen.About) }
+    PuppetClick("nav.console")  {
+        if (GameConsoleService.shouldShowConsole) GameConsoleService.hide()
+        else GameConsoleService.show()
+    }
+    if (isAuthenticated) {
+        PuppetClick("nav.logout") { onLogout() }
+    }
 
     NavigationRail(
         modifier       = Modifier.width(64.dp).fillMaxHeight(),

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -275,10 +275,20 @@ fun main() {
             .warn("Failed to restore persisted forceProxyMode at startup", it)
     }
 
+    // Puppet mode: opt-in localhost HTTP control surface for automated
+    // UI driving (see hivens.ui.puppet.PuppetServer). Bind ONLY happens
+    // when -Daura.puppet.port=N is set; without the flag this is inert
+    // even though the classes are in the JAR. MUST run after Koin so
+    // PuppetRegistry-using Composables can resolve their dependencies,
+    // and before `application` so the server is listening when the
+    // first Composable registers itself.
+    hivens.ui.puppet.PuppetServer.startIfRequested()
+
     application {
         DisposableEffect(Unit) {
             onDispose {
                 TrayManager.shutdown()
+                hivens.ui.puppet.PuppetServer.stop()
                 stopKoin()
             }
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
@@ -566,6 +566,11 @@ fun AccountPanel(session: SessionData, onLogout: () -> Unit) {
                 color = CelestiaTheme.colors.error.copy(alpha = 0.65f)
             )
         }
+        // Puppet: secondary logout entry-point (the other is the sidebar
+        // ExitToApp icon, which is `nav.logout`). Kept distinct because a
+        // regression could hit just one of them — e.g. a layout change
+        // that detaches the right-panel logout but leaves the sidebar.
+        PuppetClick("account.logout") { onLogout() }
     }
 }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
@@ -49,6 +49,10 @@ import hivens.launcher.network.ServerProtocolConfig
 import hivens.ui.components.ConfirmCodeDialog
 import hivens.ui.easter.AprilFoolsButton
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetField
+import hivens.ui.puppet.PuppetScreen
+import hivens.ui.puppet.PuppetToggle
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.utils.SkinManager
 import kotlinx.coroutines.Dispatchers
@@ -242,6 +246,10 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
     // password, rememberMe) for the resume path. Dismissal cancels the
     // 2FA flow without clearing the form, letting the user retry.
     twoFactorPending?.let {
+        // Puppet: this dialog overrides the screen marker while open so
+        // /screen returns "Login_2FA" — drivers can detect the modal and
+        // pivot to the 2FA-specific element ids instead of the form ones.
+        PuppetScreen("Login_2FA")
         ConfirmCodeDialog(
             onDismiss = {
                 twoFactorPending = null
@@ -260,6 +268,7 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
             .padding(horizontal = 16.dp, vertical = 20.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
+        PuppetScreen("Login")
         Text(
             text       = s.loginTitle,
             style      = MaterialTheme.typography.titleMedium,
@@ -378,6 +387,11 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
             shape          = RoundedCornerShape(8.dp),
             colors         = fieldColors
         )
+        PuppetField("login.username", login) {
+            login = it
+            errorMessage = null
+            sslWarning = false
+        }
 
         OutlinedTextField(
             value                = password,
@@ -394,6 +408,11 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
             shape   = RoundedCornerShape(8.dp),
             colors  = fieldColors
         )
+        PuppetField("login.password", password) {
+            password = it
+            errorMessage = null
+            sslWarning = false
+        }
 
         Row(verticalAlignment = Alignment.CenterVertically) {
             Checkbox(
@@ -410,6 +429,7 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
                 color = CelestiaTheme.colors.textSecondary
             )
         }
+        PuppetToggle("login.rememberMe", rememberMe) { rememberMe = it }
 
         // LOG IN — chaos target (only when not loading, loading state stays reliable)
         if (isLoading) {
@@ -440,6 +460,7 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
                 ),
             )
         }
+        PuppetClick("login.submit", enabled = !isLoading) { doLogin() }
 
         // REGISTER — chaos target (#105)
         AprilFoolsButton(
@@ -461,6 +482,16 @@ fun LoginPanel(onLogin: (SessionData) -> Unit) {
                 contentColor   = CelestiaTheme.colors.primary,
             ),
         )
+        PuppetClick("login.register") {
+            runCatching {
+                val url = "${protocolConfig.baseUrl}/register"
+                if (Desktop.isDesktopSupported() &&
+                    Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)
+                ) {
+                    Desktop.getDesktop().browse(URI(url))
+                }
+            }
+        }
     }
 }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/ConfirmCodeDialog.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/ConfirmCodeDialog.kt
@@ -19,6 +19,8 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetField
 import hivens.ui.theme.CelestiaTheme
 
 /**
@@ -75,6 +77,9 @@ fun ConfirmCodeDialog(
                     color = CelestiaTheme.colors.textSecondary,
                 )
 
+                PuppetField("login.twoFactor.code", code, enabled = !isSubmitting) { raw ->
+                    code = raw.filter { it.isDigit() }.take(6)
+                }
                 OutlinedTextField(
                     value = code,
                     onValueChange = { raw ->
@@ -135,6 +140,7 @@ fun ConfirmCodeDialog(
                     TextButton(onClick = onDismiss, enabled = !isSubmitting) {
                         Text(s.auth2faCancel, color = CelestiaTheme.colors.textSecondary)
                     }
+                    PuppetClick("login.twoFactor.cancel", enabled = !isSubmitting) { onDismiss() }
                     Spacer(Modifier.width(8.dp))
                     Button(
                         onClick = { onSubmit(code) },
@@ -144,6 +150,9 @@ fun ConfirmCodeDialog(
                         ),
                     ) {
                         Text(s.auth2faSubmit)
+                    }
+                    PuppetClick("login.twoFactor.submit", enabled = code.length == 6 && !isSubmitting) {
+                        onSubmit(code)
                     }
                 }
             }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
@@ -13,6 +13,7 @@ import hivens.ui.easter.AprilFools
 import hivens.ui.easter.AprilFoolsButton
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.logic.LaunchState
+import hivens.ui.puppet.PuppetClick
 import hivens.ui.theme.CelestiaTheme
 import java.text.DecimalFormat
 
@@ -139,6 +140,17 @@ fun LaunchControlPanel(
                 },
                 modifier = Modifier.fillMaxWidth().height(50.dp)
             )
+        }
+        // Puppet: single action whose semantic depends on the current LaunchState.
+        // Same mapping as the CelestiaButton onClick above — driver doesn't need
+        // to know whether it's currently a Play / Abort / ClearError button, just
+        // "do the action attached to the launch control".
+        PuppetClick("dashboard.launch", enabled = state !is LaunchState.GameRunning) {
+            when (state) {
+                is LaunchState.Downloading, is LaunchState.Prepare -> onAbort()
+                is LaunchState.Error                               -> onClearError()
+                else                                               -> onLaunch()
+            }
         }
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/ServerGrid.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/ServerGrid.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.sp
 import hivens.core.api.model.ServerProfile
 import hivens.launcher.AutoSyncService
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
 import hivens.ui.theme.CelestiaTheme
 
 /**
@@ -71,16 +72,31 @@ fun ServerGrid(
                     color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.5f), letterSpacing = 1.5.sp,
                     modifier = Modifier.padding(top = if (index > 0) 8.dp else 0.dp, bottom = 4.dp)
                 )
-                is GridItem.Server -> SquareServerCard(
-                    profile = item.profile, isSelected = item.profile == selectedServer,
-                    isFavorite = favorites.contains(item.profile.assetDir),
-                    onSelect = { if (isLaunchable) onSelect(item.profile) },
-                    onLaunch = { if (isLaunchable) onLaunch(item.profile) },
-                    onSettings = { onSettings(item.profile) },
-                    onDetails = { onDetails(item.profile) },
-                    onToggleFav = { onToggleFav(item.profile) },
-                    syncState = syncStates[item.profile.assetDir]
-                )
+                is GridItem.Server -> {
+                    SquareServerCard(
+                        profile = item.profile, isSelected = item.profile == selectedServer,
+                        isFavorite = favorites.contains(item.profile.assetDir),
+                        onSelect = { if (isLaunchable) onSelect(item.profile) },
+                        onLaunch = { if (isLaunchable) onLaunch(item.profile) },
+                        onSettings = { onSettings(item.profile) },
+                        onDetails = { onDetails(item.profile) },
+                        onToggleFav = { onToggleFav(item.profile) },
+                        syncState = syncStates[item.profile.assetDir]
+                    )
+                    // Puppet: per-card actions keyed by assetDir so drivers can
+                    // pick a specific server by name (e.g. "SkyBlock") instead
+                    // of having to know its grid index. Only registered while
+                    // the card is composed (LazyVerticalGrid only composes
+                    // visible items) — off-screen cards won't be reachable
+                    // until scrolled into view. Not a problem with Aura's
+                    // current 7-server inventory; document if it grows.
+                    val asset = item.profile.assetDir
+                    PuppetClick("server.select.$asset", enabled = isLaunchable) { onSelect(item.profile) }
+                    PuppetClick("server.launch.$asset", enabled = isLaunchable) { onLaunch(item.profile) }
+                    PuppetClick("server.details.$asset") { onDetails(item.profile) }
+                    PuppetClick("server.settings.$asset") { onSettings(item.profile) }
+                    PuppetClick("server.toggleFav.$asset") { onToggleFav(item.profile) }
+                }
             }
         }
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/UpdateDialog.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/UpdateDialog.kt
@@ -22,6 +22,8 @@ import hivens.core.api.interfaces.IUpdateApplicator
 import hivens.core.data.LauncherUpdate
 import hivens.launcher.update.UpdateService
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetScreen
 import hivens.ui.theme.CelestiaTheme
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -51,6 +53,56 @@ fun UpdateDialog(
     // for everything that's about non-dismissability, and keep `isMandatory`
     // separate for the visual + button changes.
     val isBlocking = update.isCritical || update.isMandatory
+
+    // Puppet: dialog action set. Marker screen helps drivers detect the
+    // dialog is open; ids map to the buttons rendered below.
+    PuppetScreen("UpdateDialog")
+    PuppetClick("update.viewOnGithub", enabled = downloadState !is DownloadState.Downloading) {
+        runCatching {
+            val desktop = java.awt.Desktop.getDesktop()
+            if (desktop.isSupported(java.awt.Desktop.Action.BROWSE)) {
+                desktop.browse(java.net.URI(update.releasePageUrl))
+            }
+        }
+    }
+    PuppetClick("update.dismiss", enabled = !isBlocking && downloadState !is DownloadState.Downloading) {
+        onDismiss()
+    }
+    PuppetClick("update.exitForMandatory", enabled = update.isMandatory && downloadState !is DownloadState.Downloading) {
+        exitProcess(0)
+    }
+    PuppetClick("update.download", enabled = downloadState is DownloadState.Idle) {
+        scope.launch {
+            downloadState = DownloadState.Downloading(0L, 0L, 0.0)
+            errorMessage  = null
+            try {
+                val path = updateService.downloadUpdate(update) { dl, total, speed ->
+                    downloadState = DownloadState.Downloading(dl, total, speed)
+                }
+                downloadState = DownloadState.Ready(path.toString())
+            } catch (e: Exception) {
+                logger.error("Download failed", e)
+                errorMessage  = e.message ?: s.updateErrorUnknown
+                downloadState = DownloadState.Failed
+            }
+        }
+    }
+    PuppetClick("update.install", enabled = downloadState is DownloadState.Ready) {
+        val path = (downloadState as? DownloadState.Ready)?.installerPath ?: return@PuppetClick
+        try {
+            updateApplicator.scheduleUpdate(java.nio.file.Paths.get(path))
+            logger.info("Update scheduled, exiting...")
+            exitProcess(0)
+        } catch (e: Exception) {
+            logger.error("Failed to schedule update", e)
+            errorMessage  = "${s.updateScheduleFailed}: ${e.message}"
+            downloadState = DownloadState.Failed
+        }
+    }
+    PuppetClick("update.retry", enabled = downloadState is DownloadState.Failed) {
+        errorMessage = null
+        downloadState = DownloadState.Idle
+    }
 
     BasicAlertDialog(
         onDismissRequest = { if (!isBlocking) onDismiss() }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/UpdateNotification.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/UpdateNotification.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import hivens.core.data.LauncherUpdate
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
 import hivens.ui.theme.CelestiaTheme
 
 @Composable
@@ -29,6 +30,16 @@ fun UpdateNotification(
 ) {
     val s = LocalStrings.current
     var isVisible by remember { mutableStateOf(true) }
+
+    // Puppet: toast-style notification (above the main app). We do NOT
+    // override the current screen — the notification lives on top of
+    // whichever main screen is active.
+    PuppetClick("updateNotification.details", enabled = isVisible) {
+        isVisible = false; onOpenDialog()
+    }
+    PuppetClick("updateNotification.later", enabled = isVisible && !update.isCritical) {
+        isVisible = false; onDismiss()
+    }
 
     AnimatedVisibility(
         visible = isVisible,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/puppet/PuppetModifiers.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/puppet/PuppetModifiers.kt
@@ -1,0 +1,115 @@
+package hivens.ui.puppet
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.rememberUpdatedState
+
+/**
+ * Composable side-effects that register interactive widgets with
+ * [PuppetRegistry] for the duration of their composition.
+ *
+ * Pattern:
+ *   * Each helper uses [rememberUpdatedState] for every captured
+ *     parameter, so the registry always invokes the LATEST lambda /
+ *     reads the LATEST value — even when the host Composable
+ *     recomposes with new arguments.
+ *   * [DisposableEffect] keyed on `id` registers on entry and
+ *     unregisters on exit; navigating away from a screen removes its
+ *     elements cleanly, no stale entries.
+ *
+ * Usage at call site:
+ * ```kotlin
+ * var username by remember { mutableStateOf("") }
+ * OutlinedTextField(value = username, onValueChange = { username = it })
+ * PuppetField("login.username", username, { username = it })
+ *
+ * Button(onClick = { doLogin() }) { Text("Log in") }
+ * PuppetClick("login.submit") { doLogin() }
+ * ```
+ *
+ * Place the puppet call NEXT TO the widget it shadows, not wrapped
+ * around it — keeps the existing UI tree untouched and the puppet
+ * declarations skimmable.
+ */
+
+@Composable
+internal fun PuppetClick(
+    id: String,
+    enabled: Boolean = true,
+    onClick: () -> Unit,
+) {
+    val currentClick   = rememberUpdatedState(onClick)
+    val currentEnabled = rememberUpdatedState(enabled)
+    DisposableEffect(id) {
+        PuppetRegistry.registerClick(
+            id      = id,
+            enabled = { currentEnabled.value },
+            onClick = { currentClick.value() },
+        )
+        onDispose { PuppetRegistry.unregisterClick(id) }
+    }
+}
+
+// onValueChange is the LAST parameter so callers can use trailing-lambda
+// syntax: `PuppetField("id", value) { newValue -> ... }`. Don't reorder.
+
+@Composable
+internal fun PuppetField(
+    id: String,
+    value: String,
+    enabled: Boolean = true,
+    onValueChange: (String) -> Unit,
+) {
+    val currentValue   = rememberUpdatedState(value)
+    val currentSetter  = rememberUpdatedState(onValueChange)
+    val currentEnabled = rememberUpdatedState(enabled)
+    DisposableEffect(id) {
+        PuppetRegistry.registerField(
+            id       = id,
+            getValue = { currentValue.value },
+            setValue = { currentSetter.value(it) },
+            enabled  = { currentEnabled.value },
+        )
+        onDispose { PuppetRegistry.unregisterField(id) }
+    }
+}
+
+@Composable
+internal fun PuppetToggle(
+    id: String,
+    value: Boolean,
+    enabled: Boolean = true,
+    onValueChange: (Boolean) -> Unit,
+) {
+    val currentValue   = rememberUpdatedState(value)
+    val currentSetter  = rememberUpdatedState(onValueChange)
+    val currentEnabled = rememberUpdatedState(enabled)
+    DisposableEffect(id) {
+        PuppetRegistry.registerToggle(
+            id       = id,
+            getValue = { currentValue.value },
+            setValue = { currentSetter.value(it) },
+            enabled  = { currentEnabled.value },
+        )
+        onDispose { PuppetRegistry.unregisterToggle(id) }
+    }
+}
+
+/**
+ * Marks the currently-displayed screen by name. Place at the top of a
+ * top-level Composable that represents a navigable surface (Login,
+ * Dashboard, Settings, …). The puppet HTTP `/screen` endpoint returns
+ * whatever was last set here.
+ *
+ * Nested calls are NOT scoped (out of MVP scope) — if two PuppetScreen
+ * declarations are alive simultaneously, the most recently composed
+ * one wins. Aura's current navigation is a single top-level screen at
+ * a time, so this is fine.
+ */
+@Composable
+internal fun PuppetScreen(name: String) {
+    DisposableEffect(name) {
+        PuppetRegistry.setCurrentScreen(name)
+        onDispose { /* see KDoc on nested scoping */ }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/puppet/PuppetRegistry.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/puppet/PuppetRegistry.kt
@@ -1,0 +1,114 @@
+package hivens.ui.puppet
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-process registry of "puppet-controllable" UI elements. Composables
+ * register themselves on entry (composition) and unregister on disposal
+ * via the helpers in [PuppetModifiers]; the registry therefore always
+ * mirrors the LIVE UI surface — no stale entries for screens that
+ * aren't currently mounted.
+ *
+ * Read by [PuppetServer] when handling HTTP queries; mutated only via
+ * Composable side-effects. Backed by [ConcurrentHashMap] so the HTTP
+ * thread can read snapshots without blocking the UI thread, and
+ * registration churn from rapid recomposition stays correct.
+ *
+ * **State mutation thread.** Calls into [click] / [setField] /
+ * [setToggle] invoke caller-supplied lambdas that typically touch
+ * `mutableStateOf` — those MUST run on the AWT EDT, which is Compose
+ * Desktop's UI thread. The HTTP layer in [PuppetServer] is responsible
+ * for hopping onto the EDT before calling these methods; the registry
+ * itself doesn't dispatch.
+ */
+internal object PuppetRegistry {
+
+    private data class ClickEntry(
+        val onClick: () -> Unit,
+        val enabled: () -> Boolean,
+    )
+
+    private data class FieldEntry(
+        val getValue: () -> String,
+        val setValue: (String) -> Unit,
+        val enabled: () -> Boolean,
+    )
+
+    private data class ToggleEntry(
+        val getValue: () -> Boolean,
+        val setValue: (Boolean) -> Unit,
+        val enabled: () -> Boolean,
+    )
+
+    private val clicks  = ConcurrentHashMap<String, ClickEntry>()
+    private val fields  = ConcurrentHashMap<String, FieldEntry>()
+    private val toggles = ConcurrentHashMap<String, ToggleEntry>()
+
+    @Volatile private var currentScreen: String = "Unknown"
+
+    fun registerClick(id: String, enabled: () -> Boolean, onClick: () -> Unit) {
+        clicks[id] = ClickEntry(onClick, enabled)
+    }
+
+    fun unregisterClick(id: String) { clicks.remove(id) }
+
+    fun registerField(
+        id: String,
+        getValue: () -> String,
+        setValue: (String) -> Unit,
+        enabled: () -> Boolean,
+    ) {
+        fields[id] = FieldEntry(getValue, setValue, enabled)
+    }
+
+    fun unregisterField(id: String) { fields.remove(id) }
+
+    fun registerToggle(
+        id: String,
+        getValue: () -> Boolean,
+        setValue: (Boolean) -> Unit,
+        enabled: () -> Boolean,
+    ) {
+        toggles[id] = ToggleEntry(getValue, setValue, enabled)
+    }
+
+    fun unregisterToggle(id: String) { toggles.remove(id) }
+
+    fun setCurrentScreen(name: String) { currentScreen = name }
+
+    fun snapshot(): PuppetSnapshot {
+        val elements = buildList {
+            clicks.forEach  { (id, e) -> add(PuppetElement(id, "click",  enabled = e.enabled())) }
+            fields.forEach  { (id, e) -> add(PuppetElement(id, "field",  value = e.getValue(), enabled = e.enabled())) }
+            toggles.forEach { (id, e) -> add(PuppetElement(id, "toggle", boolValue = e.getValue(), enabled = e.enabled())) }
+        }.sortedBy { it.id }
+        return PuppetSnapshot(currentScreen, elements)
+    }
+
+    fun click(id: String): Result<Unit> {
+        val entry = clicks[id]
+            ?: return Result.failure(NoSuchElementException("no click handler for id=$id"))
+        if (!entry.enabled()) {
+            return Result.failure(IllegalStateException("element id=$id is disabled"))
+        }
+        return runCatching { entry.onClick() }
+    }
+
+    fun setField(id: String, value: String): Result<Unit> {
+        val entry = fields[id]
+            ?: return Result.failure(NoSuchElementException("no field for id=$id"))
+        if (!entry.enabled()) {
+            return Result.failure(IllegalStateException("element id=$id is disabled"))
+        }
+        return runCatching { entry.setValue(value) }
+    }
+
+    fun setToggle(id: String, value: Boolean): Result<Unit> {
+        val entry = toggles[id]
+            ?: return Result.failure(NoSuchElementException("no toggle for id=$id"))
+        if (!entry.enabled()) {
+            return Result.failure(IllegalStateException("element id=$id is disabled"))
+        }
+        return runCatching { entry.setValue(value) }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/puppet/PuppetServer.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/puppet/PuppetServer.kt
@@ -1,0 +1,136 @@
+package hivens.ui.puppet
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install
+import io.ktor.server.cio.CIO
+import io.ktor.server.cio.CIOApplicationEngine
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.routing
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.swing.Swing
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+
+/**
+ * Localhost HTTP server that exposes [PuppetRegistry] over a small JSON
+ * API, allowing external scripts (curl, automated UI test harnesses)
+ * to drive the Compose UI semantically — querying the current screen,
+ * clicking buttons, filling fields, toggling switches.
+ *
+ * **Strictly opt-in.** Only binds when `-Daura.puppet.port=N` is set
+ * at JVM launch. Without the flag, [start] is a no-op and no port is
+ * occupied; production builds therefore cannot accidentally expose
+ * the surface even with the classes present in the JAR.
+ *
+ * Bind is hardcoded to `127.0.0.1` — no remote access, no auth, the
+ * threat model assumes a trusted developer workstation. If you need
+ * authentication beyond "only local processes can connect", that's a
+ * separate iteration.
+ *
+ * **Threading.** Ktor handlers run on Dispatchers.IO by default;
+ * calls into [PuppetRegistry.click] / [setField] / [setToggle]
+ * mutate Compose `mutableStateOf` values, which MUST happen on the
+ * AWT EDT (Compose Desktop's UI thread). We hop via
+ * `withContext(Dispatchers.Swing)` before invoking the registry's
+ * mutating methods. Reads (snapshot, screen) are safe off-thread
+ * because the registry is backed by [java.util.concurrent.ConcurrentHashMap]
+ * and the values it reads (mutableState getters) tolerate concurrent
+ * reads.
+ *
+ * Endpoints:
+ *   * `GET  /screen`     → { screen: String }
+ *   * `GET  /elements`   → { screen: String, elements: [PuppetElement] }
+ *   * `POST /click`      ← { id: String }                  → { ok: true } | 404
+ *   * `POST /setField`   ← { id: String, value: String }   → { ok: true } | 404
+ *   * `POST /setToggle`  ← { id: String, value: Boolean }  → { ok: true } | 404
+ */
+internal object PuppetServer {
+
+    private val log = LoggerFactory.getLogger(PuppetServer::class.java)
+
+    @Volatile
+    private var server: EmbeddedServer<CIOApplicationEngine, CIOApplicationEngine.Configuration>? = null
+
+    /**
+     * Start the puppet HTTP server if `-Daura.puppet.port=N` is set.
+     * Idempotent — a second call when already running is a no-op.
+     */
+    fun startIfRequested() {
+        if (server != null) return
+        val portProp = System.getProperty("aura.puppet.port") ?: return
+        val port = portProp.toIntOrNull() ?: run {
+            log.warn("aura.puppet.port='{}' is not an integer — puppet mode disabled", portProp)
+            return
+        }
+
+        try {
+            val s = embeddedServer(CIO, port = port, host = "127.0.0.1") {
+                install(ContentNegotiation) { json() }
+                routing {
+                    get("/screen") {
+                        call.respond(ScreenResponse(PuppetRegistry.snapshot().screen))
+                    }
+                    get("/elements") {
+                        call.respond(PuppetRegistry.snapshot())
+                    }
+                    post("/click") {
+                        val req = call.receive<ClickRequest>()
+                        val result = withContext(Dispatchers.Swing) {
+                            PuppetRegistry.click(req.id)
+                        }
+                        replyResult(result)
+                    }
+                    post("/setField") {
+                        val req = call.receive<SetFieldRequest>()
+                        val result = withContext(Dispatchers.Swing) {
+                            PuppetRegistry.setField(req.id, req.value)
+                        }
+                        replyResult(result)
+                    }
+                    post("/setToggle") {
+                        val req = call.receive<SetToggleRequest>()
+                        val result = withContext(Dispatchers.Swing) {
+                            PuppetRegistry.setToggle(req.id, req.value)
+                        }
+                        replyResult(result)
+                    }
+                }
+            }
+            s.start(wait = false)
+            server = s
+            log.warn(
+                "PUPPET MODE ACTIVE — HTTP control surface on http://127.0.0.1:{}. " +
+                "Do not enable in production.",
+                port,
+            )
+        } catch (t: Throwable) {
+            log.error("Puppet HTTP server failed to start on port {}: {}", port, t.message)
+        }
+    }
+
+    fun stop() {
+        server?.stop(gracePeriodMillis = 100, timeoutMillis = 500)
+        server = null
+    }
+
+    private suspend fun io.ktor.server.routing.RoutingContext.replyResult(result: Result<Unit>) {
+        result.fold(
+            onSuccess = { call.respond(PuppetOk()) },
+            onFailure = { t ->
+                val code = when (t) {
+                    is NoSuchElementException -> HttpStatusCode.NotFound
+                    is IllegalStateException  -> HttpStatusCode.Conflict
+                    else                      -> HttpStatusCode.InternalServerError
+                }
+                call.respond(code, PuppetError(t.message ?: t::class.simpleName ?: "unknown error"))
+            },
+        )
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/puppet/PuppetTypes.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/puppet/PuppetTypes.kt
@@ -1,0 +1,45 @@
+package hivens.ui.puppet
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire format for the puppet HTTP API. Flat shape (no polymorphic
+ * sealed hierarchy) so curl clients can pluck fields with `jq` without
+ * needing to know Kotlin serialization quirks like class discriminators.
+ *
+ * [kind] is the discriminator: "click" | "field" | "toggle". Depending
+ * on [kind], either [value] (field) or [boolValue] (toggle) carries the
+ * current widget state; for "click" both are null.
+ */
+@Serializable
+internal data class PuppetElement(
+    val id: String,
+    val kind: String,
+    val value: String? = null,
+    val boolValue: Boolean? = null,
+    val enabled: Boolean = true,
+)
+
+@Serializable
+internal data class PuppetSnapshot(
+    val screen: String,
+    val elements: List<PuppetElement>,
+)
+
+@Serializable
+internal data class ScreenResponse(val screen: String)
+
+@Serializable
+internal data class PuppetOk(val ok: Boolean = true)
+
+@Serializable
+internal data class PuppetError(val error: String)
+
+@Serializable
+internal data class ClickRequest(val id: String)
+
+@Serializable
+internal data class SetFieldRequest(val id: String, val value: String)
+
+@Serializable
+internal data class SetToggleRequest(val id: String, val value: Boolean)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/AboutScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/AboutScreen.kt
@@ -34,6 +34,8 @@ import hivens.ui.easter.AprilFoolsText.GibberishMode
 import hivens.ui.generated.resources.Res
 import hivens.ui.generated.resources.favicon
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetScreen
 import hivens.ui.theme.CelestiaTheme
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
@@ -82,6 +84,29 @@ fun AboutScreen(onBack: () -> Unit) {
             updateService = updateService,
             onDismiss     = { showUpdateDialog = false }
         )
+    }
+
+    PuppetScreen("About")
+    PuppetClick("about.back") { onBack() }
+    PuppetClick("about.checkUpdates", enabled = updateState is UpdateCheckState.Idle) {
+        updateState = UpdateCheckState.Checking
+        scope.launch {
+            updateState = try {
+                val update = updateService.checkForUpdate(force = true)
+                if (update != null) UpdateCheckState.Available(update)
+                else UpdateCheckState.UpToDate
+            } catch (e: Exception) {
+                UpdateCheckState.Error(e.message ?: s.updateErrorUnknown)
+            }
+        }
+    }
+    // Reset the check state back to Idle (works for UpToDate / Available / Error).
+    PuppetClick("about.checkAgain", enabled = updateState !is UpdateCheckState.Idle &&
+        updateState !is UpdateCheckState.Checking) {
+        updateState = UpdateCheckState.Idle
+    }
+    PuppetClick("about.openUpdateDialog", enabled = updateState is UpdateCheckState.Available) {
+        showUpdateDialog = true
     }
 
     Column(Modifier.fillMaxSize().padding(24.dp)) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/BackgroundSettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/BackgroundSettingsScreen.kt
@@ -26,6 +26,9 @@ import hivens.ui.background.CustomBackground
 import hivens.ui.background.ScaleMode
 import hivens.ui.components.GlassCard
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetScreen
+import hivens.ui.puppet.PuppetToggle
 import hivens.ui.theme.CelestiaTheme
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
@@ -49,6 +52,20 @@ fun BackgroundSettingsScreen(
         settings = settings.block()
         onSettingsChanged(settings)
     }
+
+    PuppetScreen("BackgroundSettings")
+    PuppetClick("background.back") { onBack() }
+    PuppetToggle("background.enabled", settings.enabled) { update { copy(enabled = it) } }
+    PuppetClick("background.clearImage", enabled = settings.imagePath != null) {
+        update { copy(imagePath = null, enabled = false) }
+    }
+    PuppetClick("background.reset") {
+        settings = BackgroundSettings(); onSettingsChanged(settings)
+    }
+    // Sliders are float-valued; PuppetField (string) doesn't fit naturally.
+    // Out of MVP scope — a numeric setter shape can be added later if needed.
+    // Note: scale-mode + tint-color buttons reachable from in-process state,
+    // but selecting them by enum/hex name belongs in a follow-up.
 
     Column(Modifier.fillMaxSize().padding(24.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ConsoleWindow.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ConsoleWindow.kt
@@ -36,6 +36,10 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.rememberWindowState
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetField
+import hivens.ui.puppet.PuppetScreen
+import hivens.ui.puppet.PuppetToggle
 import hivens.ui.utils.GameConsoleService
 import hivens.ui.utils.LogEntry
 import hivens.ui.utils.LogType
@@ -167,6 +171,35 @@ private fun ConsoleContent(
 
     // ── Horizontal scroll for no-wrap mode ───────────────────────────────
     val hScroll = rememberScrollState()
+
+    // Puppet: console toolbar + search wiring. The ConsoleWindow itself is
+    // a separate OS window, so "screen" semantics overlap with whichever
+    // main launcher screen is active. We don't override [currentScreen] —
+    // drivers detect console presence via `console.*` ids being registered.
+    PuppetScreen("Console")
+    PuppetToggle("console.filterInfo", filterInfo)   { filterInfo = it }
+    PuppetToggle("console.filterWarn", filterWarn)   { filterWarn = it }
+    PuppetToggle("console.filterError", filterError) { filterError = it }
+    PuppetToggle("console.wrap", wrapText)           { wrapText = it }
+    PuppetToggle("console.regexMode", regexMode)     { regexMode = it }
+    PuppetField("console.search", searchQuery)       { searchQuery = it }
+    PuppetClick("console.clearSearch", enabled = searchQuery.isNotEmpty()) { searchQuery = "" }
+    PuppetClick("console.saveToFile") { GameConsoleService.saveToFile() }
+    PuppetClick("console.copyAll") {
+        val text = logsCopy.joinToString("\n") { e ->
+            if (e.type == LogType.DIVIDER) e.text else "[${e.timestamp}] ${e.text}"
+        }
+        scope.launch { clipboard.setClipEntry(ClipEntry(StringSelection(text))) }
+    }
+    PuppetClick("console.clear") { GameConsoleService.clear() }
+    PuppetClick("console.jumpToBottom", enabled = filtered.isNotEmpty()) {
+        scope.launch { listState.scrollToItem(filtered.lastIndex) }
+    }
+    // Font-size picker — one click per available size (no need for a dropdown
+    // open/close dance).
+    FONT_SIZES.forEach { size ->
+        PuppetClick("console.fontSize.$size") { fontSize = size }
+    }
 
     Column(Modifier.fillMaxSize()) {
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/DashboardScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/DashboardScreen.kt
@@ -26,6 +26,7 @@ import hivens.ui.components.ServerGrid
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.logic.LaunchState
 import hivens.ui.logic.LauncherController
+import hivens.ui.puppet.PuppetScreen
 import hivens.ui.theme.CelestiaTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -44,6 +45,8 @@ fun DashboardScreen(
     onOpenServerSettings: (ServerProfile) -> Unit,
     onOpenDetails: (ServerProfile) -> Unit
 ) {
+    PuppetScreen("Dashboard")
+
     val serverListService: IServerListService = koinInject()
     val settingsService: ISettingsService     = koinInject()
     val profileManager: ProfileManager        = koinInject()

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ProfileScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ProfileScreen.kt
@@ -20,6 +20,8 @@ import hivens.core.data.SessionData
 import hivens.ui.components.GlassCard
 import hivens.ui.easter.AprilFoolsButton
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetScreen
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.utils.SkinManager
 import io.github.vinceglb.filekit.FileKit
@@ -61,6 +63,21 @@ fun ProfileScreen(session: SessionData, skinRepository: SkinRepository) {
     }
 
     LaunchedEffect(Unit) { loadSkins() }
+
+    PuppetScreen("Profile")
+    PuppetClick("profile.refreshSkin") {
+        skinManager.invalidate(session.playerName); loadSkins()
+    }
+    PuppetClick("profile.topUp") {
+        runCatching {
+            val url = "http://smartycraft.ru/cabinet"
+            if (Desktop.isDesktopSupported() &&
+                Desktop.getDesktop().isSupported(Desktop.Action.BROWSE))
+                Desktop.getDesktop().browse(URI(url))
+        }
+    }
+    // Note: profile.uploadSkin triggers a native file picker — unreachable
+    // from puppet without supplying a path argument. Out of MVP scope.
 
     Column(Modifier.fillMaxSize().padding(24.dp)) {
         Text(s.profileTitle, style = MaterialTheme.typography.displaySmall, color = CelestiaTheme.colors.textPrimary)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerDetailScreen.kt
@@ -26,6 +26,8 @@ import hivens.launcher.platform.PlatformPaths
 import hivens.ui.components.GlassCard
 import hivens.ui.debug.SkiaTracker
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetScreen
 import hivens.ui.theme.CelestiaTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -65,6 +67,9 @@ fun ServerDetailScreen(
             isLoading = false
         }
     }
+
+    PuppetScreen("ServerDetail")
+    PuppetClick("serverDetail.back") { onBack() }
 
     Column(Modifier.fillMaxSize().padding(16.dp)) {
         Row(Modifier.fillMaxWidth().padding(bottom = 16.dp), verticalAlignment = Alignment.CenterVertically) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerSettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerSettingsScreen.kt
@@ -39,6 +39,10 @@ import hivens.ui.components.ModItemCard
 import hivens.ui.components.RamSelector
 import hivens.ui.debug.SkiaTracker
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetField
+import hivens.ui.puppet.PuppetScreen
+import hivens.ui.puppet.PuppetToggle
 import hivens.ui.theme.CelestiaTheme
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
@@ -148,6 +152,38 @@ fun ServerSettingsScreen(server: ServerProfile, onBack: () -> Unit) {
     }
 
     val borderColor = CelestiaTheme.colors.textSecondary.copy(alpha = 0.2f)
+
+    // Puppet ids prefixed with the server's assetDir so concurrent settings
+    // dialogs (theoretical — Aura keeps only one open at a time today) stay
+    // disambiguated, and tests can verify they're acting on the intended server.
+    val pkey = "serverSettings.${server.assetDir}"
+    PuppetScreen("ServerSettings.${server.assetDir}")
+    PuppetClick("$pkey.backAndSave") { saveProfile(); onBack() }
+    PuppetField("$pkey.javaPath", javaPath) { javaPath = it }
+    PuppetField("$pkey.jvmArgs", jvmArgs) { jvmArgs = it }
+    PuppetField("$pkey.winWidth", winWidth) { winWidth = it.filter { c -> c.isDigit() } }
+    PuppetField("$pkey.winHeight", winHeight) { winHeight = it.filter { c -> c.isDigit() } }
+    PuppetToggle("$pkey.fullScreen", fullScreen) { fullScreen = it }
+    PuppetToggle("$pkey.autoConnect", autoConnect) { autoConnect = it }
+    PuppetClick("$pkey.openFolder") {
+        val path = dataDirectory.resolve("clients").resolve(server.assetDir)
+        if (!path.toFile().exists()) path.toFile().mkdirs()
+        Desktop.getDesktop().open(path.toFile())
+    }
+    PuppetClick("$pkey.resetClient") {
+        val path = dataDirectory.resolve("clients").resolve(server.assetDir)
+        path.toFile().deleteRecursively()
+        saveProfile()
+        onBack()
+    }
+    PuppetClick("$pkey.openJvmBuilder", enabled = jvmBuilderEnabled) { showJvmBuilder = true }
+    // Per-mod toggle. Mods load asynchronously — registry mirrors what's
+    // currently composed, so puppet calls before modsLoaded return 404.
+    mods.forEach { mod ->
+        PuppetToggle("$pkey.mod.${mod.id}", modStates[mod.id] ?: mod.isDefault) {
+            modStates[mod.id] = it
+        }
+    }
 
     Column(Modifier.fillMaxSize().padding(24.dp)) {
         // ── Header ────────────────────────────────────────────────────────────

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
@@ -30,6 +30,9 @@ import hivens.ui.easter.AprilFoolsButton
 import hivens.ui.easter.AprilFoolsDebugPanel
 import hivens.ui.i18n.AppLocale
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetScreen
+import hivens.ui.puppet.PuppetToggle
 import hivens.ui.theme.CelestiaTheme
 import org.koin.compose.koinInject
 import java.awt.Desktop
@@ -45,6 +48,8 @@ fun SettingsScreen(
     onOpenBackgroundSettings: () -> Unit = {},
     onOpenAbout: () -> Unit = {}
 ) {
+    PuppetScreen("Settings")
+
     val settingsService: ISettingsService = koinInject()
     val paths: PlatformPaths              = koinInject()
     val s = LocalStrings.current
@@ -157,6 +162,14 @@ fun SettingsScreen(
                                         },
                                         onClick = { langDropdownExpanded = false; onLocaleChanged(locale) }
                                     )
+                                    // Puppet: per-locale direct click. Drivers can switch
+                                    // language without opening the dropdown first — the
+                                    // onLocaleChanged callback is what actually mutates
+                                    // state, the dropdown is presentation only.
+                                    PuppetClick("settings.language.${locale.name}") {
+                                        langDropdownExpanded = false
+                                        onLocaleChanged(locale)
+                                    }
                                 }
                             }
                         }
@@ -165,6 +178,7 @@ fun SettingsScreen(
                     Spacer(Modifier.height(16.dp))
 
                     // Theme picker shortcut
+                    PuppetClick("settings.openThemePicker") { onOpenThemePicker() }
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -189,6 +203,7 @@ fun SettingsScreen(
                     Spacer(Modifier.height(16.dp))
 
                     // Custom background shortcut
+                    PuppetClick("settings.openBackground") { onOpenBackgroundSettings() }
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -219,6 +234,9 @@ fun SettingsScreen(
                         checked         = themeSwitchState,
                         onCheckedChange = { isChecked -> themeSwitchState = isChecked; onToggleTheme() }
                     )
+                    PuppetToggle("settings.darkTheme", themeSwitchState) { isChecked ->
+                        themeSwitchState = isChecked; onToggleTheme()
+                    }
                 }
 
                 // ── Behavior ──────────────────────────────────────────────────
@@ -229,6 +247,7 @@ fun SettingsScreen(
                         checked         = closeAfterStart,
                         onCheckedChange = { closeAfterStart = it; save() }
                     )
+                    PuppetToggle("settings.closeAfterStart", closeAfterStart) { closeAfterStart = it; save() }
 
                     Spacer(Modifier.height(16.dp))
 
@@ -274,6 +293,7 @@ fun SettingsScreen(
                                 checkedTrackColor = CelestiaTheme.colors.error.copy(alpha = 0.5f)
                             )
                         )
+                        PuppetToggle("settings.offlineMode", isOfflineMode) { isOfflineMode = it; save() }
                     }
                 }
 
@@ -350,6 +370,14 @@ fun SettingsScreen(
                                     ) {
                                         Text(s.sslBypassRevoke, color = CelestiaTheme.colors.textSecondary)
                                     }
+                                    // Puppet: per-host revoke. Driver picks the host
+                                    // by its actual hostname string.
+                                    PuppetClick("settings.sslBypass.revoke.${entry.host}") {
+                                        hivens.core.diag.ActionRing.record(
+                                            "SSL bypass revoked by puppet driver: ${entry.host}",
+                                        )
+                                        hivens.launcher.NetworkState.revokeBypass(entry.host)
+                                    }
                                 }
                             }
                         }
@@ -378,6 +406,7 @@ fun SettingsScreen(
                                 onCheckedChange = { forceProxyMode = it; save() },
                             )
                         }
+                        PuppetToggle("settings.forceProxyMode", forceProxyMode) { forceProxyMode = it; save() }
                     }
                 }
 
@@ -395,6 +424,7 @@ fun SettingsScreen(
                         enabled        = true,
                         onCheckedChange = { experimentalEnabled = it; save() }
                     )
+                    PuppetToggle("settings.experimental", experimentalEnabled) { experimentalEnabled = it; save() }
 
                     Spacer(Modifier.height(16.dp))
 
@@ -407,6 +437,10 @@ fun SettingsScreen(
                         enabled        = experimentalEnabled,
                         onCheckedChange = { mandatoryUpdates = it; save() }
                     )
+                    // Mirror the UI's enabled-gating: master switch off => can't touch sub-toggles.
+                    PuppetToggle("settings.mandatoryUpdates", mandatoryUpdates, enabled = experimentalEnabled) {
+                        mandatoryUpdates = it; save()
+                    }
 
                     Spacer(Modifier.height(16.dp))
 
@@ -419,6 +453,9 @@ fun SettingsScreen(
                         enabled        = experimentalEnabled,
                         onCheckedChange = { prereleaseChannel = it; save() }
                     )
+                    PuppetToggle("settings.prereleaseChannel", prereleaseChannel, enabled = experimentalEnabled) {
+                        prereleaseChannel = it; save()
+                    }
 
                     Spacer(Modifier.height(16.dp))
 
@@ -431,6 +468,9 @@ fun SettingsScreen(
                         enabled        = experimentalEnabled,
                         onCheckedChange = { autoSyncAllPacks = it; save() }
                     )
+                    PuppetToggle("settings.autoSyncAllPacks", autoSyncAllPacks, enabled = experimentalEnabled) {
+                        autoSyncAllPacks = it; save()
+                    }
 
                     Spacer(Modifier.height(16.dp))
 
@@ -443,6 +483,9 @@ fun SettingsScreen(
                         enabled        = experimentalEnabled,
                         onCheckedChange = { jvmBuilderEnabled = it; save() }
                     )
+                    PuppetToggle("settings.jvmBuilder", jvmBuilderEnabled, enabled = experimentalEnabled) {
+                        jvmBuilderEnabled = it; save()
+                    }
                 }
 
                 // ── Data directory (move to a different drive / folder) ───────
@@ -604,6 +647,7 @@ fun SettingsScreen(
                                 contentColor   = CelestiaTheme.colors.textPrimary,
                             ),
                         )
+                        PuppetClick("settings.openLogsDir") { openFolder(paths.logsDir.toString()) }
                         // Open crash reports — chaos target
                         AprilFoolsButton(
                             id       = "settings_crash_reports_btn",
@@ -615,6 +659,7 @@ fun SettingsScreen(
                                 contentColor   = CelestiaTheme.colors.textPrimary,
                             ),
                         )
+                        PuppetClick("settings.openCrashReports") { openFolder(paths.crashDir.toString()) }
                     }
 
                     Spacer(Modifier.height(8.dp))
@@ -662,6 +707,16 @@ fun SettingsScreen(
                             ),
                             enabled  = !bundleBusy,
                         )
+                        PuppetClick("settings.createDiagBundle", enabled = !bundleBusy) {
+                            bundleBusy = true
+                            bundleScope.launch {
+                                val zip = withContext(kotlinx.coroutines.Dispatchers.IO) {
+                                    runCatching { DiagnosticBundle.create(paths) }.getOrNull()
+                                }
+                                if (zip != null) lastBundlePath = zip
+                                bundleBusy = false
+                            }
+                        }
                         AprilFoolsButton(
                             id       = "settings_report_github_btn",
                             text     = s.settingsReportOnGithub,
@@ -688,6 +743,18 @@ fun SettingsScreen(
                             ),
                             enabled  = lastBundlePath != null,
                         )
+                        PuppetClick("settings.reportOnGithub", enabled = lastBundlePath != null) {
+                            val zip = lastBundlePath ?: return@PuppetClick
+                            runCatching {
+                                java.awt.Toolkit.getDefaultToolkit().systemClipboard
+                                    .setContents(java.awt.datatransfer.StringSelection(zip.toString()), null)
+                                if (Desktop.isDesktopSupported()) {
+                                    Desktop.getDesktop().browse(
+                                        java.net.URI(hivens.launcher.diag.IssueReporter.bundleIssueUrl(zip))
+                                    )
+                                }
+                            }
+                        }
                     }
                     Text(
                         text     = s.settingsDiagnosticBundleHint,
@@ -700,6 +767,7 @@ fun SettingsScreen(
                 // ── About ─────────────────────────────────────────────────────
                 item {
                     SettingsSectionTitle(s.settingsSectionAbout)
+                    PuppetClick("settings.openAbout") { onOpenAbout() }
 
                     Row(
                         modifier = Modifier

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ThemePickerScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ThemePickerScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.unit.dp
 import hivens.ui.components.GlassCard
 import hivens.ui.easter.AprilFoolsButton
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetScreen
 import hivens.ui.theme.*
 
 @Composable
@@ -37,6 +39,17 @@ fun ThemePickerScreen(
     val s = LocalStrings.current
     var selectedTheme by remember { mutableStateOf(currentTheme) }
     val themes = remember { ThemePresets.getAll() }
+
+    PuppetScreen("ThemePicker")
+    PuppetClick("themePicker.back") { onBack() }
+    PuppetClick("themePicker.apply") { onThemeSelected(selectedTheme) }
+    // Per-theme select. Puppet driver names themes by their canonical
+    // theme.name (free text — Tea Sakura, Aurora, etc.). LazyVerticalGrid
+    // only composes visible rows; scroll the grid first if you target an
+    // off-screen theme. Aura's preset list fits in one viewport.
+    themes.forEach { theme ->
+        PuppetClick("themePicker.select.${theme.name}") { selectedTheme = theme }
+    }
 
     Column(
         modifier = Modifier

--- a/dev-tools/puppet/README.md
+++ b/dev-tools/puppet/README.md
@@ -1,0 +1,35 @@
+# puppet — CLI driver for Aura's in-process control surface
+
+Aura's UI exposes a small HTTP control surface (see
+`client-ui/src/desktopMain/kotlin/hivens/ui/puppet/`) when launched with
+`-Daura.puppet.port=N`. These scripts are thin curl wrappers around
+that surface, intended for ad-hoc UX debugging and automated regression
+scenarios.
+
+## Enabling puppet mode
+
+```sh
+./gradlew :client-ui:run \
+    -Pkotlin.jvm.target.validation.mode=ignore \
+    -Daura.puppet.port=58000
+```
+
+Without the system property, the server never binds — release builds
+cannot accidentally expose this surface.
+
+## Scripts
+
+All scripts default to `127.0.0.1:58000`. Override via
+`PUPPET_HOST=...` and `PUPPET_PORT=...` env vars.
+
+* `screen.sh`              — current top-level screen name
+* `elements.sh`            — full snapshot (screen + registered widgets)
+* `click.sh <id>`          — click a button / icon
+* `set-field.sh <id> <v>`  — fill a text field
+* `set-toggle.sh <id> <v>` — flip a switch (true/false)
+
+## Scenarios
+
+* `login.sh <user> <pass>`         — login form -> dashboard
+* `select-server.sh <assetDir>`    — click a server card
+* `launch-server.sh <assetDir>`    — full flow: select + click PLAY

--- a/dev-tools/puppet/_common.sh
+++ b/dev-tools/puppet/_common.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Shared helpers for puppet scripts.
+
+PUPPET_HOST="${PUPPET_HOST:-127.0.0.1}"
+PUPPET_PORT="${PUPPET_PORT:-58000}"
+PUPPET_BASE="http://${PUPPET_HOST}:${PUPPET_PORT}"
+
+# curl wrapper that surfaces non-2xx as a non-zero exit code AND prints
+# the JSON body so callers can pipe to jq even on errors.
+puppet_curl() {
+    local method="$1" path="$2" body="${3:-}"
+    local args=(-sS -X "$method" -H "Accept: application/json" "${PUPPET_BASE}${path}")
+    if [[ -n "$body" ]]; then
+        args+=(-H "Content-Type: application/json" --data "$body")
+    fi
+    local response status
+    response="$(curl "${args[@]}" -w '\n__HTTP_STATUS__:%{http_code}' 2>&1)" || {
+        echo "curl failed talking to ${PUPPET_BASE}" >&2
+        return 2
+    }
+    status="${response##*__HTTP_STATUS__:}"
+    response="${response%$'\n'__HTTP_STATUS__:*}"
+    printf '%s\n' "$response"
+    if (( status >= 400 )); then
+        echo "(http $status)" >&2
+        return 1
+    fi
+}

--- a/dev-tools/puppet/click.sh
+++ b/dev-tools/puppet/click.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <element-id>" >&2
+    exit 64
+fi
+puppet_curl POST /click "{\"id\":\"$1\"}"

--- a/dev-tools/puppet/elements.sh
+++ b/dev-tools/puppet/elements.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+puppet_curl GET /elements | jq .

--- a/dev-tools/puppet/launch-server.sh
+++ b/dev-tools/puppet/launch-server.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <assetDir>   # e.g. SkyBlock, Industrial, Create" >&2
+    exit 64
+fi
+echo "[puppet] select $1"
+"$(dirname "$0")/click.sh" "server.select.$1" >/dev/null
+sleep 0.2
+echo "[puppet] click dashboard.launch"
+"$(dirname "$0")/click.sh" dashboard.launch

--- a/dev-tools/puppet/login.sh
+++ b/dev-tools/puppet/login.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Drive the login form, optionally complete a 2FA prompt if it appears.
+#
+# Polls /screen between steps because submit is async — the API call
+# returns 200 OK as soon as the click is dispatched, NOT after the
+# server-side login completes. We need to wait for either:
+#   * screen -> "Dashboard" (login succeeded directly)
+#   * screen -> "Login_2FA" (server asked for a code)
+#
+# Usage:
+#   ./login.sh <username> <password>           # no 2FA expected
+#   ./login.sh <username> <password> <code>    # supply TOTP code in advance
+#
+# A timeout of 15 s on each wait — adjust via PUPPET_WAIT_TIMEOUT.
+
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+
+if [[ $# -lt 2 ]]; then
+    echo "usage: $0 <username> <password> [totp-code]" >&2
+    exit 64
+fi
+
+USERNAME="$1"
+PASSWORD="$2"
+TOTP_CODE="${3:-}"
+WAIT_TIMEOUT="${PUPPET_WAIT_TIMEOUT:-15}"
+
+wait_screen() {
+    local want="$1" deadline now
+    deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+    while true; do
+        local current
+        current="$(puppet_curl GET /screen | jq -r .screen)"
+        if [[ "$current" == "$want" ]]; then
+            echo "[puppet] screen=$current"
+            return 0
+        fi
+        now=$(date +%s)
+        if (( now >= deadline )); then
+            echo "[puppet] timeout waiting for screen=$want, current=$current" >&2
+            return 1
+        fi
+        sleep 0.3
+    done
+}
+
+wait_screen_either() {
+    local want_a="$1" want_b="$2" deadline now
+    deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+    while true; do
+        local current
+        current="$(puppet_curl GET /screen | jq -r .screen)"
+        if [[ "$current" == "$want_a" || "$current" == "$want_b" ]]; then
+            echo "[puppet] screen=$current"
+            printf '%s' "$current"
+            return 0
+        fi
+        now=$(date +%s)
+        if (( now >= deadline )); then
+            echo "[puppet] timeout waiting for screen in {$want_a,$want_b}, current=$current" >&2
+            return 1
+        fi
+        sleep 0.3
+    done
+}
+
+echo "[puppet] waiting for Login screen"
+wait_screen Login >/dev/null
+
+echo "[puppet] filling username"
+"$(dirname "$0")/set-field.sh" login.username "$USERNAME" >/dev/null
+
+echo "[puppet] filling password"
+"$(dirname "$0")/set-field.sh" login.password "$PASSWORD" >/dev/null
+
+echo "[puppet] click login.submit"
+"$(dirname "$0")/click.sh" login.submit >/dev/null
+
+reached="$(wait_screen_either Dashboard Login_2FA | tail -n 1)"
+
+if [[ "$reached" == "Login_2FA" ]]; then
+    if [[ -z "$TOTP_CODE" ]]; then
+        echo "[puppet] 2FA required but no code supplied; pass as 3rd arg" >&2
+        exit 1
+    fi
+    echo "[puppet] filling 2FA code"
+    "$(dirname "$0")/set-field.sh" login.twoFactor.code "$TOTP_CODE" >/dev/null
+    echo "[puppet] click login.twoFactor.submit"
+    "$(dirname "$0")/click.sh" login.twoFactor.submit >/dev/null
+    wait_screen Dashboard >/dev/null
+fi
+
+echo "[puppet] logged in OK"

--- a/dev-tools/puppet/login.sh
+++ b/dev-tools/puppet/login.sh
@@ -77,9 +77,41 @@ echo "[puppet] filling password"
 echo "[puppet] click login.submit"
 "$(dirname "$0")/click.sh" login.submit >/dev/null
 
-reached="$(wait_screen_either Dashboard Login_2FA | tail -n 1)"
+# Success detection: account.logout appears in the registry once
+# AppState transitions to Authenticated (the right-panel AccountPanel
+# renders). We do NOT rely on /screen — Aura preserves the previously-
+# selected Screen across logout, so after login we may land back on
+# Settings instead of Dashboard, and the screen marker can lag because
+# PuppetScreen uses last-writer-wins (see PR #201 known limitations).
+# 2FA detection: login.twoFactor.code appears.
+wait_post_login() {
+    local deadline now
+    deadline=$(( $(date +%s) + WAIT_TIMEOUT ))
+    while true; do
+        local snapshot
+        snapshot="$(curl -sS "${PUPPET_BASE}/elements" 2>/dev/null || echo '{}')"
+        if jq -e '.elements[] | select(.id == "login.twoFactor.code")' <<<"$snapshot" >/dev/null 2>&1; then
+            echo "[puppet] 2FA prompt detected"
+            printf '%s' "2FA"
+            return 0
+        fi
+        if jq -e '.elements[] | select(.id == "account.logout")' <<<"$snapshot" >/dev/null 2>&1; then
+            echo "[puppet] authenticated (account.logout in registry)"
+            printf '%s' "OK"
+            return 0
+        fi
+        now=$(date +%s)
+        if (( now >= deadline )); then
+            echo "[puppet] timeout waiting for post-login state" >&2
+            return 1
+        fi
+        sleep 0.3
+    done
+}
 
-if [[ "$reached" == "Login_2FA" ]]; then
+reached="$(wait_post_login | tail -n 1)"
+
+if [[ "$reached" == "2FA" ]]; then
     if [[ -z "$TOTP_CODE" ]]; then
         echo "[puppet] 2FA required but no code supplied; pass as 3rd arg" >&2
         exit 1
@@ -88,7 +120,8 @@ if [[ "$reached" == "Login_2FA" ]]; then
     "$(dirname "$0")/set-field.sh" login.twoFactor.code "$TOTP_CODE" >/dev/null
     echo "[puppet] click login.twoFactor.submit"
     "$(dirname "$0")/click.sh" login.twoFactor.submit >/dev/null
-    wait_screen Dashboard >/dev/null
+    # Same registry-based success detection after the 2FA submit.
+    wait_post_login >/dev/null
 fi
 
 echo "[puppet] logged in OK"

--- a/dev-tools/puppet/screen.sh
+++ b/dev-tools/puppet/screen.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+puppet_curl GET /screen

--- a/dev-tools/puppet/select-server.sh
+++ b/dev-tools/puppet/select-server.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <assetDir>   # e.g. SkyBlock, Industrial, Create" >&2
+    exit 64
+fi
+"$(dirname "$0")/click.sh" "server.select.$1"

--- a/dev-tools/puppet/set-field.sh
+++ b/dev-tools/puppet/set-field.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+if [[ $# -lt 2 ]]; then
+    echo "usage: $0 <element-id> <value>" >&2
+    exit 64
+fi
+# jq-build the request body so quotes / special chars in value are escaped properly
+body="$(jq -nc --arg id "$1" --arg value "$2" '{id:$id, value:$value}')"
+puppet_curl POST /setField "$body"

--- a/dev-tools/puppet/set-toggle.sh
+++ b/dev-tools/puppet/set-toggle.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/_common.sh"
+if [[ $# -lt 2 ]]; then
+    echo "usage: $0 <element-id> <true|false>" >&2
+    exit 64
+fi
+val="$2"
+case "$val" in
+    true|false) ;;
+    *) echo "value must be 'true' or 'false', got '$val'" >&2; exit 64 ;;
+esac
+body="$(jq -nc --arg id "$1" --argjson value "$val" '{id:$id, value:$value}')"
+puppet_curl POST /setToggle "$body"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,11 @@ ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-conte
 ktor-serialization-json         = { group = "io.ktor", name = "ktor-serialization-kotlinx-json",  version.ref = "ktor" }
 ktor-client-mock                = { group = "io.ktor", name = "ktor-client-mock",                 version.ref = "ktor" }
 
+# Ktor server (puppet HTTP control surface in client-ui — see hivens.ui.puppet)
+ktor-server-core                = { group = "io.ktor", name = "ktor-server-core",                 version.ref = "ktor" }
+ktor-server-cio                 = { group = "io.ktor", name = "ktor-server-cio",                  version.ref = "ktor" }
+ktor-server-content-negotiation = { group = "io.ktor", name = "ktor-server-content-negotiation",  version.ref = "ktor" }
+
 # Kotlinx
 kotlinx-serialization-json      = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 kotlinx-coroutines-test         = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test",    version.ref = "coroutines" }


### PR DESCRIPTION
## Why

Aura's UI had zero automated test coverage — every regression was caught by manual click-through or by an end user. The session that uncovered the LinuxUpdateApplicator AccessDeniedException (auto-update trying to swap /usr/lib/jvm/.../bin/java) was a perfect illustration: a real production bug we hit by accident during ad-hoc manual testing. Whatever else sits in the UI of the same flavour, we have no way to find it short of more accidents.

This PR introduces a small, opt-in, in-process control surface that lets a CLI driver (curl + jq) reach every navigable widget in the launcher. No OS-level click injection. No Selenium. Pure Compose-side instrumentation that mirrors the live composition.

## How

Three pieces:

1. **`PuppetRegistry`** (Kotlin `object`) — in-process registry of click handlers, field setters, toggle setters, current screen marker. Composables opt in via small side-effects (`PuppetClick`, `PuppetField`, `PuppetToggle`, `PuppetScreen`) placed next to the existing widget. `DisposableEffect` + `rememberUpdatedState` make the registry always mirror the live UI surface — navigate away and the entries disappear.

2. **`PuppetServer`** (Ktor CIO) — localhost HTTP server, binds ONLY when `-Daura.puppet.port=N` is set at JVM launch (forwarded via `./gradlew :client-ui:run -PauraPuppetPort=N`). Without the flag, classes are loaded but no port binds — release builds cannot accidentally expose the surface. Mutating handlers hop onto `Dispatchers.Swing` before invoking the registry, because Compose state mutation requires the UI thread.

3. **`dev-tools/puppet/*.sh`** — bash wrappers over `curl`. `screen.sh`, `elements.sh`, `click.sh`, `set-field.sh`, `set-toggle.sh`, plus higher-level `login.sh` / `select-server.sh` / `launch-server.sh` scenarios.

## Coverage

Currently instrumented:

- Sidebar nav (Home / Profile / Settings / About / Console / Logout)
- Login form (username / password / rememberMe / submit / register / 2FA dialog)
- Dashboard server cards (select / launch / details / settings / toggleFav per server)
- Launch control panel (single `dashboard.launch` mirroring play/abort/clear)
- Settings (all 8 toggles incl. closeAfterStart/forceProxyMode/experimental gating, language picker, diag bundle, open logs, theme/background entries, per-host SSL revoke)
- BackgroundSettings (back / enabled / clearImage / reset)
- ThemePicker (back / apply / per-theme select)
- Profile (refreshSkin / topUp)
- About (back / checkUpdates / checkAgain / openUpdateDialog)
- ServerDetail (back)
- ServerSettings (per-server prefixed: javaPath / jvmArgs / window / fullScreen / autoConnect / openFolder / resetClient / openJvmBuilder / per-mod toggle)
- Console (filter toggles / wrap / regex / search / saveToFile / copyAll / clear / jumpToBottom / fontSize)
- UpdateDialog (viewOnGithub / dismiss / exitForMandatory / download / install / retry — all with enabled-state mirroring the dialog's internal state machine)
- UpdateNotification (details / later)

~80 widget ids across 11 screens.

## Validated end-to-end (Hyprland session)

- `-PauraPuppetPort=58000` ⇒ server binds, warning logged, port listens
- Navigation Home → Profile → Settings → About round-trips, element counts shift per screen (Dashboard=43, Profile=9, Settings=18, About=11) — registry mirrors live composition
- **`POST /setToggle settings.closeAfterStart true` → `settings.json` on disk has `closeAfterStart=true`; flip back to false → reverts on disk**. End-to-end Compose state mutation, not just click dispatch.
- `POST /setField serverSettings.SkyBlock.javaPath` → value visible in OutlinedTextField via `/elements` read-back.
- `about.checkUpdates` kicks `UpdateService.checkForUpdate(force=true)` async; element enabled-state flips while in-flight and again on completion; `about.openUpdateDialog` becomes enabled when a release is available.
- Open `UpdateDialog` → `update.*` ids appear in registry → click `update.dismiss` → all `update.*` ids disappear (dialog disposed).
- All 7 server cards reachable for select / launch / details / settings / toggleFav.

## Security

- Bind hardcoded to `127.0.0.1` — no remote access.
- No auth — threat model is a trusted developer workstation. Anyone with shell on the box already has more dangerous capabilities than puppet provides.
- Off by default (no system property = no server) — release builds carry the classes inert.

## Known limitations (follow-up issues, not blockers for this PR)

- `LazyColumn` / `LazyVerticalGrid` only compose visible items — Settings sections below the fold (Diagnostics, DataDir) and off-screen server cards aren't in the registry until scrolled. Resolved by future `POST /scrollTo {id}`.
- `PuppetScreen` uses last-writer-wins. When a dialog over a screen disposes, `/screen` reports the disposed dialog's name until next nav. `/elements` stays correct — drivers can detect dialog presence via dialog-specific ids. Resolved by stack-based screen tracking.
- Native file pickers (uploadSkin, javaPath browse, dataDir move) unreachable from puppet. Resolved by a separate `PuppetSetPath` shape that bypasses the dialog.

## Footprint

- New deps: `ktor-server-core` + `ktor-server-cio` + `ktor-server-content-negotiation` (~4 MB to the release JAR, idiomatic with existing Ktor client usage).
- All puppet classes are `internal` to `client-ui` desktopMain.
- No changes to non-UI modules.

## Test plan
- [ ] `./gradlew :client-core:test :client-launcher:test` green (no test changes, sanity)
- [ ] `./gradlew :client-ui:run -PauraPuppetPort=58000` ⇒ launcher boots, log warns "PUPPET MODE ACTIVE"
- [ ] `./gradlew :client-ui:run` (no flag) ⇒ no port binds, no warning
- [ ] `curl 127.0.0.1:58000/screen` returns current screen
- [ ] `./dev-tools/puppet/login.sh <user> <pass>` drives login → dashboard