### PR TITLE
fix(sync): clean disabled mod jars before cache short-circuit

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/FileDownloadService.kt
@@ -63,6 +63,20 @@ class FileDownloadService(
         val manifest = session.fileManifest ?: throw IOException("File manifest is empty!")
         Files.createDirectories(targetDir)
 
+        // ── Disabled-mod cleanup runs UNCONDITIONALLY ────────────────────
+        // Must precede the cache short-circuit below: a stale jar in
+        // top-level mods/ (from a prior install where the upstream
+        // manifest placed the mod there, or from SC's own launcher)
+        // never appears in the current manifest's filesMap, so the
+        // integrity walk doesn't notice it. Cache hit then skips the
+        // walk too, and Forge happily loads a "disabled" mod every
+        // launch. The cost is one Files.walk over a few-hundred-entry
+        // tree -- well under 50 ms on SSD, negligible against the rest
+        // of launch latency.
+        if (!ignoredFiles.isNullOrEmpty()) {
+            cleanupIgnoredFiles(targetDir, ignoredFiles)
+        }
+
         // ── Manifest cache short-circuit ─────────────────────────────────
         // If this same manifest *with the same ignoredFiles set* was
         // successfully synced recently (≤TTL), skip the full per-file
@@ -72,11 +86,11 @@ class FileDownloadService(
         // TTL inside ManifestCache is the safety valve for "what if a
         // file got corrupted on disk?" scenarios.
         //
-        // ignoredFiles is part of the cache input because
-        // cleanupIgnoredFiles (which physically deletes disabled mod
-        // jars) lives below this gate -- caching only on manifest hash
-        // would let a freshly-disabled mod stay loaded until the cache
-        // expires or the manifest changes upstream.
+        // ignoredFiles is still part of the cache key so a toggle change
+        // invalidates the cache and forces the full integrity walk;
+        // cleanupIgnoredFiles above is the belt that catches stale jars,
+        // the cache key is the suspenders that catches missing
+        // newly-enabled jars.
         val manifestHash = manifestCache.hashOf(cacheKeyInputFor(manifest, ignoredFiles))
         // Disk-sanity gate: the manifest-cache file alone can't tell
         // that the user moved their data dir leaving manifest-cache/
@@ -117,13 +131,14 @@ class FileDownloadService(
             return@withContext
         }
 
-        // 2. Filtering
+        // 2. Filtering -- remove disabled mods from the download set.
+        // (Their on-disk copies, if any, were already removed by the
+        // unconditional cleanupIgnoredFiles pass above the cache gate.)
         if (!ignoredFiles.isNullOrEmpty()) {
             filesMap.keys.removeIf { relativePath ->
                 val clean = normalizePath(relativePath)
                 ignoredFiles.any { clean.endsWith("/$it") || clean == it }
             }
-            cleanupIgnoredFiles(targetDir, ignoredFiles)
         }
 
         // 3. Downloading
@@ -585,34 +600,46 @@ class FileDownloadService(
         if (ignoredFiles.isEmpty()) return
 
         val modsDir = baseDir.resolve("mods")
-        var deletedCount = 0
+        if (!Files.exists(modsDir)) return
 
-        if (Files.exists(modsDir)) {
-            try {
-                // .use{} closes the underlying directory stream; Files.walk holds
-                // an OS file handle that won't be released by .forEach termination.
-                Files.walk(modsDir).use { stream ->
-                    stream
-                        .filter { Files.isRegularFile(it) }
-                        .forEach { file ->
-                            val fileName = file.fileName.toString()
-                            if (ignoredFiles.contains(fileName)) {
-                                try {
-                                    Files.delete(file)
-                                    deletedCount++
-                                } catch (e: Exception) {
-                                    logger.warn("Failed to remove disabled mod: $fileName", e)
-                                }
+        var deletedCount = 0
+        var failureCount = 0
+
+        // Recursive walk covers both top-level mods/ and version subdirs
+        // like mods/1.12.2/. A jar gets matched by basename so the
+        // ignoredFiles set can contain plain names ("FoamFix.jar")
+        // regardless of where the manifest currently places it. Catches
+        // the case where SC moved the jar between top-level and a
+        // version subdir across releases -- without this, the old copy
+        // in the old location would survive and Forge would load a
+        // user-disabled mod.
+        try {
+            Files.walk(modsDir).use { stream ->
+                stream
+                    .filter { Files.isRegularFile(it) }
+                    .forEach { file ->
+                        val fileName = file.fileName.toString()
+                        if (ignoredFiles.contains(fileName)) {
+                            try {
+                                Files.delete(file)
+                                deletedCount++
+                                logger.debug("Removed disabled mod jar: {}", file)
+                            } catch (e: Exception) {
+                                failureCount++
+                                logger.warn("Failed to remove disabled mod jar: {}", file, e)
                             }
                         }
-                }
-            } catch (e: Exception) {
-                logger.error("Error cleaning mods folder: ${e.message}")
+                    }
             }
+        } catch (e: Exception) {
+            logger.error("Error walking mods folder during cleanup", e)
         }
 
-        if (deletedCount > 0) {
-            logger.info("Client cleanup: deleted $deletedCount disabled mods.")
+        if (deletedCount > 0 || failureCount > 0) {
+            logger.info(
+                "Disabled-mod cleanup: removed {}, failures {}",
+                deletedCount, failureCount,
+            )
         }
     }
 }

--- a/client-launcher/src/test/kotlin/hivens/launcher/FileDownloadDiskIntegrationTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/FileDownloadDiskIntegrationTest.kt
@@ -292,6 +292,71 @@ class FileDownloadDiskIntegrationTest {
             "post-truncation sync must refetch -- cache must NOT short-circuit when size doesn't match manifest")
     }
 
+    // ── Stale disabled jars in legacy location ────────────────────────────
+
+    @Test
+    fun `cleanup deletes disabled jar in top-level mods even when cache is hot`() = runBlocking {
+        // Scenario: SC's manifest used to place FoamFix at top-level
+        // mods/FoamFix.jar; a later release moved it into the version
+        // subdir mods/1.12.2/FoamFix.jar. The user has the mod disabled.
+        // The current manifest only references the subdir path, so the
+        // integrity walk never inspects the top-level legacy copy --
+        // without an unconditional cleanup pass, Forge happily loads the
+        // "disabled" mod from the stale top-level path every launch.
+        val keeperBytes = "still-here".toByteArray()
+        val files = mapOf("mods/1.12.2/FoamFix.jar" to "current-version".toByteArray())
+        val manifest = manifestOf(files + mapOf("mods/keeper.jar" to keeperBytes))
+        val (svc, _) = newService(files + mapOf("mods/keeper.jar" to keeperBytes))
+
+        // Pre-populate the stale top-level jar (the historical install).
+        Files.createDirectories(clientDir.resolve("mods"))
+        Files.write(clientDir.resolve("mods/FoamFix.jar"), "legacy-bytes".toByteArray())
+        Files.write(clientDir.resolve("mods/keeper.jar"), keeperBytes)
+
+        val ignored = setOf("FoamFix.jar")
+
+        // First sync: cache cold, integrity walk runs, cleanup runs.
+        svc.processSession(sessionWith(manifest), "Industrial", clientDir, null, ignored, null, null)
+        assertTrue(!Files.exists(clientDir.resolve("mods/FoamFix.jar")),
+            "stale top-level disabled jar must be removed on first sync")
+        assertTrue(Files.exists(clientDir.resolve("mods/keeper.jar")),
+            "non-ignored jar must be preserved")
+
+        // Reintroduce the stale jar (simulating an external write between launches)
+        // and confirm cleanup still fires on the next sync even when the
+        // manifest cache would short-circuit the integrity walk.
+        Files.write(clientDir.resolve("mods/FoamFix.jar"), "legacy-bytes-again".toByteArray())
+        svc.processSession(sessionWith(manifest), "Industrial", clientDir, null, ignored, null, null)
+        assertTrue(!Files.exists(clientDir.resolve("mods/FoamFix.jar")),
+            "cleanup must run before the cache short-circuit so a reintroduced stale jar still gets removed")
+    }
+
+    @Test
+    fun `cleanup deletes disabled jar from version subdir alongside top-level`() = runBlocking {
+        // The cleanup walk must hit both `mods/` directly and `mods/{mc}/`
+        // -- some mods appear in both locations during the upstream
+        // transition period, and missing either side would leave Forge
+        // loading the disabled mod from whichever copy survived.
+        val files = mapOf("mods/keeper.jar" to "keep me".toByteArray())
+        val manifest = manifestOf(files)
+        val (svc, _) = newService(files)
+
+        Files.createDirectories(clientDir.resolve("mods/1.12.2"))
+        Files.write(clientDir.resolve("mods/FoamFix.jar"), "top".toByteArray())
+        Files.write(clientDir.resolve("mods/1.12.2/FoamFix.jar"), "sub".toByteArray())
+        Files.write(clientDir.resolve("mods/keeper.jar"), files.values.first())
+
+        svc.processSession(sessionWith(manifest), "Industrial", clientDir,
+            null, setOf("FoamFix.jar"), null, null)
+
+        assertTrue(!Files.exists(clientDir.resolve("mods/FoamFix.jar")),
+            "top-level disabled jar must be removed")
+        assertTrue(!Files.exists(clientDir.resolve("mods/1.12.2/FoamFix.jar")),
+            "version-subdir disabled jar must be removed")
+        assertTrue(Files.exists(clientDir.resolve("mods/keeper.jar")),
+            "non-ignored jar must survive cleanup")
+    }
+
     // ── Network failure ───────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

\`processSession\` ran \`cleanupIgnoredFiles\` inside the cache-miss branch, so a cache-valid path skipped cleanup entirely. The symptom in the wild: a user disables an optional mod (say FoamFix) in the launcher panel, sync removes \`mods/1.12.2/FoamFix.jar\` once, the cache marks the state clean, and every subsequent launch short-circuits the integrity walk and the cleanup. A stale \`mods/FoamFix.jar\` left over from an earlier era when the upstream SC manifest placed the mod at top-level survives indefinitely, and Forge loads the "disabled" mod every launch -- the toggle in the UI was a lie.

Moves \`cleanupIgnoredFiles\` above the cache gate so it runs on every \`processSession\` regardless of cache state. The cache key still includes \`ignoredFiles\` so re-enabling a mod still busts the cache and re-downloads. Cost of the always-on cleanup is one \`Files.walk\` over the mods tree -- under 50 ms on SSD against a several-hundred-jar pack.

## Test plan

- [x] \`./gradlew :client-launcher:test\` passes
- [x] New integration test: stale top-level jar gets removed even when the manifest only references the version subdir
- [x] New integration test: a jar present in both top-level and version subdir gets cleaned from both at once
- [x] Manual: disable an optional in the launcher panel and launch -- the jar disappears from \`mods/\` (top-level and any version subdir) and stays gone