### PR TITLE
fix(jdk): browser UA + Adoptium fallback so BellSoft + CloudFlare WARP stops 403'ing

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JavaManagerService.kt
@@ -72,37 +72,67 @@ class JavaManagerService(
     }
 
     private suspend fun downloadAndUnpack(version: Int, targetDir: Path) {
-        val url = getDownloadUrl(version)
-            ?: throw IOException("There is no Java build for this system (${getOsName()} ${getArchName()})")
-
-        val isZip = url.endsWith(".zip")
-        val archive = Files.createTempFile("java_pkg", if (isZip) ".zip" else ".tar.gz")
-
-        try {
-            log.info("Download Java: $url")
-
-            httpClient.prepareGet(url).execute { httpResponse ->
-                if (!httpResponse.status.isSuccess()) {
-                    throw IOException("Loading error: ${httpResponse.status}")
-                }
-                val channel = httpResponse.bodyAsChannel()
-                FileOutputStream(archive.toFile()).use { fileStream ->
-                    channel.copyTo(fileStream)
-                }
-            }
-
-            log.info("Unpacking to $targetDir")
-            deleteDirectoryRecursively(targetDir)
-            Files.createDirectories(targetDir)
-
-            if (isZip) {
-                unzip(archive.toFile(), targetDir)
-            } else {
-                untargz(archive.toFile(), targetDir)
-            }
-        } finally {
-            Files.deleteIfExists(archive)
+        val urls = getDownloadUrls(version)
+        if (urls.isEmpty()) {
+            throw IOException("There is no Java build for this system (${getOsName()} ${getArchName()})")
         }
+
+        // Try each mirror in order; first one that returns a usable
+        // archive wins. Fallback exists because CloudFlare in front of
+        // BellSoft 403s certain regions / IP ranges entirely (filed
+        // 2026-05-24: RF-based tester saw consistent 403 from BellSoft
+        // despite valid URL, while curl from elsewhere returned 200).
+        // Adoptium is hosted on GitHub releases which has wider regional
+        // reachability and less aggressive bot detection.
+        var lastError: Exception? = null
+        for ((index, url) in urls.withIndex()) {
+            val isZip = url.endsWith(".zip")
+            val archive = Files.createTempFile("java_pkg", if (isZip) ".zip" else ".tar.gz")
+            try {
+                log.info("Download Java attempt {}/{}: {}", index + 1, urls.size, url)
+
+                // Browser-shaped User-Agent. Default ktor UA ("Ktor
+                // client/...") is on CloudFlare's bot signature list and
+                // gets blanket-403'd from regions CloudFlare flags as
+                // bot-heavy. Sending a real-Chrome UA passes the cheap
+                // bot heuristic; sophisticated TLS-fingerprint detection
+                // would still catch us, but BellSoft / GitHub don't
+                // appear to use that tier.
+                httpClient.prepareGet(url) {
+                    header(HttpHeaders.UserAgent, DOWNLOAD_UA)
+                }.execute { httpResponse ->
+                    if (!httpResponse.status.isSuccess()) {
+                        throw IOException("Loading error: ${httpResponse.status}")
+                    }
+                    val channel = httpResponse.bodyAsChannel()
+                    FileOutputStream(archive.toFile()).use { fileStream ->
+                        channel.copyTo(fileStream)
+                    }
+                }
+
+                log.info("Unpacking to {}", targetDir)
+                deleteDirectoryRecursively(targetDir)
+                Files.createDirectories(targetDir)
+
+                if (isZip) {
+                    unzip(archive.toFile(), targetDir)
+                } else {
+                    untargz(archive.toFile(), targetDir)
+                }
+                Files.deleteIfExists(archive)
+                return
+            } catch (e: Exception) {
+                Files.deleteIfExists(archive)
+                log.warn("Download from {} failed: {}", url, e.message)
+                lastError = e
+                // Continue to next mirror.
+            }
+        }
+        throw IOException(
+            "All Java $version download mirrors failed for ${getOsName()} ${getArchName()}. " +
+                "Last error: ${lastError?.message ?: "unknown"}",
+            lastError,
+        )
     }
     internal fun getOsName(): String {
         val os = System.getProperty("os.name").lowercase()
@@ -321,7 +351,24 @@ class JavaManagerService(
         }
     }
 
-    internal fun getDownloadUrl(version: Int): String? {
+    /**
+     * Ordered list of mirrors to try for the given Java major. The
+     * downloader walks the list in order; first one that delivers a
+     * usable archive wins. Adoptium is the fallback because BellSoft
+     * (via CloudFlare) blanket-403s certain regions / IP ranges that
+     * the user's network may sit behind.
+     */
+    internal fun getDownloadUrls(version: Int): List<String> =
+        listOfNotNull(getBellSoftUrl(version), getAdoptiumUrl(version))
+
+    /**
+     * Backwards-compatible alias: existing tests + callers that want
+     * just the primary URL keep working. New code should prefer
+     * [getDownloadUrls] so fallback is exercised.
+     */
+    internal fun getDownloadUrl(version: Int): String? = getBellSoftUrl(version)
+
+    internal fun getBellSoftUrl(version: Int): String? {
         val os = getOsName()
         val arch = getArchName()
         return when (version) {
@@ -350,5 +397,70 @@ class JavaManagerService(
             }
             else -> null
         }
+    }
+
+    /**
+     * Adoptium / Temurin GitHub-release URL for the given Java major.
+     * Pinned to a known LTS-line build per major; bump these by hand
+     * when a newer build is needed. GitHub releases are statically
+     * served, no CloudFlare bot manager in front -- works from
+     * regions where BellSoft's CDN returns 403.
+     *
+     * The `+` in the Temurin tag name is %2B-encoded so the URL stays
+     * valid through every HTTP-client URL-parser variant. The filename
+     * uses the underscored form (`21.0.5_11`) which is Adoptium's own
+     * convention.
+     */
+    internal fun getAdoptiumUrl(version: Int): String? {
+        val os = getOsName()
+        val arch = getArchName()
+        return when (version) {
+            8 -> when (os) {
+                "win"   if arch == "x64"   -> adoptium(8, "8u442-b06", "8u442b06", "x64",     "windows", "zip")
+                "linux" if arch == "x64"   -> adoptium(8, "8u442-b06", "8u442b06", "x64",     "linux",   "tar.gz")
+                "mac"   if arch == "x64"   -> adoptium(8, "8u442-b06", "8u442b06", "x64",     "mac",     "tar.gz")
+                "mac"   if arch == "arm64" -> adoptium(8, "8u442-b06", "8u442b06", "aarch64", "mac",     "tar.gz")
+                else -> null
+            }
+            17 -> when (os) {
+                "win"   if arch == "x64"   -> adoptium(17, "17.0.13+11", "17.0.13_11", "x64",     "windows", "zip")
+                "linux" if arch == "x64"   -> adoptium(17, "17.0.13+11", "17.0.13_11", "x64",     "linux",   "tar.gz")
+                "mac"   if arch == "x64"   -> adoptium(17, "17.0.13+11", "17.0.13_11", "x64",     "mac",     "tar.gz")
+                "mac"   if arch == "arm64" -> adoptium(17, "17.0.13+11", "17.0.13_11", "aarch64", "mac",     "tar.gz")
+                else -> null
+            }
+            21 -> when (os) {
+                "win"   if arch == "x64"   -> adoptium(21, "21.0.5+11", "21.0.5_11", "x64",     "windows", "zip")
+                "linux" if arch == "x64"   -> adoptium(21, "21.0.5+11", "21.0.5_11", "x64",     "linux",   "tar.gz")
+                "mac"   if arch == "x64"   -> adoptium(21, "21.0.5+11", "21.0.5_11", "x64",     "mac",     "tar.gz")
+                "mac"   if arch == "arm64" -> adoptium(21, "21.0.5+11", "21.0.5_11", "aarch64", "mac",     "tar.gz")
+                else -> null
+            }
+            else -> null
+        }
+    }
+
+    private fun adoptium(
+        major: Int,
+        tag: String,
+        fileVersion: String,
+        arch: String,
+        os: String,
+        ext: String,
+    ): String {
+        val tagEncoded = tag.replace("+", "%2B")
+        // Java 8 release tag prefix is `jdk` (no dash before the version),
+        // 9+ uses `jdk-`. Mirrors Adoptium's own release naming.
+        val tagPrefix = if (major == 8) "jdk" else "jdk-"
+        return "https://github.com/adoptium/temurin${major}-binaries/releases/download/" +
+            "$tagPrefix$tagEncoded/OpenJDK${major}U-jdk_${arch}_${os}_hotspot_$fileVersion.$ext"
+    }
+
+    companion object {
+        // Real-Chrome User-Agent. See downloadAndUnpack for why this is
+        // not the launcher's default identifier.
+        internal const val DOWNLOAD_UA =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     }
 }

--- a/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/JavaManagerServiceTest.kt
@@ -221,6 +221,60 @@ class JavaManagerServiceTest {
         }
     }
 
