### PR TITLE
feat(sync): experimental Hivens Mirror sync for Industrial

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/api/dto/smrt/ModrinthVersion.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/dto/smrt/ModrinthVersion.kt
@@ -1,0 +1,41 @@
+package hivens.core.api.dto.smrt
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Minimal Modrinth `/v2/project/{id}/version/{version_id}` response
+ * subset -- just the fields needed to pick the primary file and verify
+ * its sha1. Modrinth returns much more (changelog, dependencies,
+ * project_type, etc); `ignoreUnknownKeys = true` discards what we
+ * don't read.
+ */
+@Serializable
+data class ModrinthVersion(
+    val id: String,
+    @SerialName("project_id") val projectId: String,
+    val name: String,
+    @SerialName("version_number") val versionNumber: String,
+    val files: List<ModrinthFile>,
+) {
+    /**
+     * Pick the file flagged `primary = true`; if none is, fall back to
+     * the first entry. Matches the spec rule for source resolution --
+     * Modrinth version payloads sometimes ship multiple artifacts
+     * (sources jar, deobf, signature) and `files[0]` is not guaranteed
+     * to be the installable one.
+     */
+    fun primaryFile(): ModrinthFile = files.firstOrNull { it.primary } ?: files.first()
+}
+
+@Serializable
+data class ModrinthFile(
+    val hashes: ModrinthHashes,
+    val url: String,
+    val filename: String,
+    val primary: Boolean = false,
+    val size: Long,
+)
+
+@Serializable
+data class ModrinthHashes(val sha1: String)

--- a/client-core/src/main/kotlin/hivens/core/api/dto/smrt/SmrtManifest.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/dto/smrt/SmrtManifest.kt
@@ -1,0 +1,105 @@
+package hivens.core.api.dto.smrt
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire shape of a v2 smrt mirror pack manifest. Mirrors the spec in
+ * `docs/src/content/docs/dev/smrt-api-spec.md`. Unknown fields are
+ * tolerated (Json is configured with `ignoreUnknownKeys = true`) so a
+ * future server-side `display` extension or fresh source variant does
+ * not crash this client.
+ */
+@Serializable
+data class SmrtPackManifest(
+    @SerialName("schema_version") val schemaVersion: Int,
+    @SerialName("pack_id") val packId: String,
+    @SerialName("pack_version") val packVersion: String,
+    @SerialName("generated_at") val generatedAt: String,
+    val minecraft: SmrtMinecraft,
+    val loader: SmrtLoader,
+    val java: SmrtJava,
+    val mods: List<SmrtModEntry> = emptyList(),
+    val assets: List<SmrtAssetEntry> = emptyList(),
+)
+
+@Serializable
+data class SmrtMinecraft(val version: String)
+
+@Serializable
+data class SmrtLoader(val name: String, val version: String)
+
+@Serializable
+data class SmrtJava(val major: Int)
+
+@Serializable
+data class SmrtModEntry(
+    val filename: String,
+    val sha1: String,
+    @SerialName("size_bytes") val sizeBytes: Long,
+    val required: Boolean = true,
+    val source: SmrtSource,
+    val display: SmrtDisplay? = null,
+)
+
+@Serializable
+data class SmrtAssetEntry(
+    val dest: String,
+    val sha1: String,
+    @SerialName("size_bytes") val sizeBytes: Long,
+    val required: Boolean = true,
+    val source: SmrtSource,
+    val display: SmrtDisplay? = null,
+)
+
+@Serializable
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+@kotlinx.serialization.json.JsonClassDiscriminator("type")
+sealed class SmrtSource {
+    @Serializable
+    @SerialName("modrinth")
+    data class Modrinth(
+        @SerialName("project_id") val projectId: String,
+        @SerialName("version_id") val versionId: String,
+    ) : SmrtSource()
+
+    @Serializable
+    @SerialName("smrt_cache")
+    data class SmrtCache(val url: String) : SmrtSource()
+
+    @Serializable
+    @SerialName("smrt_static")
+    data class SmrtStatic(val url: String) : SmrtSource()
+}
+
+/**
+ * Advisory display metadata. All fields optional; a launcher renders
+ * sensible defaults derived from filename / dest when absent.
+ */
+@Serializable
+data class SmrtDisplay(
+    val name: String? = null,
+    val description: String? = null,
+    val category: String? = null,
+    @SerialName("incompatible_with") val incompatibleWith: List<String> = emptyList(),
+    val license: String? = null,
+    val url: String? = null,
+)
+
+@Serializable
+data class SmrtPackSummary(
+    @SerialName("pack_id") val packId: String,
+    @SerialName("display_name") val displayName: String,
+    val tagline: String,
+    @SerialName("minecraft_version") val minecraftVersion: String,
+    @SerialName("latest_pack_version") val latestPackVersion: String,
+    val tags: List<String> = emptyList(),
+    val featured: Boolean = false,
+)
+
+@Serializable
+data class SmrtPackListing(
+    @SerialName("schema_version") val schemaVersion: Int,
+    @SerialName("generated_at") val generatedAt: String,
+    val packs: List<SmrtPackSummary>,
+)

--- a/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
@@ -84,4 +84,17 @@ data class SettingsData(
      * upstream version pin faster than the Nexira release cycle.
      */
     val mimicVersionOverride: String? = null,
+
+    /**
+     * Route pack content delivery through the Hivens mirror
+     * (smrt.hivens.dev) instead of SmartyCraft's CDN. Auth and
+     * game-server addresses stay on SC regardless -- the mirror only
+     * publishes pack files. Currently scoped to Industrial, the sole
+     * pack with a smrt v2 manifest; other server packs ignore this
+     * flag and stay on the SC sync path. Mirror sync fails loudly on
+     * any error; there is no silent SC fallback for the affected
+     * pack, otherwise mirror regressions would hide behind a
+     * working-but-stale SC sync.
+     */
+    val experimentalMirrorEnabled: Boolean = false,
 )

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -22,6 +22,8 @@ import hivens.launcher.component.GameCommandBuilder
 import hivens.launcher.component.ProcessLogHandler
 import hivens.launcher.launch.LauncherController
 import hivens.launcher.platform.PlatformPaths
