### PR TITLE
fix(zip,tar): allow in-target symlinks (closes #202)

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
@@ -177,7 +177,22 @@ class JavaManagerService(
                     throw IOException("Zip entry is outside of the target dir: ${entry.name}")
                 }
                 if (entry.isUnixSymlink) {
-                    throw SecurityException("Archive contains symlink entry: ${entry.name}")
+                    // For Zip, the link target is stored as the entry's payload
+                    // bytes (not a separate field like TAR). Validate that the
+                    // target, resolved relative to the symlink's parent, stays
+                    // within [dest] — same CVE-resistant pattern as the
+                    // TAR path below.
+                    val linkTarget = zf.getInputStream(entry).use { it.readBytes() }.decodeToString()
+                    val resolvedTarget = resolvedPath.parent.resolve(linkTarget).normalize()
+                    if (!resolvedTarget.startsWith(dest)) {
+                        throw SecurityException(
+                            "Symlink target escapes destination: ${entry.name} -> $linkTarget",
+                        )
+                    }
+                    Files.createDirectories(resolvedPath.parent)
+                    Files.deleteIfExists(resolvedPath)
+                    Files.createSymbolicLink(resolvedPath, Path.of(linkTarget))
+                    continue
                 }
 
                 if (entry.isDirectory) {
@@ -203,21 +218,41 @@ class JavaManagerService(
                             if (!resolvedPath.startsWith(dest)) {
                                 throw IOException("Tar entry is outside of the target dir: ${entry.name}")
                             }
-                            // Reject every entry kind that isn't a plain file or
-                            // directory (#187). TAR natively encodes symlinks /
-                            // hardlinks / FIFOs / device nodes — none of which
-                            // belong in a BellSoft JDK tarball, but a tampered
-                            // upstream could ship one to redirect writes outside
-                            // [dest]. Hard fail rather than skip so a malicious
-                            // archive surfaces loudly in logs / crash report.
-                            if (entry.isSymbolicLink || entry.isLink ||
-                                entry.isFIFO || entry.isCharacterDevice || entry.isBlockDevice) {
+                            // Hard-reject entry kinds that have no legitimate use
+                            // in any archive we extract: hardlinks (would let a
+                            // tampered tarball create a hardlink to a sensitive
+                            // file outside [dest] for the next write to clobber),
+                            // FIFOs, character devices, block devices.
+                            if (entry.isLink || entry.isFIFO ||
+                                entry.isCharacterDevice || entry.isBlockDevice) {
                                 throw SecurityException(
                                     "Archive contains non-regular entry (${entry.javaClass.simpleName}): ${entry.name}",
                                 )
                             }
 
-                            if (entry.isDirectory) {
+                            if (entry.isSymbolicLink) {
+                                // BellSoft Linux/macOS JDK tarballs include
+                                // legitimate intra-package symlinks (e.g.
+                                // jre/lib/.../libjsig.so → libjsig.so.0).
+                                // Allow the link when its target, resolved
+                                // relative to the symlink's parent, stays
+                                // within [dest]; reject when it would escape,
+                                // so a tampered upstream can't redirect the
+                                // next write outside our extraction root.
+                                // (#202 — was blanket-rejected before, which
+                                // broke fresh Linux installs since every
+                                // BellSoft Linux JDK ships symlinks.)
+                                val linkTarget = entry.linkName ?: ""
+                                val resolvedTarget = resolvedPath.parent.resolve(linkTarget).normalize()
+                                if (!resolvedTarget.startsWith(dest)) {
+                                    throw SecurityException(
+                                        "Symlink target escapes destination: ${entry.name} -> $linkTarget",
+                                    )
+                                }
+                                Files.createDirectories(resolvedPath.parent)
+                                Files.deleteIfExists(resolvedPath)
+                                Files.createSymbolicLink(resolvedPath, Path.of(linkTarget))
+                            } else if (entry.isDirectory) {
                                 Files.createDirectories(resolvedPath)
                             } else {
                                 Files.createDirectories(resolvedPath.parent)

--- a/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
@@ -339,6 +339,89 @@ class JavaManagerServiceTest {
         }
     }
 
+    // ── #202: in-target symlinks must be ALLOWED ─────────────────────────
+    //
+    // BellSoft's Linux/macOS JDK tarballs ship legitimate intra-package
+    // symlinks (jre/lib/.../libjsig.so → libjsig.so.0 and similar). The
+    // post-#187 blanket rejection turned every Linux fresh install into a
+    // SecurityException at JDK-extract time. Allow them when the target,
+    // resolved relative to the symlink's parent, stays within [dest].
+
+    @Test
+    fun `untargz allows in-target symbolic link (BellSoft JDK layout)`() {
+        val archive = workDir.resolve("jdk-with-symlink.tar.gz").toFile()
+        TarArchiveOutputStream(GzipCompressorOutputStream(FileOutputStream(archive))).use { tos ->
+            // The real target file.
+            val real = TarArchiveEntry("lib/libjsig.so.0")
+            val bytes = "fake-elf".toByteArray()
+            real.size = bytes.size.toLong()
+            tos.putArchiveEntry(real)
+            tos.write(bytes)
+            tos.closeArchiveEntry()
+            // Symlink alongside it pointing to the real file via a relative path
+            // — same shape as the BellSoft tarball entry that previously broke
+            // Linux fresh installs.
+            val link = TarArchiveEntry("lib/libjsig.so", TarArchiveEntry.LF_SYMLINK)
+            link.linkName = "libjsig.so.0"
+            tos.putArchiveEntry(link)
+            tos.closeArchiveEntry()
+        }
+        val dest = workDir / "extract-jdk"
+        Files.createDirectories(dest)
+
+        svc.untargz(archive, dest)
+
+        val symlink = dest / "lib" / "libjsig.so"
+        assertEquals(true, Files.isSymbolicLink(symlink), "expected symlink at $symlink")
+        // Resolving the link should land on the real file inside dest.
+        assertEquals("fake-elf", Files.readString(symlink.toRealPath()))
+    }
+
+    @Test
+    fun `untargz rejects symbolic link whose target escapes destination`() {
+        val malicious = workDir.resolve("evil-escaping-symlink.tar.gz").toFile()
+        TarArchiveOutputStream(GzipCompressorOutputStream(FileOutputStream(malicious))).use { tos ->
+            // Relative path that climbs out of [dest] entirely.
+            val link = TarArchiveEntry("inside/safe-name", TarArchiveEntry.LF_SYMLINK)
+            link.linkName = "../../../../etc/passwd"
+            tos.putArchiveEntry(link)
+            tos.closeArchiveEntry()
+        }
+        val dest = workDir / "extract-target"
+        Files.createDirectories(dest)
+        assertFailsWith<SecurityException> {
+            svc.untargz(malicious, dest)
+        }
+    }
+
+    @Test
+    fun `unzip allows in-target symbolic link`() {
+        val archive = workDir.resolve("zip-with-symlink.zip").toFile()
+        ZipArchiveOutputStream(FileOutputStream(archive)).use { zos ->
+            // Real file.
+            val real = ZipArchiveEntry("inner/target.txt")
+            val bytes = "hello".toByteArray()
+            real.size = bytes.size.toLong()
+            zos.putArchiveEntry(real)
+            zos.write(bytes)
+            zos.closeArchiveEntry()
+            // Symlink with target stored as the entry's payload (Zip convention).
+            val link = ZipArchiveEntry("inner/link.txt")
+            link.unixMode = UnixStat.LINK_FLAG or 0b111_111_111
+            zos.putArchiveEntry(link)
+            zos.write("target.txt".toByteArray())
+            zos.closeArchiveEntry()
+        }
+        val dest = workDir / "extract-zip-target"
+        Files.createDirectories(dest)
+
+        svc.unzip(archive, dest)
+
+        val symlink = dest / "inner" / "link.txt"
+        assertEquals(true, Files.isSymbolicLink(symlink), "expected symlink at $symlink")
+        assertEquals("hello", Files.readString(symlink.toRealPath()))
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────
 
     private inline fun <T> withSystemProp(key: String, value: String, block: () -> T): T {


### PR DESCRIPTION
Closes #202.

## Problem

71438ee added a blanket symlink rejection in `JavaManagerService` (both `untargz` and `unzip`) to plug zip-slip via symlinks (#187). The implementation overshot: BellSoft Linux/macOS JDK tarballs ship legitimate intra-package symlinks (`jre/lib/<arch>/server/libjsig.so → libjsig.so.0` and similar), so every Linux fresh-install JDK download fails with `SecurityException: Archive contains non-regular entry`. Users who upgraded from 2.2.12 keep working (their runtimes/ was extracted pre-71438ee); new installs are fully blocked.

## Fix

Narrow the symlink check to the actual threat model: allow symlinks whose target, resolved relative to the symlink's parent directory, stays within `dest`; reject when it would escape. Hardlinks, FIFOs, char/block devices stay hard-rejected (different attack surfaces the symlink path can't safely cover).

Same treatment in both extractors. `client-core/ZipUtils.unzip` (modpack/assets path) intentionally unchanged — that handles untrusted upstream content and the existing skip-with-warn is the correct conservative default.

## Tests

New:
- `untargz allows in-target symbolic link (BellSoft JDK layout)` — extracts the libjsig.so → libjsig.so.0 shape, asserts `toRealPath` resolves to the real file.
- `untargz rejects symbolic link whose target escapes destination` — `../../../../etc/passwd` style.
- `unzip allows in-target symbolic link` — same shape for Zip.

Existing #187 tests still green: escaping symlinks rejected (TAR + ZIP), hardlinks rejected.

`:client-core:test` and `:client-launcher:test` both pass.

## How found

PR #201 (puppet mode) made it cheap to drive a real launch end-to-end on a wiped data directory. Aura downloaded the SkyBlock pack, then the BellSoft JDK 8 tarball, then died at extract. The fix unblocks the Linux fresh-install path.

## Test plan
- [ ] `./gradlew :client-core:test :client-launcher:test` green
- [ ] On Linux, wipe `~/.local/share/aura-launcher/runtimes/`, click PLAY on any server — JDK extracts cleanly, game launches
- [ ] On Windows (Setup.exe), fresh install — JDK extracts cleanly (Windows JDKs don't ship symlinks today, but the unzip path also allows in-target ones for future-proofing)