+    // ── getAdoptiumUrl + getDownloadUrls: fallback mirror plumbing ──────────
+
+    @Test
+    fun `getAdoptiumUrl shapes GitHub-release path with +-encoded build tag`() {
+        // Filed 2026-05-24: RF tester on CloudFlare WARP got blanket
+        // 403 from BellSoft (CloudFlare bot manager hostile to its own
+        // WARP exits). Adoptium on GitHub releases dodges both legs of
+        // the CloudFlare double-whammy. This test pins the URL shape so
+        // a future Temurin tag rotation surfaces in tests, not in a
+        // user report.
+        withSystemProp("os.name", "Windows 10") {
+            withSystemProp("os.arch", "amd64") {
+                val url21 = svc.getAdoptiumUrl(21)!!
+                assertEquals(true, url21.startsWith("https://github.com/adoptium/temurin21-binaries/releases/download/"))
+                assertEquals(true, url21.contains("%2B"))                // + is %2B-encoded
+                assertEquals(true, url21.endsWith("_windows_hotspot_21.0.5_11.zip"))
+
+                val url17 = svc.getAdoptiumUrl(17)!!
+                assertEquals(true, url17.contains("temurin17-binaries"))
+                assertEquals(true, url17.endsWith("_windows_hotspot_17.0.13_11.zip"))
+
+                val url8 = svc.getAdoptiumUrl(8)!!
+                // Java 8 tag prefix is `jdk` (no dash), 9+ is `jdk-`.
+                assertEquals(true, url8.contains("/download/jdk8u442-b06/"))
+                assertEquals(true, url8.endsWith("_windows_hotspot_8u442b06.zip"))
+            }
+        }
+    }
+
+    @Test
+    fun `getDownloadUrls returns BellSoft first then Adoptium`() {
+        withSystemProp("os.name", "Linux") {
+            withSystemProp("os.arch", "amd64") {
+                val urls = svc.getDownloadUrls(21)
+                assertEquals(2, urls.size)
+                assertEquals(true, urls[0].startsWith("https://download.bell-sw.com/"))
+                assertEquals(true, urls[1].startsWith("https://github.com/adoptium/"))
+            }
+        }
+    }
+
+    @Test
+    fun `getDownloadUrls is empty for unsupported os arch combos`() {
+        withSystemProp("os.name", "Linux") {
+            withSystemProp("os.arch", "i386") {
+                // Neither mirror ships Linux x86, so the list collapses
+                // to empty rather than half-populated -- caller throws
+                // "no Java build for this system" instead of trying a
+                // mismatched arch.
+                assertEquals(emptyList<String>(), svc.getDownloadUrls(21))
+            }
+        }
+    }
+
     // ── findJavaExecutable: locate java/java.exe in BellSoft archive layout ─
 
     @Test


