### PR TITLE
fix(packaging): keep filekit through ProGuard, surface picker errors

### DIFF
--- a/client-ui/compose-desktop.pro
+++ b/client-ui/compose-desktop.pro
@@ -151,6 +151,23 @@
 # namespace; we don't ship anything else in those packages.
 -keep class org.freedesktop.dbus.** { *; }
 
+# ── FileKit: extension-function overloads + PlatformFile constructors ─────
+# Filed report after 2.3.1: the "Move data directory" picker call site
+# (only one that passes `directory = PlatformFile(...)`) was a dead
+# button on Win11 AND on Linux AppImage, but worked in dev. Other
+# FilePicker call sites that don't pass `directory =` worked everywhere.
+# Release-vs-dev with same platform behaviour points at ProGuard:
+# the with-directory overload of openDirectoryPicker is reachable from
+# only one place, and the `PlatformFile(File)` constructor only from
+# that same place -- ProGuard's reachability culled one or both, and
+# the call exploded at runtime in a way the call site silently
+# swallowed. Keep the whole filekit namespace; the jar is small, we
+# use the API surface across multiple screens, and a wildcard prevents
+# the next "only this picker uses parameter X and now it's broken"
+# variant of the same class of bug.
+-keep class io.github.vinceglb.filekit.** { *; }
+-keepclassmembers class io.github.vinceglb.filekit.** { *; }
+
 # --- Suppress Warnings ---
 -dontwarn ch.qos.logback.**
 -dontwarn org.slf4j.**

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -390,6 +390,7 @@ interface AppStrings {
     val settingsDataDirQuitNow: String
     val settingsDataDirErrorSamePath: String
     val settingsDataDirErrorNotEmpty: String
+    fun settingsDataDirErrorPickerFailed(reason: String): String
 
     // ═══════════════════════════════════════════════════════════════════════
     // JVM Args Builder dialog

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -378,6 +378,8 @@ object EnglishStrings : AppStrings {
     override val settingsDataDirQuitNow         = "Quit now"
     override val settingsDataDirErrorSamePath   = "That's already the current directory — pick a different folder"
     override val settingsDataDirErrorNotEmpty   = "Target folder is not empty — pick an empty folder or delete its contents"
+    override fun settingsDataDirErrorPickerFailed(reason: String) =
+        "Couldn't open the folder picker: $reason"
 
     // ── JVM Args Builder ────────────────────────────────────────────────
     override val jvmTitle    = "JVM Args Builder"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -378,6 +378,8 @@ object GermanStrings : AppStrings {
     override val settingsDataDirQuitNow         = "Jetzt beenden"
     override val settingsDataDirErrorSamePath   = "Das ist bereits das aktuelle Verzeichnis — wähle einen anderen Ordner"
     override val settingsDataDirErrorNotEmpty   = "Zielordner ist nicht leer — wähle einen leeren Ordner oder lösche dessen Inhalt"
+    override fun settingsDataDirErrorPickerFailed(reason: String) =
+        "Ordnerauswahl konnte nicht geöffnet werden: $reason"
 
     // ── JVM Args Builder ────────────────────────────────────────────────
     override val jvmTitle    = "JVM-Argument-Builder"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -379,6 +379,8 @@ object RussianStrings : AppStrings {
     override val settingsDataDirQuitNow         = "Выйти сейчас"
     override val settingsDataDirErrorSamePath   = "Это и есть текущий каталог — выбери другую папку"
     override val settingsDataDirErrorNotEmpty   = "Целевая папка не пуста — выбери пустую папку или удали её содержимое"
+    override fun settingsDataDirErrorPickerFailed(reason: String) =
+        "Не удалось открыть выбор папки: $reason"
 
     // ── JVM Args Builder ────────────────────────────────────────────────
     override val jvmTitle    = "Конструктор JVM-аргументов"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/AdvancedSection.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/AdvancedSection.kt
@@ -21,17 +21,19 @@ import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 import io.github.vinceglb.filekit.FileKit
-import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.openDirectoryPicker
 import io.github.vinceglb.filekit.path
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.system.exitProcess
+
+private val log = LoggerFactory.getLogger("AdvancedSection")
 
 /**
  * Advanced surface -- currently houses the data-directory mover.
@@ -85,12 +87,36 @@ internal fun AdvancedSection(paths: PlatformPaths) {
                     // and some backends render a less-styled fallback
                     // chrome (no titlebar text, generic icon). Match what
                     // ProfileScreen + ServerSettingsScreen pass here.
-                    val pickedFile = runCatching {
+                    //
+                    // The `directory =` initial-folder hint is deliberately
+                    // NOT passed. On Win11 the data dir lives at
+                    // %LocalAppData%\Nexira (a reparse-pointed path under
+                    // some OEM setups); IFileDialog returns ERROR_CANCELLED
+                    // when given such a path as its initial folder, and
+                    // FileKit translates that into an exception that this
+                    // call site used to swallow silently -- the button
+                    // appeared "dead" with no log, no UI feedback (issue
+                    // raised on 2.3.1 release day). Letting FileKit pick
+                    // its own default (CWD or last-used) sidesteps the
+                    // platform quirk; the dialog title carries enough
+                    // context for the user. Other FilePicker call sites
+                    // (ProfileScreen, ServerSettingsScreen) also do not
+                    // pass `directory =` and have always worked.
+                    val pickResult = runCatching {
                         FileKit.openDirectoryPicker(
-                            directory      = PlatformFile(paths.dataDir.toFile()),
                             dialogSettings = FileKitDialogSettings(title = s.settingsDataDirMove),
                         )
-                    }.getOrNull() ?: return@launch
+                    }
+                    val pickedFile = pickResult.getOrElse { ex ->
+                        // Swallowing the exception silently here was the
+                        // exact bug above. Surface it: log so the next
+                        // diagnostic bundle has the stack, show a short
+                        // line to the user so a "dead button" stops
+                        // looking dead.
+                        log.warn("openDirectoryPicker failed", ex)
+                        showError = s.settingsDataDirErrorPickerFailed(ex.message ?: ex.javaClass.simpleName)
+                        return@launch
+                    } ?: return@launch
 
                     val picked = Paths.get(pickedFile.path)
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/AdvancedSection.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/AdvancedSection.kt
@@ -21,6 +21,7 @@ import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.openDirectoryPicker
 import io.github.vinceglb.filekit.path
@@ -88,22 +89,21 @@ internal fun AdvancedSection(paths: PlatformPaths) {
                     // chrome (no titlebar text, generic icon). Match what
                     // ProfileScreen + ServerSettingsScreen pass here.
                     //
-                    // The `directory =` initial-folder hint is deliberately
-                    // NOT passed. On Win11 the data dir lives at
-                    // %LocalAppData%\Nexira (a reparse-pointed path under
-                    // some OEM setups); IFileDialog returns ERROR_CANCELLED
-                    // when given such a path as its initial folder, and
-                    // FileKit translates that into an exception that this
-                    // call site used to swallow silently -- the button
-                    // appeared "dead" with no log, no UI feedback (issue
-                    // raised on 2.3.1 release day). Letting FileKit pick
-                    // its own default (CWD or last-used) sidesteps the
-                    // platform quirk; the dialog title carries enough
-                    // context for the user. Other FilePicker call sites
-                    // (ProfileScreen, ServerSettingsScreen) also do not
-                    // pass `directory =` and have always worked.
+                    // The bug this call site had on 2.3.1: button did
+                    // nothing on Windows AND on Linux AppImage. Initial
+                    // hypothesis was a platform-specific FileKit issue
+                    // (Win11 IFileDialog rejecting Local-AppData junction
+                    // paths via `directory =`), but the bug also showed
+                    // on AppImage Linux which ruled platform out and left
+                    // ProGuard as the only release-vs-dev discriminator.
+                    // Fix lives in client-ui/compose-desktop.pro: keep
+                    // io.github.vinceglb.filekit.** so PlatformFile +
+                    // the with-directory overload survive shrinking.
+                    // With the keep rule in place the original
+                    // directory-hint call below works on every platform.
                     val pickResult = runCatching {
                         FileKit.openDirectoryPicker(
+                            directory      = PlatformFile(paths.dataDir.toFile()),
                             dialogSettings = FileKitDialogSettings(title = s.settingsDataDirMove),
                         )
                     }


### PR DESCRIPTION
Post-2.3.1 hotfix. The \"Move data directory\" button was a dead button on Win11 AND on Linux AppImage builds, but worked in dev. Same-platform release-vs-dev divergence pointed at ProGuard.

## Cause

The AdvancedSection call site is the only place in the codebase that passes \`directory = PlatformFile(paths.dataDir.toFile())\` to \`FileKit.openDirectoryPicker\`. Other FilePicker call sites (ProfileScreen, ServerSettingsScreen) don't pass \`directory =\` and worked everywhere. ProGuard's reachability analysis culled the with-\`directory\` overload of \`openDirectoryPicker\` and/or the \`PlatformFile(File)\` constructor as unreachable (only one caller, no other entry points). At runtime the call exploded with an exception that the call site silently swallowed via \`runCatching { ... }.getOrNull() ?: return@launch\` -- the user saw a dead button with no log line.

## Fix

- Wildcard keep for \`io.github.vinceglb.filekit.**\` in \`client-ui/compose-desktop.pro\`. The jar is small, we use the API across multiple screens, and a wildcard prevents the next \"only this picker uses parameter X and is now broken\" variant.
- Replace the silent swallow in \`AdvancedSection\` with an explicit \`getOrElse\` that LOGs the exception and surfaces a localized error in the same \`showError\` slot the other failure modes already use. \`settingsDataDirErrorPickerFailed(reason)\` lands in EN, RU, DE.
- The \`directory =\` hint is restored on the picker call -- now that ProGuard keeps it, the original UX of opening the picker at the current data dir is back.

## Test plan

- [ ] Local AppImage: button opens directory picker successfully (was the reproducer).
- [ ] Win11: same -- new ProGuard rule should fix it identically.
- [ ] If the picker DOES error out for any other reason: error line appears under the button instead of nothing, and the launcher log carries the stack.