### PR TITLE
refactor(server-list): rename ServerListService to SmartyCraftServerListService, add ServerProfile.source

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/api/model/ServerProfile.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/model/ServerProfile.kt
@@ -15,6 +15,14 @@ data class ServerProfile(
     val optionalModsData: Map<String, JsonElement>? = null,
     val neoForgeArgs: Map<String, String>? = null,
     val ignoreModulesList: String? = null,
+    /**
+     * Default is [ServerSource.Smartycraft] because every persisted
+     * ServerProfile from before this field existed originated from
+     * the SC dashboard. Cached profiles deserialise into Smartycraft
+     * automatically; new profiles produced by the mirror impl set
+     * the field explicitly.
+     */
+    val source: ServerSource = ServerSource.Smartycraft,
 ) {
     override fun toString(): String = title ?: name
 }

--- a/client-core/src/main/kotlin/hivens/core/api/model/ServerSource.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/model/ServerSource.kt
@@ -1,0 +1,20 @@
+package hivens.core.api.model
+
+/**
+ * Origin of a [ServerProfile]. Drives downstream choices that
+ * depend on which upstream produced the entry -- mainly the
+ * shape of the per-server settings screen (SmartyCraft and the
+ * Hivens mirror declare different optional-mod surfaces and
+ * different administrative actions), and any source-specific
+ * sync paths the launcher takes.
+ *
+ * Currently two values, both shipped: [Smartycraft] for entries
+ * produced by SmartyCraft's launcher API, [Mirror] for entries
+ * produced by the smrt.hivens.dev mirror. Additional values
+ * land when an additional upstream becomes real, not before --
+ * speculative variants do not belong in this enum.
+ */
+enum class ServerSource {
+    Smartycraft,
+    Mirror,
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/SmartyCraftServerListService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/SmartyCraftServerListService.kt
@@ -4,6 +4,7 @@ import hivens.core.api.ServerRepository
 import hivens.core.api.dto.SmartyServer
 import hivens.core.api.interfaces.IServerListService
 import hivens.core.api.model.ServerProfile
+import hivens.core.api.model.ServerSource
 import hivens.core.data.DashboardData
 import hivens.core.data.NewsItem
 import hivens.launcher.network.ServerProtocolConfig
@@ -19,12 +20,12 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 import java.util.concurrent.CompletableFuture
 
-class ServerListService(
+class SmartyCraftServerListService(
     private val repository: ServerRepository,
     private val protocolConfig: ServerProtocolConfig = ServerProtocolConfig(),
 ) : IServerListService {
 
-    private val logger = LoggerFactory.getLogger(ServerListService::class.java)
+    private val logger = LoggerFactory.getLogger(SmartyCraftServerListService::class.java)
     private val lock = Any()
     @Volatile
     private var cachedData: DashboardData? = null
@@ -99,6 +100,7 @@ class ServerListService(
             assetDir         = srv.assetDir,
             extraCheckSum    = srv.extraCheckSum,
             optionalModsData = (srv.optionalMods as? JsonObject) ?: emptyMap(),
+            source           = ServerSource.Smartycraft,
         )
 
     private fun formatTimestamp(ts: Long): String {

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -410,7 +410,7 @@ val appModule = module {
         AuthService(get<IServerProtocol>(named("insecure")))
     }
 
-    single<IServerListService> { ServerListService(get(), get()) }
+    single<IServerListService> { SmartyCraftServerListService(get(), get()) }
 
     single {
         val dataDir: Path = get()

--- a/client-launcher/src/test/kotlin/hivens/launcher/SmartyCraftServerListServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/SmartyCraftServerListServiceTest.kt
@@ -21,7 +21,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * The pre-fix `@Volatile` stopgap allowed all N to slip past the null check
  * and each kick off their own future.
  */
-class ServerListServiceTest {
+class SmartyCraftServerListServiceTest {
 
     @Test
     fun `concurrent fetchDashboardData fires the underlying repo only once`() = runBlocking {
@@ -35,7 +35,7 @@ class ServerListServiceTest {
             }
         }
         val repo = ServerRepository(protocol)
-        val svc = ServerListService(repo)
+        val svc = SmartyCraftServerListService(repo)
 
         val parallel = 32
         val results = coroutineScope {
@@ -52,7 +52,7 @@ class ServerListServiceTest {
             // Cache only memorizes a non-empty result -- give it something to bite on.
             loaderResult = { LoaderResponse(status = "OK", servers = listOf(SmartyServer(id = "Industrial", ip = "127.0.0.1"))) }
         }
-        val svc = ServerListService(ServerRepository(protocol))
+        val svc = SmartyCraftServerListService(ServerRepository(protocol))
 
         val first = svc.fetchDashboardData().await()
         val second = svc.fetchDashboardData().await()
@@ -69,7 +69,7 @@ class ServerListServiceTest {
         val protocol = FakeServerProtocol().apply {
             loaderResult = { LoaderResponse(status = "ERROR") }
         }
-        val svc = ServerListService(ServerRepository(protocol))
+        val svc = SmartyCraftServerListService(ServerRepository(protocol))
 
         svc.fetchDashboardData().await()
         delay(10.milliseconds)


### PR DESCRIPTION
## Summary

Prepares the \`IServerListService\` surface for a second implementation that fetches from the smrt.hivens.dev mirror. The interface contract is unchanged; only the implementation gets a name that says where it fetches from.

- New \`ServerSource\` enum with two shipped values: \`Smartycraft\` and \`Mirror\`. Other variants land when an additional upstream becomes real, not before.
- \`ServerProfile\` gains a \`source\` field with default \`Smartycraft\` so every persisted profile from before this change deserialises without producing a \"missing field\" parse error.
- \`ServerListService\` is renamed to \`SmartyCraftServerListService\`; its \`getProfile\` mapper sets \`source = Smartycraft\` explicitly.
- Koin binding updates to use the new class name. UI call sites consume \`IServerListService\` and stay untouched.
- Test class renamed alongside.

Mirror impl, multi-source merging, and per-server settings split are follow-up work and do not land here.

## Test plan

- [x] \`./gradlew :client-launcher:test\` passes (SmartyCraftServerListServiceTest + the rest)
- [x] \`./gradlew :client-ui:compileKotlinDesktop\` passes (UI compiles against the renamed binding)
- [ ] Launcher boots and the dashboard loads (manual smoke -- the binding now resolves to the renamed class)