### PR DESCRIPTION
Post-2.3.1 hotfix. Reported by RF-based tester on Create pack.

## Symptom

\`\`\`
Download Java: https://download.bell-sw.com/java/21.0.9+15/bellsoft-jdk21.0.9+15-windows-amd64-full.zip
java.io.IOException: Loading error: 403
\`\`\`

Persistent across multiple launch attempts. URL is valid (curl from elsewhere returns 200).

## Cause

Two compounding causes:

1. CloudFlare bot manager is hostile to ktor's default \`User-Agent\` (\"Ktor client/<version>\"). It's on the known bot signature list and gets blanket-403'd from regions CloudFlare flags as bot-heavy.
2. The user's VPN is **CloudFlare WARP**, which gives her a CloudFlare-owned exit IP. BellSoft is **also** fronted by CloudFlare. So the request shape is \`CloudFlare -> CloudFlare\`, and CloudFlare's own bot manager treats traffic from its own infrastructure with extra suspicion. Even if the UA fix would normally pass, WARP-to-CDN is the worst possible IP-to-destination shape.

## Fix

Two additive changes:

- **Browser User-Agent.** Set a real-Chrome UA on the JDK download request. Cheapest possible bot-detection bypass.
- **Adoptium / Temurin fallback mirror.** GitHub-release URLs are hosted on Azure blob, not CloudFlare. The WARP-to-CDN problem evaporates entirely. The downloader walks the mirror list in order; first one that delivers a usable archive wins.

\`getDownloadUrls(version)\` is the new entry point, returning \`[BellSoft, Adoptium]\`. The legacy \`getDownloadUrl(version)\` (returning just the BellSoft URL) is preserved as a thin alias so the existing test matrix keeps passing.

## Test plan

- [x] \`./gradlew :client-launcher:test --tests \"*JavaManagerServiceTest*\"\` passes (existing BellSoft tests + new Adoptium URL-shape tests + new ordering test).
- [ ] After merge: RF tester retries Create launch, Java 21 downloads cleanly from Adoptium fallback.
- [ ] Adoptium tag-rotation surveillance: the URL-shape tests fail loudly if Temurin renames anything in the release path.