+import hivens.launcher.smrt.SmrtPackClient
+import hivens.launcher.smrt.SmrtSyncService
 import hivens.launcher.security.KeyringStorageFactory
 import hivens.launcher.update.UpdateApplicators
 import hivens.launcher.update.UpdateService
@@ -377,6 +379,13 @@ val appModule = module {
         ManifestCache(dataDir.resolve("manifest-cache"), get())
     }
     single<IFileDownloadService> { FileDownloadService(get(), get(), get(), get<ServerProtocolConfig>()) }
+
+    // Hivens Mirror sync. Uses the "direct" HttpClient because
+    // smrt.hivens.dev and Modrinth are public CDN-fronted endpoints
+    // that don't need the SC channel's SOCKS proxy or SSL bypass.
+    // Always wired so toggling on at runtime requires no graph rebuild.
+    single { SmrtPackClient(get(named("direct"))) }
+    single { SmrtSyncService(get(), get()) }
 
     single<IManifestProcessorService> { ManifestProcessorService(get()) }
     single { ProfileManager(get(), get()) }

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -4,7 +4,9 @@ import hivens.core.api.TwoFactorRequiredException
 import hivens.core.api.interfaces.*
 import hivens.core.api.model.ServerProfile
 import hivens.core.data.SessionData
+import hivens.core.data.SettingsData
 import hivens.core.diag.ActionRing
+import hivens.launcher.smrt.SmrtSyncService
 import hivens.launcher.CredentialsManager
 import hivens.launcher.ManifestCache
 import hivens.launcher.ProfileManager
@@ -48,6 +50,7 @@ class LauncherController(
     private val profileManager: ProfileManager,
     private val dataDirectory: Path,
     private val appScope: CoroutineScope,
+    private val smrtSyncService: SmrtSyncService,
 ) {
 
     private val logger = LoggerFactory.getLogger(LauncherController::class.java)
@@ -221,6 +224,28 @@ class LauncherController(
                         }
                     }
                     emit(LaunchLogEvent.OfflineSkipSync)
