### PR TITLE
fix(packaging): ship bilingual README in portable zip, delete stale Gradle task

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -257,6 +257,13 @@ jobs:
           # Nexira\bin\..., Nexira\lib\runtime\... shape
           # inside the zip stays identical from the user's perspective.
           $src = "client-ui\build\customJpackageImage"
+          # Drop the bilingual README inside Nexira\ before zipping so
+          # users see it immediately on extraction. Without it, the
+          # natural-but-wrong "copy just Nexira.exe to Desktop" move
+          # produces a cryptic "Nexira.cfg not found" error at launch
+          # (see issue #227).
+          Copy-Item -Path "packaging\portable-readme.txt" `
+                    -Destination "$src\Nexira\README.txt"
           Compress-Archive -Path "$src\*" `
             -DestinationPath "Nexira-$env:APP_VERSION-Windows-Portable.zip"
 

--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -487,16 +487,13 @@ tasks.configureEach {
     }
 }
 
-// ========================================================================
-// PORTABLE ZIP (Windows)
-// For local dev use; CI also runs this step independently.
-// ========================================================================
-tasks.register<Zip>("packageWindowsPortableZip") {
-    group = "compose desktop"
-    description = "Packages the Windows distributable as a portable ZIP"
-    dependsOn("createReleaseDistributable")
-
-    from(layout.buildDirectory.dir("compose/binaries/main-release/app"))
-    archiveFileName.set("Nexira-${project.version}-Windows-Portable.zip")
-    destinationDirectory.set(layout.buildDirectory.dir("compose/binaries/main-release"))
-}
+// Portable ZIP packaging lives in the build_release workflow's
+// PowerShell step, not in a Gradle task. The previous local-dev task
+// here still pointed at the pre-B-3 Compose Desktop output path
+// (compose/binaries/main-release/app) which is no longer produced
+// since the customJpackageImage migration, so the task produced an
+// empty / broken zip. Having two sources of truth for the same
+// artifact (Gradle task + CI step) is the worst-of-both: divergence
+// goes unnoticed locally until CI's version reaches a user. CI is
+// the single source of truth; reproduce the steps from
+// build_release.yml directly if you need a local portable.

--- a/packaging/portable-readme.txt
+++ b/packaging/portable-readme.txt
@@ -1,0 +1,47 @@
+Nexira - Portable
+=================
+
+ENGLISH
+-------
+
+Do not copy individual files out of this folder.
+
+The launcher needs Nexira.exe, the app\ folder, and the runtime\
+folder to stay together at the same level. Copying just Nexira.exe
+to your Desktop (or anywhere else) will produce this error on
+launch:
+
+    Error opening "...\app\Nexira.cfg" file: No such file or directory
+
+To launch:
+    Double-click Nexira.exe inside this folder.
+
+To move the portable install:
+    Copy the entire Nexira\ folder, not just the EXE.
+
+To install permanently with Start Menu / Desktop shortcuts:
+    Use Nexira-Setup.exe from the same release instead of the
+    portable build.
+
+
+RUSSIAN
+-------
+
+Не копируйте отдельные файлы из этой папки.
+
+Лаунчер требует, чтобы Nexira.exe, папка app\ и папка runtime\
+оставались вместе на одном уровне. Если перенести только
+Nexira.exe на рабочий стол (или в любое другое место),
+при запуске будет ошибка:
+
+    Error opening "...\app\Nexira.cfg" file: No such file or directory
+
+Запуск:
+    Двойной клик по Nexira.exe внутри этой папки.
+
+Перенос portable-сборки:
+    Копируйте всю папку Nexira\ целиком, а не один EXE.
+
+Постоянная установка с ярлыками в меню Пуск / на рабочем столе:
+    Используйте Nexira-Setup.exe из того же релиза вместо
+    portable-сборки.


### PR DESCRIPTION
Closes #227.

## Summary

The portable build extracts to a \`Nexira\\\` folder with \`Nexira.exe\` and its required \`app\\\` + \`runtime\\\` siblings. Some users instinctively copy just \`Nexira.exe\` out of that folder (to Desktop or wherever) thinking the EXE is standalone, and then hit the cryptic jpackage error \"Error opening 'app\\Nexira.cfg' file: No such file or directory\" on launch.

Two parts:

1. Ship a bilingual EN+RU \`README.txt\` inside the portable's \`Nexira\\\` folder. Catches the eye before the user goes splitting things up; the file lives in repo at \`packaging/portable-readme.txt\` and CI copies it into the jpackage output before zipping.

2. Delete the stale \`packageWindowsPortableZip\` Gradle task. It still pointed at the pre-B-3 Compose Desktop output path (\`compose/binaries/main-release/app\`) which is no longer produced since the customJpackageImage migration, so the task produced either an empty or broken zip. CI's PowerShell step in \`build_release.yml\` has been the real portable builder for a while; deleting the Gradle task makes that explicit and removes the local-dev footgun. A comment in the same place points future contributors at the CI step.

## Test plan

- [ ] CI's Create Portable ZIP step finds \`packaging/portable-readme.txt\` and copies it into \`client-ui\\build\\customJpackageImage\\Nexira\\README.txt\`.
- [ ] Built portable zip, extracted to a clean folder, contains a \`README.txt\` at the same level as \`Nexira.exe\`.
- [ ] \`./gradlew :client-ui:tasks --group=\"compose desktop\"\` no longer lists \`packageWindowsPortableZip\`.