### PR TITLE
fix(test): skip getJavaPath-existing-binary test on Windows

### DIFF
--- a/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
@@ -478,11 +478,21 @@ class JavaManagerServiceTest {
     // ── getJavaPath: orchestrator (find -> download -> find -> +x) ────────
 
     @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
     fun `getJavaPath returns existing executable without triggering download`() {
         // Pre-place a valid-looking java binary in the version-specific
         // runtime dir. The dead-HttpClient provider catches a regression
         // where the early-return gate fails and the orchestrator falls
         // through to downloadAndUnpack.
+        //
+        // Linux/Mac only: even though the test simulates Linux via
+        // os.name/os.arch overrides, the underlying file system probe
+        // (Files.isExecutable on the pre-placed `bin/java` binary)
+        // runs on the real OS. On Windows NTFS, isExecutable returns
+        // false for extensionless files regardless of setExecutable(true),
+        // so the orchestrator decides "binary not present" and falls
+        // through to download -- hits the dead HttpClient and throws.
+        // Same rationale as the tar.gz unpack test below.
         val runtimesRoot = workDir
         withSystemProp("os.name", "Linux") {
             withSystemProp("os.arch", "amd64") {


### PR DESCRIPTION
Hotfix for the v2.3.1 release push (CI run [26363601566](https://github.com/Kitty-Hivens/Nexira/actions/runs/26363601566)).

## Cause

The test simulates Linux via \`os.name\` / \`os.arch\` overrides so the service generates the \`linux-x64\` folder name, but \`Files.isExecutable\` on the pre-placed \`bin/java\` probe runs on the REAL OS. On Windows NTFS that returns false for extensionless files regardless of \`setExecutable(true)\`, so the orchestrator decides \"binary not present\" and falls through to the download path -- which hits the test's dead HttpClient and throws.

Same rationale as the neighbouring \`getJavaPath downloads tar-gz\` test that already carries \`@EnabledOnOs(OS.LINUX, OS.MAC)\`.

## Latency

The Windows-only failure was latent because PR Portability + Qodana only run on Linux. The Windows test matrix in \`build_release.yml\` runs ONLY on tag push / workflow_dispatch, so the bug only surfaced when the v2.3.1 tag fired the release pipeline.

## After merge

The v2.3.1 tag will be deleted and re-pushed on the new HEAD to retry the release pipeline. No release artifact was published yet (the test job blocked the build job), so no users are affected.

## Test plan

- [x] \`./gradlew :client-launcher:test --tests \"*JavaManagerServiceTest*\"\` passes on Linux (silent on -q success).
- [ ] After merge + re-tag, Windows test matrix passes in build_release.