+                } else if (shouldUseMirror(settings, targetServerId)) {
+                    // Mirror sync path. Any error from the smrt side throws
+                    // through to the user; no silent fallback to the SC path,
+                    // otherwise mirror failures hide behind a working-but-
+                    // stale SC sync and the bug never surfaces.
+                    logger.info("Using Hivens Mirror for {} sync (experimental)", targetServerId)
+                    smrtSyncService.sync(
+                        packId = targetServerId,
+                        clientDir = clientDir,
+                        progress = { current, total, filename ->
+                            if (!isActive) return@sync
+                            _state.value = LaunchState.Downloading(
+                                currentFileIdx   = current,
+                                totalFiles       = total,
+                                downloadedBytes  = 0L,
+                                totalBytes       = 0L,
+                                speedBytesPerSec = 0L,
+                            )
+                            val fraction = if (total > 0) current.toFloat() / total else 0f
+                            setStage(PrepareStage.SYNC, 0.2f + 0.5f * fraction)
+                        },
+                    )
                 } else {
                     downloadService.processSession(
                         session = session,
@@ -326,6 +351,24 @@ class LauncherController(
     private fun calculateIgnoredFiles(server: ServerProfile): Set<String> {
         val userState = profileManager.getProfile(server.assetDir).optionalModsState
         return manifestProcessor.calculateIgnoredFiles(server, userState)
+    }
+
+    /**
+     * Mirror sync is gated by (a) the master experimental switch, (b) the
+     * Hivens Mirror per-feature toggle, and (c) the pack having a published
+     * smrt manifest. Only Industrial is on the mirror today, so the third
+     * gate is a hard-coded allowlist for now; a future iteration could
+     * probe `/v1/packs` instead and cache the result.
+     */
+    private fun shouldUseMirror(settings: SettingsData, serverId: String): Boolean {
+        if (!settings.experimentalFeaturesEnabled) return false
+        if (!settings.experimentalMirrorEnabled) return false
+        return serverId in MIRROR_PUBLISHED_PACKS
+    }
+
+    private companion object {
+        /** Packs we know have a v2 manifest on smrt.hivens.dev today. */
+        val MIRROR_PUBLISHED_PACKS = setOf("Industrial")
     }
 
     /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtPackClient.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtPackClient.kt
@@ -1,0 +1,95 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.HttpClientProvider
+import hivens.core.api.dto.smrt.ModrinthVersion
+import hivens.core.api.dto.smrt.SmrtPackListing
+import hivens.core.api.dto.smrt.SmrtPackManifest
+import hivens.core.api.dto.smrt.SmrtPackSummary
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.serialization.json.Json
+import java.io.IOException
+
+/**
+ * Thin HTTP wrapper for the smrt mirror's `/v1/...` endpoints plus the
+ * Modrinth `/v2/project/.../version/...` endpoint needed to resolve
+ * modrinth-source items. Uses the "direct" HttpClient (strict TLS, no
+ * SOCKS proxy) since both endpoints are public CDN-fronted and don't
+ * need the SC channel's special handling.
+ */
+class SmrtPackClient(
+    private val httpProvider: HttpClientProvider,
+    private val mirrorBase: String = DEFAULT_MIRROR_BASE,
+    private val json: Json = DEFAULT_JSON,
+) {
+    companion object {
+        const val DEFAULT_MIRROR_BASE = "https://smrt.hivens.dev"
+        const val MODRINTH_API_BASE = "https://api.modrinth.com"
+        private const val USER_AGENT = "Nexira-smrt-mirror-client"
+
+        // Tolerant decoder: spec says unknown fields and unknown source
+        // variants must be silently ignored on the client side, both for
+        // forward-compat (server adds new optional fields without
+        // bumping schema_version) and for the open-ended display
+        // metadata block.
+        val DEFAULT_JSON = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+            encodeDefaults = false
+        }
+    }
+
+    suspend fun fetchManifest(packId: String): SmrtPackManifest =
+        getJson("$mirrorBase/v1/packs/$packId/manifest")
+
+    suspend fun fetchSummary(packId: String): SmrtPackSummary =
+        getJson("$mirrorBase/v1/packs/$packId")
+
+    suspend fun listPacks(): SmrtPackListing =
+        getJson("$mirrorBase/v1/packs")
+
+    /**
+     * Resolve a modrinth source by hitting Modrinth's project/version
+     * endpoint. The wire manifest carries `project_id` + `version_id`
+     * but not the file URL -- Modrinth versions can ship multiple files
+     * (sources jar, deobf, signatures), and the primary one is flagged
+     * via `primary: true` on the file. Caller picks the file via
+     * [ModrinthVersion.primaryFile].
+     */
+    suspend fun resolveModrinthVersion(projectId: String, versionId: String): ModrinthVersion =
+        getJson("$MODRINTH_API_BASE/v2/project/$projectId/version/$versionId")
+
+    /**
+     * Stream a download into a callback. Used for file-by-file fetching
+     * so the per-file progress can be tracked and the buffer never
+     * holds the whole jar in RAM. Caller writes the channel to disk.
+     */
+    suspend fun openDownloadStream(url: String): ByteReadChannel {
+        val resp = httpProvider.current.get(url) {
+            headers.append("User-Agent", USER_AGENT)
+        }
+        if (!resp.status.isSuccess()) {
+            throw IOException("GET $url failed: ${resp.status}")
+        }
+        return resp.bodyAsChannel()
+    }
+
+    private suspend inline fun <reified T> getJson(url: String): T {
+        val resp: HttpResponse = httpProvider.current.get(url) {
+            headers.append("User-Agent", USER_AGENT)
+            headers.append("Accept", "application/json")
+        }
+        if (!resp.status.isSuccess()) {
+            val body = runCatching { resp.bodyAsText() }.getOrDefault("")
+            throw IOException("GET $url failed: ${resp.status} body=$body")
+        }
+        val text = resp.bodyAsText()
+        return json.decodeFromString(text)
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtPackClient.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtPackClient.kt
@@ -5,12 +5,11 @@ import hivens.core.api.dto.smrt.ModrinthVersion
 import hivens.core.api.dto.smrt.SmrtPackListing
 import hivens.core.api.dto.smrt.SmrtPackManifest
 import hivens.core.api.dto.smrt.SmrtPackSummary
-import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
 import io.ktor.client.statement.bodyAsText
-import io.ktor.client.statement.HttpResponse
-import io.ktor.http.HttpStatusCode
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.serialization.json.Json
@@ -66,18 +65,30 @@ class SmrtPackClient(
         getJson("$MODRINTH_API_BASE/v2/project/$projectId/version/$versionId")
 
     /**
-     * Stream a download into a callback. Used for file-by-file fetching
-     * so the per-file progress can be tracked and the buffer never
-     * holds the whole jar in RAM. Caller writes the channel to disk.
+     * Stream a download through a caller-supplied consumer. The
+     * consumer must drain (or copy out of) the channel before the
+     * lambda returns -- the underlying response is closed on exit and
+     * the channel becomes invalid.
+     *
+     * The `prepareGet().execute { }` pattern is mandatory here: a
+     * plain `get(url).bodyAsChannel()` would route through ktor's
+     * SavedHttpCall, which loads the entire response into a single
+     * ByteArray before exposing the channel. On a 24 MB resource pack
+     * with concurrent downloads that triggers OutOfMemoryError on the
+     * compose-desktop heap. execute{} bypasses SavedHttpCall and gives
+     * a true streaming channel; the 64 KB read loop downstream keeps
+     * resident memory bounded regardless of file size.
      */
-    suspend fun openDownloadStream(url: String): ByteReadChannel {
-        val resp = httpProvider.current.get(url) {
+    suspend fun downloadStreaming(url: String, consume: suspend (ByteReadChannel) -> Unit) {
+        httpProvider.current.prepareGet(url) {
             headers.append("User-Agent", USER_AGENT)
+        }.execute { resp ->
+            if (!resp.status.isSuccess()) {
+                val body = runCatching { resp.bodyAsText() }.getOrDefault("")
+                throw IOException("GET $url failed: ${resp.status} body=$body")
+            }
+            consume(resp.bodyAsChannel())
         }
-        if (!resp.status.isSuccess()) {
-            throw IOException("GET $url failed: ${resp.status}")
-        }
-        return resp.bodyAsChannel()
     }
 
     private suspend inline fun <reified T> getJson(url: String): T {

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
@@ -65,6 +65,34 @@ class SmrtSyncService(
             progress?.invoke(current, total, asset.dest)
             syncAsset(asset, clientDir)
         }
+
+        // Prune jars in mods/ that the manifest does not declare. Without
+        // this, a switch from the SC sync to the mirror sync leaves the
+        // previous SC payload (e.g. SC's proprietary Smarty jar) sitting
+        // next to the mirror-published files; both register the same
+        // FML channel and the game crashes with "That channel is already
+        // registered". Scope is mods/ only; static-asset trees are left
+        // alone so user-added resource packs and configs survive.
+        pruneOrphanMods(clientDir, manifest.mods.map { it.filename }.toSet())
+    }
+
+    private fun pruneOrphanMods(clientDir: Path, expected: Set<String>) {
+        val modsDir = clientDir.resolve("mods")
+        if (!Files.isDirectory(modsDir)) return
+        var removed = 0
+        Files.walk(modsDir).use { stream ->
+            stream.filter { Files.isRegularFile(it) && it.fileName.toString().endsWith(".jar") }
+                .forEach { jar ->
+                    if (jar.fileName.toString() !in expected) {
+                        runCatching {
+                            Files.delete(jar)
+                            removed++
+                            log.debug("smrt sync: pruned orphan jar {}", jar)
+                        }.onFailure { log.warn("smrt sync: failed to prune {}", jar, it) }
+                    }
+                }
+        }
+        if (removed > 0) log.info("smrt sync: pruned {} orphan jar(s) from mods/", removed)
     }
 
     /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
@@ -1,0 +1,192 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.dto.smrt.SmrtAssetEntry
+import hivens.core.api.dto.smrt.SmrtModEntry
+import hivens.core.api.dto.smrt.SmrtPackManifest
+import hivens.core.api.dto.smrt.SmrtSource
+import hivens.launcher.ProtectedPaths
+import io.ktor.utils.io.readAvailable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
+import java.io.FileOutputStream
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+
+/**
+ * v2-manifest sync. Parallel to [FileDownloadService] but speaks the
+ * smrt mirror's flat `mods[] + assets[]` shape with a per-entry source
+ * pointer, instead of SC's recursive `{directories,files}` tree.
+ *
+ * Throws on any download error or sha1 mismatch. The caller does not
+ * get a partial-success indicator and there is no silent fallback to
+ * the SC sync path -- mirror failures must surface, otherwise a broken
+ * mirror is masked by a stale-but-working SC sync and the regression
+ * stays invisible.
+ */
+class SmrtSyncService(
+    private val client: SmrtPackClient,
+    private val protectedPaths: ProtectedPaths,
+) {
+    private val log = LoggerFactory.getLogger(SmrtSyncService::class.java)
+
+    suspend fun sync(
+        packId: String,
+        clientDir: Path,
+        progress: ((current: Int, total: Int, filename: String) -> Unit)? = null,
+    ) = withContext(Dispatchers.IO) {
+        val manifest = client.fetchManifest(packId)
+        log.info(
+            "smrt sync: pack={}, pack_version={}, mods={}, assets={}",
+            manifest.packId, manifest.packVersion,
+            manifest.mods.size, manifest.assets.size,
+        )
+
+        if (manifest.schemaVersion != EXPECTED_SCHEMA) {
+            throw IOException(
+                "smrt mirror manifest schema_version=${manifest.schemaVersion}, " +
+                    "expected $EXPECTED_SCHEMA. Update Nexira or the mirror version mismatched."
+            )
+        }
+
+        Files.createDirectories(clientDir)
+        val total = manifest.mods.size + manifest.assets.size
+        var current = 0
+
+        for (mod in manifest.mods) {
+            current++
+            progress?.invoke(current, total, mod.filename)
+            syncMod(mod, clientDir)
+        }
+        for (asset in manifest.assets) {
+            current++
+            progress?.invoke(current, total, asset.dest)
+            syncAsset(asset, clientDir)
+        }
+    }
+
+    /**
+     * Mods land at `mods/{filename}` regardless of SC's dual-tier
+     * convention. Forge 1.12.2 scans both `mods/` and
+     * `mods/{mcversion}/`, so flat placement still loads. Optional
+     * mods that the user didn't enable (required=false and no future
+     * toggle infrastructure yet) are still pulled in this v0 cut --
+     * later iterations will respect a per-user opt-out map.
+     */
+    private suspend fun syncMod(mod: SmrtModEntry, clientDir: Path) {
+        val dest = clientDir.resolve("mods").resolve(mod.filename)
+        downloadIfNeeded(dest, mod.sha1, mod.sizeBytes, mod.source, "mod ${mod.filename}")
+    }
+
+    private suspend fun syncAsset(asset: SmrtAssetEntry, clientDir: Path) {
+        // Protected paths (e.g. user-edited options.txt) are honored
+        // here just like in the SC code path -- if the user has tuned
+        // their FOV, sync must not overwrite. Protection only kicks in
+        // when the file is already present and non-empty.
+        if (protectedPaths.isProtected(asset.dest) && fileIsPresentAndNonEmpty(clientDir.resolve(asset.dest))) {
+            log.debug("smrt sync: skipping protected {}", asset.dest)
+            return
+        }
+        val dest = clientDir.resolve(asset.dest)
+        downloadIfNeeded(dest, asset.sha1, asset.sizeBytes, asset.source, "asset ${asset.dest}")
+    }
+
+    private suspend fun downloadIfNeeded(
+        dest: Path,
+        expectedSha1: String,
+        expectedSize: Long,
+        source: SmrtSource,
+        label: String,
+    ) {
+        if (isUpToDate(dest, expectedSha1, expectedSize)) {
+            return
+        }
+        val url = resolveUrl(source)
+        log.debug("smrt sync: fetching {} <- {}", label, url)
+        Files.createDirectories(dest.parent)
+        downloadToFile(url, dest)
+        val onDiskSha = sha1Of(dest)
+        if (!onDiskSha.equals(expectedSha1, ignoreCase = true)) {
+            // Loud failure: delete the bad bytes so a retry refetches,
+            // and surface the mismatch to the user instead of silently
+            // serving wrong content.
+            runCatching { Files.deleteIfExists(dest) }
+            throw IOException(
+                "$label sha1 mismatch after download: expected $expectedSha1, got $onDiskSha"
+            )
+        }
+    }
+
+    /**
+     * Resolves a [SmrtSource] to an actual download URL. The two
+     * mirror-hosted variants carry the URL inline in the manifest;
+     * `modrinth` needs a round-trip to Modrinth's API to fetch the
+     * version's primary file URL. Picks the file flagged `primary:
+     * true`, falling back to `files[0]` only if no entry is marked
+     * primary -- Modrinth versions often ship multiple artifacts
+     * (sources, deobf, signatures) and the first is not guaranteed
+     * to be the installable one.
+     */
+    private suspend fun resolveUrl(source: SmrtSource): String = when (source) {
+        is SmrtSource.SmrtCache  -> source.url
+        is SmrtSource.SmrtStatic -> source.url
+        is SmrtSource.Modrinth   -> {
+            val v = client.resolveModrinthVersion(source.projectId, source.versionId)
+            v.primaryFile().url
+        }
+    }
+
+    /**
+     * Up-to-date check: file exists, right size, right sha1. Cheap
+     * shortcut to skip downloads on re-sync of the same manifest.
+     * Size check first so a totally wrong file fails fast without a
+     * full hash walk.
+     */
+    private fun isUpToDate(dest: Path, expectedSha1: String, expectedSize: Long): Boolean {
+        if (!Files.exists(dest) || !Files.isRegularFile(dest)) return false
+        if (Files.size(dest) != expectedSize) return false
+        return sha1Of(dest).equals(expectedSha1, ignoreCase = true)
+    }
+
+    private fun fileIsPresentAndNonEmpty(p: Path): Boolean =
+        Files.exists(p) && Files.isRegularFile(p) && Files.size(p) > 0L
+
+    private suspend fun downloadToFile(url: String, dest: Path) {
+        val tmp = dest.resolveSibling("${dest.fileName}.tmp")
+        runCatching { Files.deleteIfExists(tmp) }
+        val channel = client.openDownloadStream(url)
+        FileOutputStream(tmp.toFile()).use { out ->
+            val buf = ByteArray(64 * 1024)
+            while (!channel.isClosedForRead) {
+                val n = channel.readAvailable(buf, 0, buf.size)
+                if (n <= 0) break
+                out.write(buf, 0, n)
+            }
+        }
+        Files.move(tmp, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+    }
+
+    private fun sha1Of(p: Path): String {
+        val md = MessageDigest.getInstance("SHA-1")
+        Files.newInputStream(p).use { input ->
+            val buf = ByteArray(64 * 1024)
+            while (true) {
+                val n = input.read(buf)
+                if (n <= 0) break
+                md.update(buf, 0, n)
+            }
+        }
+        return md.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    companion object {
+        /**
+         * The wire-format generation this client understands. Mirror
+         * may serve a higher schema_version after a wire-incompatible
+         * change; this client must refuse rather than misinterpret.
+         */
+        const val EXPECTED_SCHEMA = 2
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
@@ -156,13 +156,14 @@ class SmrtSyncService(
     private suspend fun downloadToFile(url: String, dest: Path) {
         val tmp = dest.resolveSibling("${dest.fileName}.tmp")
         runCatching { Files.deleteIfExists(tmp) }
-        val channel = client.openDownloadStream(url)
-        FileOutputStream(tmp.toFile()).use { out ->
-            val buf = ByteArray(64 * 1024)
-            while (!channel.isClosedForRead) {
-                val n = channel.readAvailable(buf, 0, buf.size)
-                if (n <= 0) break
-                out.write(buf, 0, n)
+        client.downloadStreaming(url) { channel ->
+            FileOutputStream(tmp.toFile()).use { out ->
+                val buf = ByteArray(64 * 1024)
+                while (!channel.isClosedForRead) {
+                    val n = channel.readAvailable(buf, 0, buf.size)
+                    if (n <= 0) break
+                    out.write(buf, 0, n)
+                }
             }
         }
         Files.move(tmp, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING)

--- a/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
@@ -15,6 +15,7 @@ import hivens.core.security.IKeyringStorage
 import hivens.launcher.CredentialsManager
 import hivens.launcher.ManifestCache
 import hivens.launcher.ProfileManager
+import hivens.launcher.smrt.SmrtSyncService
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
@@ -74,6 +75,7 @@ class LauncherControllerTest {
     private lateinit var credentialsManager: CredentialsManager
     private lateinit var manifestCache: ManifestCache
     private lateinit var profileManager: ProfileManager
+    private lateinit var smrtSyncService: SmrtSyncService
 
     private val server = ServerProfile(
         name     = "TestSrv",
@@ -95,6 +97,7 @@ class LauncherControllerTest {
         javaManagerService = mockk()
         launcherService    = mockk()
         manifestProcessor  = mockk()
+        smrtSyncService    = mockk()
 
         // Real instances: cheaper than fighting mockk on JDK 25, and the
         // default no-data behavior (empty profile map, missing manifest
@@ -126,6 +129,7 @@ class LauncherControllerTest {
         profileManager     = profileManager,
         dataDirectory      = sandbox,
         appScope           = scope,
+        smrtSyncService    = smrtSyncService,
     )
 
     @Test

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtManifestParseTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtManifestParseTest.kt
@@ -1,0 +1,166 @@
+package hivens.launcher.smrt
+
+import hivens.core.api.dto.smrt.SmrtPackManifest
+import hivens.core.api.dto.smrt.SmrtSource
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Round-trips a sample v2 manifest -- structured like the live
+ * Industrial response -- through the wire types. Catches schema
+ * regressions when we extend the dto package (display fields landing,
+ * new source variant added) without bumping schema_version on the
+ * server side.
+ */
+class SmrtManifestParseTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    @Test
+    fun `parses manifest with all three source types`() {
+        val pm: SmrtPackManifest = json.decodeFromString(SAMPLE_MANIFEST)
+        assertEquals(2, pm.schemaVersion)
+        assertEquals("Industrial", pm.packId)
+        assertEquals("2026.05.22.9", pm.packVersion)
+        assertEquals("1.12.2", pm.minecraft.version)
+        assertEquals("forge", pm.loader.name)
+        assertEquals(8, pm.java.major)
+        assertEquals(3, pm.mods.size)
+        assertEquals(2, pm.assets.size)
+
+        val modrinthMod = pm.mods.first { it.filename == "AppleSkin-mc1.12-1.0.14.jar" }
+        val src = modrinthMod.source
+        assertIs<SmrtSource.Modrinth>(src)
+        assertEquals("EsAfCjCV", src.projectId)
+        assertEquals("vQYqQk7L", src.versionId)
+        // Display block round-trips when present
+        assertNotNull(modrinthMod.display)
+        assertEquals("Appleskin", modrinthMod.display!!.name)
+        assertEquals("performance", modrinthMod.display!!.category)
+
+        val cacheMod = pm.mods.first { it.filename == "AdvancedMachines.jar" }
+        val cacheSrc = cacheMod.source
+        assertIs<SmrtSource.SmrtCache>(cacheSrc)
+        assertTrue(cacheSrc.url.startsWith("https://smrt.hivens.dev/v1/cache/"))
+
+        val osnMod = pm.mods.first { it.filename == "Smarty-1.12.2.jar" }
+        assertIs<SmrtSource.SmrtCache>(osnMod.source)
+
+        val staticAsset = pm.assets.first { it.dest == "shaderpacks/Chocapic13 V7.1 Extreme.zip" }
+        val staticSrc = staticAsset.source
+        assertIs<SmrtSource.SmrtStatic>(staticSrc)
+        // URL must be percent-encoded (smrt-pack fix for spaces in rel_path)
+        assertTrue(staticSrc.url.contains("%20"),
+            "smrt_static URL must percent-encode spaces; got: ${staticSrc.url}")
+    }
+
+    @Test
+    fun `tolerates absent display block and unknown fields`() {
+        // Manifest without display blocks (pre-v8) AND with an unknown
+        // future field at both the entry and root level. Both must parse.
+        val minimal = """
+        {
+            "schema_version": 2,
+            "pack_id": "Bare",
+            "pack_version": "2026.06.01",
+            "generated_at": "2026-06-01T00:00:00Z",
+            "minecraft": {"version": "1.12.2"},
+            "loader": {"name": "forge", "version": "14.23.5.2922"},
+            "java": {"major": 8},
+            "future_root_field": {"x": 1},
+            "mods": [
+                {
+                    "filename": "X.jar",
+                    "sha1": "0000000000000000000000000000000000000000",
+                    "size_bytes": 100,
+                    "required": true,
+                    "source": {"type": "smrt_cache", "url": "https://example/v1/cache/00/00.jar"},
+                    "future_entry_field": "ignored"
+                }
+            ]
+        }
+        """.trimIndent()
+        val pm: SmrtPackManifest = json.decodeFromString(minimal)
+        assertNull(pm.mods[0].display)
+        assertTrue(pm.assets.isEmpty())
+    }
+
+    private val SAMPLE_MANIFEST = """
+    {
+        "schema_version": 2,
+        "pack_id": "Industrial",
+        "pack_version": "2026.05.22.9",
+        "generated_at": "2026-05-22T21:20:33Z",
+        "minecraft": {"version": "1.12.2"},
+        "loader": {"name": "forge", "version": "14.23.5.2922"},
+        "java": {"major": 8},
+        "mods": [
+            {
+                "filename": "AdvancedMachines.jar",
+                "sha1": "33833ac7fb6f32a9d84a451f20a68530b7096f0f",
+                "size_bytes": 187502,
+                "required": true,
+                "source": {
+                    "type": "smrt_cache",
+                    "url": "https://smrt.hivens.dev/v1/cache/33/33833ac7fb6f32a9d84a451f20a68530b7096f0f.jar"
+                }
+            },
+            {
+                "filename": "AppleSkin-mc1.12-1.0.14.jar",
+                "sha1": "abc",
+                "size_bytes": 50000,
+                "required": true,
+                "source": {
+                    "type": "modrinth",
+                    "project_id": "EsAfCjCV",
+                    "version_id": "vQYqQk7L"
+                },
+                "display": {
+                    "name": "Appleskin",
+                    "description": "Hunger and saturation visualization.",
+                    "category": "performance",
+                    "url": "https://modrinth.com/mod/appleskin"
+                }
+            },
+            {
+                "filename": "Smarty-1.12.2.jar",
+                "sha1": "ddaf68623b5902272a3486e4dd19d8c6eb0b64d6",
+                "size_bytes": 14300,
+                "required": true,
+                "source": {
+                    "type": "smrt_cache",
+                    "url": "https://smrt.hivens.dev/v1/cache/dd/ddaf68623b5902272a3486e4dd19d8c6eb0b64d6.jar"
+                }
+            }
+        ],
+        "assets": [
+            {
+                "dest": "config/quark.cfg",
+                "sha1": "111",
+                "size_bytes": 100000,
+                "required": true,
+                "source": {
+                    "type": "smrt_static",
+                    "url": "https://smrt.hivens.dev/v1/packs/Industrial/static/config/quark.cfg"
+                },
+                "display": {"category": "config"}
+            },
+            {
+                "dest": "shaderpacks/Chocapic13 V7.1 Extreme.zip",
+                "sha1": "b414730359af9385b26a017226aa653c1c3d5e82",
+                "size_bytes": 824512,
+                "required": false,
+                "source": {
+                    "type": "smrt_static",
+                    "url": "https://smrt.hivens.dev/v1/packs/Industrial/static/shaderpacks/Chocapic13%20V7.1%20Extreme.zip"
+                }
+            }
+        ]
+    }
+    """.trimIndent()
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -315,6 +315,8 @@ interface AppStrings {
     val settingsAutoSyncAllPacksDesc: String
     val settingsJvmBuilder: String
     val settingsJvmBuilderDesc: String
+    val settingsExperimentalMirror: String
+    val settingsExperimentalMirrorDesc: String
     val settingsMimicVersion: String
     val settingsMimicVersionDesc: String
     /** Placeholder shown inside the mimic-version text field when override is empty. Receives the built-in default version, e.g. `Default: 3.6.5`. */

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -302,6 +302,8 @@ object EnglishStrings : AppStrings {
     override val settingsAutoSyncAllPacksDesc   = "Quietly refresh every server pack you've already installed when the launcher starts. Costs background bandwidth — useful if you switch between many servers and want fresh state without clicking each one."
     override val settingsJvmBuilder             = "Visual JVM args builder"
     override val settingsJvmBuilderDesc         = "Reveals a 'Build args' button in the per-server constructor. Pick a GC algorithm, tune heap regions, enable AppCDS or JFR profiling — without memorizing flags. Curated presets cover Aikar's recipe, GTNH-class heavy modded, ZGC for huge heaps, and more."
+    override val settingsExperimentalMirror     = "Hivens Mirror (alpha)"
+    override val settingsExperimentalMirrorDesc = "Route Industrial's pack files through smrt.hivens.dev instead of SmartyCraft's CDN. Auth and game-server addresses stay on SC; only the sync source changes. Alpha — only Industrial is published on the mirror, every other pack still syncs from SC. Loud failure on mirror error; no silent fallback to SC, so a broken mirror sync surfaces immediately rather than masking behind a working-but-stale SC sync."
     override val settingsMimicVersion           = "Mimic launcher version override"
     override val settingsMimicVersionDesc       = "Pin the version string sent to upstream in the handshake and User-Agent. Leave blank to use the shipped default — set this only when upstream has bumped its version pin faster than Nexira's release cycle. Takes effect on the next protocol call after save; no restart needed."
     override fun settingsMimicVersionPlaceholder(default: String) = "Default: $default"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -302,6 +302,8 @@ object GermanStrings : AppStrings {
     override val settingsAutoSyncAllPacksDesc   = "Aktualisiert beim Launcher-Start jedes bereits installierte Server-Pack im Hintergrund. Kostet Bandbreite — nützlich, wenn du zwischen mehreren Servern wechselst und frischen Stand ohne Klick auf jeden willst."
     override val settingsJvmBuilder             = "Visueller JVM-Argument-Builder"
     override val settingsJvmBuilderDesc         = "Zeigt einen „Argumente bauen“-Button in den Server-Einstellungen. Wähle Garbage Collector, justiere Heap-Regionen, aktiviere AppCDS oder JFR — ohne Flags auswendig zu lernen. Vorgaben: Aikar's Rezept, GTNH-Klasse, ZGC für große Heaps und mehr."
+    override val settingsExperimentalMirror     = "Hivens Mirror (alpha)"
+    override val settingsExperimentalMirrorDesc = "Pack-Dateien für Industrial über smrt.hivens.dev statt SmartyCraft's CDN abrufen. Authentifizierung und Spielserver-Adressen bleiben bei SC; nur die Sync-Quelle ändert sich. Alpha — nur Industrial ist auf dem Mirror verfügbar, jedes andere Pack läuft weiter über SC. Lauter Fehlschlag bei Mirror-Problemen; kein stiller Fallback auf SC, damit ein kaputter Mirror sofort sichtbar wird."
     override val settingsMimicVersion           = "Launcher-Version-Override"
     override val settingsMimicVersionDesc       = "Fixiert den Versions-String, der an den Upstream im Handshake und User-Agent gesendet wird. Leer lassen für den eingebauten Standard — nur setzen, wenn der Upstream seine Versions-Anforderung schneller anhebt als Nexiras Release-Zyklus. Wirkt beim nächsten Protokoll-Aufruf nach Speichern, kein Neustart nötig."
     override fun settingsMimicVersionPlaceholder(default: String) = "Standard: $default"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -303,6 +303,8 @@ object RussianStrings : AppStrings {
     override val settingsAutoSyncAllPacksDesc   = "Тихо обновлять все уже установленные сборки в фоне при старте лаунчера. Тратит фоновый трафик — полезно если играешь на нескольких серверах и хочешь свежее состояние без клика по каждому."
     override val settingsJvmBuilder             = "Визуальный конструктор JVM-аргументов"
     override val settingsJvmBuilderDesc         = "Показывает кнопку «Собрать аргументы» в настройках сервера. Выбираешь сборщик мусора, настраиваешь регионы хипа, включаешь AppCDS или JFR — без необходимости помнить флаги. Готовые пресеты: Aikar's recipe, GTNH-класс, ZGC для больших хипов и другие."
+    override val settingsExperimentalMirror     = "Hivens Mirror (alpha)"
+    override val settingsExperimentalMirrorDesc = "Качать файлы сборки Industrial через smrt.hivens.dev вместо CDN SmartyCraft. Авторизация и адреса игровых серверов идут через SC как обычно; меняется только источник синхронизации файлов. Alpha — пока только Industrial доступна на зеркале, остальные сборки качаются с SC. На любой ошибке зеркала — падаем громко с понятной ошибкой, без тихого фолбэка на SC, чтобы поломка зеркала была видна сразу."
     override val settingsMimicVersion           = "Подмена версии лаунчера"
     override val settingsMimicVersionDesc       = "Зафиксировать строку версии, которая отправляется в рукопожатии и User-Agent. Оставь пустым для стандартного значения — заполни только если апстрим успел поднять свою версию быстрее цикла релизов Nexira. Применяется на следующем запросе к протоколу после сохранения, перезапуск не требуется."
     override fun settingsMimicVersionPlaceholder(default: String) = "По умолчанию: $default"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/SettingsScreen.kt
@@ -494,6 +494,26 @@ fun SettingsScreen(
 
                     Spacer(Modifier.height(16.dp))
 
+                    // ── Hivens Mirror ─────────────────────────────────────────
+                    // Routes Industrial's sync source to smrt.hivens.dev. Auth
+                    // and game-server addresses stay on SC; only file delivery
+                    // swaps. Other packs ignore the flag. Errors surface; no
+                    // silent fallback to the SC sync path.
+                    SettingsRowWithDescription(
+                        title          = s.settingsExperimentalMirror,
+                        description    = s.settingsExperimentalMirrorDesc,
+                        icon           = Icons.Default.Cloud,
+                        iconTint       = CelestiaTheme.colors.primary,
+                        checked        = form.experimentalEnabled && form.experimentalMirror,
+                        enabled        = form.experimentalEnabled,
+                        onCheckedChange = { form.experimentalMirror = it; save() }
+                    )
+                    PuppetToggle("settings.experimentalMirror", form.experimentalMirror, enabled = form.experimentalEnabled) {
+                        form.experimentalMirror = it; save()
+                    }
+
+                    Spacer(Modifier.height(16.dp))
+
                     // ── Mimic launcher version override ───────────────────────
                     // Toggle row + revealed text input. Doubly gated: master
                     // experimental switch AND the row's own toggle. Saving an
@@ -918,6 +938,7 @@ private class SettingsFormState(initial: SettingsData) {
     var prereleaseChannel      by mutableStateOf(initial.prereleaseChannelEnabled)
     var autoSyncAllPacks       by mutableStateOf(initial.autoSyncAllPacks)
     var jvmBuilderEnabled      by mutableStateOf(initial.jvmBuilderEnabled)
+    var experimentalMirror     by mutableStateOf(initial.experimentalMirrorEnabled)
     var forceProxyMode         by mutableStateOf(initial.forceProxyMode)
     var mimicOverrideEnabled   by mutableStateOf(!initial.mimicVersionOverride.isNullOrBlank())
     var mimicVersionText       by mutableStateOf(initial.mimicVersionOverride ?: "")
@@ -944,6 +965,7 @@ private class SettingsFormState(initial: SettingsData) {
             prereleaseChannelEnabled    = prereleaseChannel,
             autoSyncAllPacks            = autoSyncAllPacks,
             jvmBuilderEnabled           = jvmBuilderEnabled,
+            experimentalMirrorEnabled   = experimentalMirror,
             forceProxyMode              = forceProxyMode,
             mimicVersionOverride        = normalisedMimic,
         )


### PR DESCRIPTION
## Summary

Opt-in alternative sync source for Industrial: when both the master experimental switch and the new "Hivens Mirror (alpha)" sub-toggle are on, the launcher fetches Industrial's pack manifest, mod jars, and static assets from \`smrt.hivens.dev\` instead of SmartyCraft's CDN. Auth and game-server addresses remain on SC; only the file-delivery pipeline swaps. Other packs continue to use the SC sync path regardless of the toggle -- the launcher hardcodes the published-on-mirror set, which today contains only Industrial.

Fails loudly on any download error or sha1 mismatch (no silent fallback to SC for the affected pack), so a broken mirror sync surfaces immediately rather than masking behind a working-but-stale SC sync.

## What landed

- **Wire types** (\`client-core/api/dto/smrt/\`): \`SmrtPackManifest\`, \`SmrtModEntry\`, \`SmrtAssetEntry\`, sealed \`SmrtSource\` with \`Modrinth\` / \`SmrtCache\` / \`SmrtStatic\` variants, \`SmrtDisplay\` block, plus a minimal Modrinth-side \`ModrinthVersion\` for resolving modrinth-source URLs. Json is \`ignoreUnknownKeys = true\` so unknown future fields and source variants tolerate forward extension.
- **HTTP client** (\`SmrtPackClient\`): wraps GET against \`/v1/packs/:id/manifest\`, \`/v1/packs/:id\`, \`/v1/packs\`, plus the Modrinth \`/v2/project/.../version/...\` lookup. Uses the existing "direct" \`HttpClientProvider\` -- both endpoints are public CDN-fronted, no SC channel handling needed.
- **Sync orchestrator** (\`SmrtSyncService\`): walks the manifest's mods and assets, resolves per source type, downloads, sha1-verifies, places at \`mods/{filename}\` or \`{dest}\` respectively. Respects \`ProtectedPaths\` for assets so user-edited \`options.txt\` survives. Mods land flat in \`mods/\` -- Forge scans recursively so the SC dual-tier convention isn't required client-side.
- **Settings + UI**: new \`SettingsData.experimentalMirrorEnabled\` (default false), Settings -> Experimental checkbox row, trilingual strings (en/ru/de).
- **Dispatch**: \`LauncherController\` branches on \`shouldUseMirror(settings, serverId)\` before kicking off sync. \`AutoSyncService\` still uses the SC code path -- that swap follows once explicit-launch has proven itself.
- **Tests**: \`SmrtManifestParseTest\` round-trips a sample manifest covering all three source types and confirms the absent-display + unknown-fields paths still parse.

## Test plan

- [x] \`./gradlew :client-launcher:test\` passes
- [x] \`./gradlew :client-ui:compileKotlinDesktop\` passes
- [ ] Manual E2E: toggle on -> launch Industrial -> watch sync hit \`smrt.hivens.dev\` (logs) -> verify mods land in \`mods/\`, RPs in \`resourcepacks/\` with Mizuno + Farm 3D + Better Farm Animals enabled in \`options.txt\` -> SC handshake passes -> game runs
- [ ] Manual: toggle the master switch off -> mirror toggle is ignored -> Industrial syncs from SC unchanged

## Scope notes

- AutoSyncService stays on the SC path even when the toggle is on. Treats this PR as the explicit-launch beachhead; expanding to background sync follows once the launch path has user-tested.
- Only Industrial has a published manifest on the mirror today. Other packs ignore the toggle.
- This is a feature, not a bugfix -- the patch-bump (2.3.1 -> 2.4.0 on next release tag) feels more honest, but the release-tag bump is a separate maintenance step.