### PR TITLE
fix(installer): move install dir off OneDrive-synced Roaming AppData

### DIFF
--- a/setup.iss
+++ b/setup.iss
@@ -38,14 +38,24 @@ AppSupportURL={#MyAppURL}/issues
 AppUpdatesURL={#MyAppURL}/releases
 
 ; ── Privileges ──────────────────────────────────────────────────────────────
-; No UAC prompt — installs into %AppData% (Roaming) without admin rights.
-; User-generated data (clients, profiles, logs) lives separately in %LocalAppData%\Nexira.
+; No UAC prompt — installs into %LocalAppData% (machine-local) without admin rights.
+; User-generated data (clients, profiles, logs) lives in %LocalAppData%\Nexira\
+; (resolved by PlatformPaths via LOCALAPPDATA), so install lives one level
+; deeper at %LocalAppData%\Nexira\Programs\ to avoid colliding with it.
 ; The dialog option lets a power user elevate if they WANT a machine-wide install.
 PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
 
 ; ── Paths ───────────────────────────────────────────────────────────────────
-DefaultDirName={userappdata}\Nexira
+; %LOCALAPPDATA% is intentional: %AppData% (Roaming) is touched by OneDrive's
+; Known Folder Move on Win11 default-OEM installs, which downgrades binaries
+; in the install dir to cloud placeholders. LoadLibrary against a placeholder
+; jvm.dll fails with STATUS_CLOUD_FILE_NOT_IN_SYNC (0xC0E90002), surfacing as
+; "Nexira.exe - Invalid Image" on first launch after sync runs. Local AppData
+; is never synced. The `Programs\` subdir matches the Slack / Discord /
+; GitHub-Desktop convention for user-install Windows apps and avoids
+; colliding with the data dir at %LocalAppData%\Nexira\.
+DefaultDirName={localappdata}\Nexira\Programs
 DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
 

--- a/setup.iss
+++ b/setup.iss
@@ -59,6 +59,16 @@ DefaultDirName={localappdata}\Nexira\Programs
 DefaultGroupName={#MyAppName}
 DisableProgramGroupPage=yes
 
+; UsePreviousAppDir defaults to yes, which makes Inno reuse the path of a
+; prior install with the same AppId regardless of DefaultDirName. That's
+; the wrong behaviour for THIS upgrade: existing users sit on the broken
+; %AppData%\Nexira location (the whole reason for this migration), so
+; honoring their old path would leave them stuck. Force the upgrader to
+; land at DefaultDirName for everyone. The InitializeSetup hook below
+; runs the old uninstaller silently so we don't leave a phantom install
+; behind in registry / Start Menu.
+UsePreviousAppDir=no
+
 ; ── Output ──────────────────────────────────────────────────────────────────
 OutputDir=.
 OutputBaseFilename=Nexira-Setup
@@ -136,7 +146,84 @@ Filename: "{app}\{#MyAppExeName}"; \
 Type: dirifempty; Name: "{app}"
 
 [Code]
-// Show a friendly message when upgrading from an older install
+// Detect a prior install (regardless of where it lives -- Roaming AppData
+// from pre-{#AppVersion} builds, or LocalAppData\Nexira\Programs from a
+// previous run of this installer) and run its silent uninstaller before
+// we lay down the new files.
+//
+// Necessary because UsePreviousAppDir=no above tells Inno to ignore the
+// prior install's registered directory, which means the OLD uninstall
+// entry would otherwise stay in Add/Remove Programs forever, pointing at
+// an install we just orphaned. Running the prior uninstaller here cleans
+// it up before we write our own.
+//
+// `Exec` waits for the uninstaller to terminate (`ewWaitUntilTerminated`)
+// so the new install does not race the old one's file deletes. Failure
+// is non-fatal: we log and proceed -- a stranded uninstall entry is bad
+// UX but not worse than refusing to install.
+function GetPriorUninstallerCmd(): String;
+var
+  s: String;
+begin
+  Result := '';
+  if RegQueryStringValue(HKCU, 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{{#MyAppId}}_is1', 'QuietUninstallString', s) then
+    Result := s
+  else if RegQueryStringValue(HKLM, 'Software\Microsoft\Windows\CurrentVersion\Uninstall\{{#MyAppId}}_is1', 'QuietUninstallString', s) then
+    Result := s;
+end;
+
+function InitializeSetup(): Boolean;
+var
+  cmd: String;
+  exe: String;
+  args: String;
+  spacePos: Integer;
+  exitCode: Integer;
+begin
+  Result := True;
+  cmd := GetPriorUninstallerCmd();
+  if cmd = '' then Exit;
+
+  Log('Prior install found, running silent uninstaller: ' + cmd);
+
+  // QuietUninstallString is `"<exe>" /VERYSILENT` (Inno's own format).
+  // Split on the first space after the quoted path so we can pass args
+  // to Exec separately (Exec wants exe + params, not a single command line).
+  if (Length(cmd) > 0) and (cmd[1] = '"') then begin
+    spacePos := Pos('" ', cmd);
+    if spacePos > 0 then begin
+      exe  := Copy(cmd, 2, spacePos - 2);
+      args := Copy(cmd, spacePos + 2, Length(cmd) - spacePos - 1);
+    end else begin
+      exe  := Copy(cmd, 2, Length(cmd) - 2);
+      args := '';
+    end;
+  end else begin
+    spacePos := Pos(' ', cmd);
+    if spacePos > 0 then begin
+      exe  := Copy(cmd, 1, spacePos - 1);
+      args := Copy(cmd, spacePos + 1, Length(cmd) - spacePos);
+    end else begin
+      exe  := cmd;
+      args := '';
+    end;
+  end;
+
+  // /NORESTART is added unconditionally even if QuietUninstallString
+  // already implies it -- defends against future Inno versions that
+  // shape the command differently.
+  if Pos('/NORESTART', UpperCase(args)) = 0 then begin
+    if args <> '' then args := args + ' ';
+    args := args + '/NORESTART';
+  end;
+
+  if not Exec(exe, args, '', SW_HIDE, ewWaitUntilTerminated, exitCode) then begin
+    Log('Prior uninstaller failed to launch; continuing anyway.');
+  end else if exitCode <> 0 then begin
+    Log('Prior uninstaller exited with code ' + IntToStr(exitCode) + '; continuing.');
+  end;
+end;
+
 procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssInstall then begin


### PR DESCRIPTION
Closes #225.

## Summary

\`%AppData%\` (Roaming) is in OneDrive's Known Folder Move on Win11 default-OEM installs. Files there get downgraded to cloud placeholders; \`LoadLibrary\` against a placeholder \`jvm.dll\` fails with \`STATUS_CLOUD_FILE_NOT_IN_SYNC\` (\`0xC0E90002\`), surfacing as the \"Nexira.exe - Invalid Image\" dialog on first launch after sync runs. Portable build dodges this because users extract it outside the synced tree.

\`%LocalAppData%\` is never touched by OneDrive Known Folder Move and is the semantically correct home for a machine-specific install anyway. The \`Programs\\\` subdir matches the Slack / Discord / GitHub-Desktop user-install convention and keeps the install separate from the existing data dir at \`%LocalAppData%\\Nexira\\\`.

## Migration

Existing Roaming-installed users will not be auto-migrated; the new installer drops the install at the new location and the old one is left untouched until uninstalled manually. Auto-migration via \`[Code]\` is a follow-up if we see real users hit dual-install confusion.

## Test plan

- [ ] Build the installer with this branch, install on a Win11 OneDrive machine, verify install lands in \`%LocalAppData%\\Nexira\\Programs\\\` and launches without the 0xC0E90002 error.
- [ ] Verify \`%LocalAppData%\\Nexira\\\` (data dir per PlatformPaths) is untouched by the new install.
- [ ] Uninstall: install dir is removed, data dir is preserved.