### PR TITLE
fix(jdk): validate runnability of existing and freshly downloaded JDK

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
@@ -16,6 +16,7 @@ import java.io.*
 import java.nio.file.*
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.PosixFilePermission
+import java.util.concurrent.TimeUnit
 
 class JavaManagerService(
     baseDir: Path,
@@ -37,9 +38,15 @@ class JavaManagerService(
         val folderName = "java-$javaVersion-$os-$arch"
         val targetDir = runtimesDir.resolve(folderName)
 
-        findJavaExecutable(targetDir)?.let { return@withContext it }
-
-        log.info("Java {} ({}/{}) was not found locally. We are starting to download...", javaVersion, os, arch)
+        val existing = findJavaExecutable(targetDir)
+        if (existing != null && isJavaUsable(existing)) {
+            return@withContext existing
+        }
+        if (existing != null) {
+            log.warn("Java at {} failed -version check, treating as broken and re-downloading", existing)
+        } else {
+            log.info("Java {} ({}/{}) was not found locally. We are starting to download...", javaVersion, os, arch)
+        }
         downloadAndUnpack(javaVersion, targetDir)
 
         val executable = findJavaExecutable(targetDir)
@@ -47,6 +54,10 @@ class JavaManagerService(
 
         if (os != "win") {
             setExecutablePermissions(executable)
+        }
+
+        if (!isJavaUsable(executable)) {
+            throw IOException("Java was downloaded and extracted, but $executable failed -version check. Archive may be corrupt or missing native loader files (e.g. libjli.so).")
         }
 
         return@withContext executable
@@ -124,6 +135,36 @@ class JavaManagerService(
                 }.findFirst().orElse(null)
             }
         } catch (_: Exception) { null }
+    }
+
+    /**
+     * Runs `<javaExe> -version` and returns true iff the process completes
+     * with exit code 0 within a few seconds. Detects JDKs whose binary exists
+     * and has the executable bit set but cannot actually launch — e.g. an
+     * extracted archive missing native loader files like `libjli.so`, where
+     * the dynamic linker fails before the JVM itself starts.
+     */
+    internal fun isJavaUsable(javaExe: Path): Boolean {
+        return try {
+            val process = ProcessBuilder(javaExe.toString(), "-version")
+                .redirectErrorStream(true)
+                .start()
+            // Drain the merged stream in a background daemon thread so a
+            // chatty JDK does not block on a full pipe buffer, and so a
+            // hanging child cannot keep us in readBytes() past the
+            // waitFor timeout. Daemon so JVM exit is never blocked by a
+            // stuck reader.
+            Thread {
+                try { process.inputStream.use { it.readBytes() } } catch (_: Exception) {}
+            }.apply { isDaemon = true }.start()
+            if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                return false
+            }
+            process.exitValue() == 0
+        } catch (_: Exception) {
+            false
+        }
     }
 
     private fun deleteDirectoryRecursively(path: Path) {

--- a/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
@@ -159,6 +159,13 @@ class JavaManagerService(
             }.apply { isDaemon = true }.start()
             if (!process.waitFor(5, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
+                // destroyForcibly is async (SIGKILL on Linux,
+                // TerminateProcess on Windows). Block briefly so file
+                // handles release before the caller deletes targetDir
+                // -- on Windows a still-alive java.exe keeps extracted
+                // files locked, turning the recovery re-download into
+                // an exception loop.
+                process.waitFor(3, TimeUnit.SECONDS)
                 return false
             }
             process.exitValue() == 0

--- a/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
@@ -30,6 +30,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
@@ -246,6 +247,45 @@ class JavaManagerServiceTest {
         val found = svc.findJavaExecutable(jdkRoot)
         assertNotNull(found)
         assertEquals("java", found.fileName.toString())
+    }
+
+    // ── isJavaUsable: subprocess gate against broken JDK extractions ──────
+
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun `isJavaUsable returns true for runnable binary exiting 0`() {
+        val ok = workDir / "fakejava"
+        Files.writeString(ok, "#!/bin/sh\nexit 0\n")
+        ok.toFile().setExecutable(true)
+        assertTrue(svc.isJavaUsable(ok))
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun `isJavaUsable returns false for executable file with no valid interpreter`() {
+        // +x bit set but content is not a valid script or ELF -- the
+        // exec syscall fails and the spawned process never starts.
+        val broken = workDir / "garbage"
+        Files.writeString(broken, "this is not a script or executable")
+        broken.toFile().setExecutable(true)
+        assertFalse(svc.isJavaUsable(broken))
+    }
+
+    @Test
+    fun `isJavaUsable returns false for missing file`() {
+        assertFalse(svc.isJavaUsable(workDir / "does-not-exist"))
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun `isJavaUsable returns false when subprocess does not finish within timeout`() {
+        // A real broken JDK can hang during the dynamic linker stage. The
+        // 5s timeout fires and destroyForcibly cleans up; we must not
+        // wait forever.
+        val slow = workDir / "slow"
+        Files.writeString(slow, "#!/bin/sh\nsleep 30\n")
+        slow.toFile().setExecutable(true)
+        assertFalse(svc.isJavaUsable(slow))
     }
 
     // ── unzip: zip-slip protection (security-relevant) ───────────────────
@@ -541,16 +581,82 @@ class JavaManagerServiceTest {
         }
     }
 
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun `getJavaPath re-downloads when existing executable fails -version check`() {
+        // Pre-place a "java" with the +x bit but content that cannot
+        // execute (no shebang, no interpreter). isJavaUsable rejects it,
+        // the orchestrator must fall through to download instead of
+        // returning a path that would die with exit 127 when launched.
+        val runtimesRoot = workDir
+        val folderName = "java-21-linux-x64"
+        val targetDir = runtimesRoot / "runtimes" / folderName
+        val binDir = (targetDir / "bin").also { Files.createDirectories(it) }
+        Files.writeString(binDir / "java", "broken bytes with no shebang")
+        binDir.resolve("java").toFile().setExecutable(true)
+
+        val tarGz = synthesiseJdkTarGz("jdk-21.0.9+15/bin/java")
+        val provider = mockClientWithBytes(tarGz)
+
+        withSystemProp("os.name", "Linux") {
+            withSystemProp("os.arch", "amd64") {
+                val resolved = runBlocking {
+                    JavaManagerService(runtimesRoot, provider).getJavaPath("1.21.1")
+                }
+                assertEquals("java", resolved.fileName.toString())
+                assertTrue(
+                    svc.isJavaUsable(resolved),
+                    "re-downloaded Java must be runnable so the next call short-circuits",
+                )
+            }
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun `getJavaPath throws when freshly downloaded java fails -version check`() {
+        // Server returns a tarball whose "java" exists at the expected
+        // path with the +x bit but cannot run. This is the libjli-missing
+        // shape: findJavaExecutable returns a path, isJavaUsable rejects
+        // it, the orchestrator throws so the caller surfaces a clear
+        // error instead of handing back a path that will exit 127.
+        val runtimesRoot = workDir
+        val tarGz = synthesiseJdkTarGz(
+            "jdk-21.0.9+15/bin/java",
+            "unrunnable garbage with no shebang".toByteArray(),
+        )
+        val provider = mockClientWithBytes(tarGz)
+
+        withSystemProp("os.name", "Linux") {
+            withSystemProp("os.arch", "amd64") {
+                val ex = assertFails {
+                    runBlocking {
+                        JavaManagerService(runtimesRoot, provider).getJavaPath("1.21.1")
+                    }
+                }
+                assertTrue(
+                    ex is IOException &&
+                        ex.message?.contains("failed -version", ignoreCase = true) == true,
+                    "expected IOException about failed -version check, got ${ex::class.simpleName}: ${ex.message}",
+                )
+            }
+        }
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────
 
     /**
      * Build a minimal in-memory `.tar.gz` containing a single regular-file
-     * entry at [path] with execute-bit-set mode. Bytes are the literal
-     * "fake-jdk-binary" -- enough for findJavaExecutable to treat the file
-     * as a real binary candidate after extraction.
+     * entry at [path] with execute-bit-set mode. Default [payload] is a
+     * minimal shell script that exits 0 -- runnable enough for the
+     * isJavaUsable `-version` probe to return true after extraction.
+     * Override [payload] for tests that need an explicitly unrunnable
+     * binary (e.g. the libjli-missing shape).
      */
-    private fun synthesiseJdkTarGz(path: String): ByteArray {
-        val payload = "fake-jdk-binary".toByteArray()
+    private fun synthesiseJdkTarGz(
+        path: String,
+        payload: ByteArray = "#!/bin/sh\nexit 0\n".toByteArray(),
+    ): ByteArray {
         val out = ByteArrayOutputStream()
         GzipCompressorOutputStream(out).use { gz ->
             TarArchiveOutputStream(gz).use { tar ->


### PR DESCRIPTION
Closes a silent-failure path where JavaManagerService returned the path to a JDK whose binary couldn't actually launch (e.g. extracted archive missing libjli.so). Adds isJavaUsable() probe and re-download / throw on failure. Full rationale in the commit.