### PR TITLE
fix(easter,packaging): gate 5-tap unlock on real DebugPanel + bundle jdk.security.auth for FileKit Linux

### DIFF
--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -202,6 +202,15 @@ compose.desktop {
                 "java.management",
                 "java.prefs",
                 "jdk.crypto.ec",
+                // jdk.security.auth: provides com.sun.security.auth.module.UnixSystem,
+                // which FileKit's Linux dialog backend dlopens for user/group lookup
+                // when resolving xdg-desktop-portal session context. Without it the
+                // first FilePicker call on Linux crashes with NoClassDefFoundError
+                // for UnixSystem -- reported on 2.3.2 via the AdvancedSection
+                // openDirectoryPicker after the silent-swallow fix in PR 231 made
+                // the underlying exception visible. Module is small (~30 KB);
+                // adding it is cheaper than hand-wrapping the Linux backend.
+                "jdk.security.auth",
                 "jdk.unsupported",
                 "jdk.zipfs"
             )
@@ -339,6 +348,13 @@ packaging {
         "java.management",
         "java.prefs",
         "jdk.crypto.ec",
+        // See the matching note in the compose.desktop.application block
+        // above for why jdk.security.auth is required (FileKit Linux
+        // dialog backend dlopens UnixSystem; absence -> NoClassDefFound
+        // on first FilePicker call). This is the authoritative list
+        // since the customJpackageImage migration; keep it in sync with
+        // the legacy compose block until that block goes away.
+        "jdk.security.auth",
         "jdk.unsupported",
         "jdk.zipfs",
         "jdk.localedata",

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsLifecycle.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsLifecycle.kt
@@ -117,9 +117,24 @@ interface AprilFoolsLifecycle {
     /**
      * Developer-only debug panel that flips [debugForceActive] / [debugIntensity]
      * to test chaos behaviour out of season. NoOp impl renders nothing.
+     *
+     * Callers MUST gate access on [providesDebugPanel]; rendering this when
+     * the impl returns false produces an invisible no-op, and any unlock
+     * gesture wired to it (5-tap-Diagnostics-title) silently does nothing.
+     * That mismatch was the 2.3.2 "screen jiggles but panel never shows"
+     * report.
      */
     @Composable
     fun DebugPanel()
+
+    /**
+     * Whether [DebugPanel] renders real content in this build. False for
+     * NoOpAprilFools (production builds without `-PauraAprilFools=true`),
+     * true for RealAprilFools. Used by Diagnostics to conditionally
+     * attach the 5-tap unlock gesture so users on production builds do
+     * not see the title twitch on tap with nothing to show for it.
+     */
+    val providesDebugPanel: Boolean
 }
 
 /**

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/easter/NoOpAprilFools.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/easter/NoOpAprilFools.kt
@@ -30,6 +30,8 @@ object NoOpAprilFools : AprilFoolsLifecycle {
     override fun isActive(): Boolean = false
     override fun intensity(): Float = 0f
 
+    override val providesDebugPanel: Boolean = false
+
     // Debug knobs are still writable so the DebugPanel UI itself could
     // bind to them (the panel doesn't render in NoOp, but the contract
     // stays uniform).

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/easter/RealAprilFools.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/easter/RealAprilFools.kt
@@ -22,6 +22,8 @@ class RealAprilFools : AprilFoolsLifecycle {
     override fun isActive(): Boolean = AprilFools.isActive()
     override fun intensity(): Float = AprilFools.intensity()
 
+    override val providesDebugPanel: Boolean = true
+
     override var debugForceActive: Boolean?
         get() = AprilFools.debugForceActive
         set(value) { AprilFools.debugForceActive = value }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/DiagnosticsSection.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/DiagnosticsSection.kt
@@ -70,47 +70,48 @@ internal fun DiagnosticsSection(
     val style = LocalStyle.current
 
     // ── April Fools debug panel -- secret unlock ────────────────────
-    var debugTapCount  by remember { mutableStateOf(0) }
-    var showAprilDebug by remember { mutableStateOf(false) }
-    // Brings the panel into the ancestor vertical-scroll viewport when
-    // it appears. Without this the panel renders below the visible
-    // area (Diagnostics also hosts Open-logs / Crash-reports / Bundle
-    // / About below the title, plenty of content to push the panel
-    // off-screen) and the user only sees the rest of the list shift a
-    // couple of pixels -- looks like a click that "did nothing but
-    // twitch" instead of an unlock.
-    val debugPanelBringIntoView = remember { BringIntoViewRequester() }
+    // Only wire the 5-tap gesture when the active impl actually renders
+    // a debug panel. Production builds without `-PauraAprilFools=true`
+    // ship NoOpAprilFools whose DebugPanel() is empty, so a 5-tap on
+    // those builds would toggle a hidden state that renders to a couple
+    // of invisible Spacers -- exact symptom of "tap the title, list
+    // twitches a tiny bit, panel never shows" from the 2.3.2 report.
+    if (af.providesDebugPanel) {
+        var debugTapCount  by remember { mutableStateOf(0) }
+        var showAprilDebug by remember { mutableStateOf(false) }
+        val debugPanelBringIntoView = remember { BringIntoViewRequester() }
 
-    // Tap the diagnostics title 5 times to toggle the April Fools debug panel
-    Box(
-        Modifier.clickable {
-            debugTapCount++
-            if (debugTapCount >= 5) {
-                debugTapCount  = 0
-                showAprilDebug = !showAprilDebug
+        Box(
+            Modifier.clickable {
+                debugTapCount++
+                if (debugTapCount >= 5) {
+                    debugTapCount  = 0
+                    showAprilDebug = !showAprilDebug
+                }
+            }
+        ) {
+            SettingsSectionTitle(s.settingsSectionDiagnostics)
+        }
+
+        LaunchedEffect(showAprilDebug) {
+            if (showAprilDebug) {
+                // Wait one frame so the panel has been laid out before
+                // the scroll request is sent. bringIntoView() against a
+                // not-yet-positioned target is a no-op.
+                yield()
+                runCatching { debugPanelBringIntoView.bringIntoView() }
             }
         }
-    ) {
-        SettingsSectionTitle(s.settingsSectionDiagnostics)
-    }
 
-    LaunchedEffect(showAprilDebug) {
         if (showAprilDebug) {
-            // Wait one frame so the panel has been laid out before the
-            // scroll request is sent. bringIntoView() against a not-
-            // yet-positioned target is a no-op.
-            yield()
-            runCatching { debugPanelBringIntoView.bringIntoView() }
+            Spacer(Modifier.height(2.dp))
+            Box(Modifier.bringIntoViewRequester(debugPanelBringIntoView)) {
+                af.DebugPanel()
+            }
+            Spacer(Modifier.height(2.dp))
         }
-    }
-
-    // April Fools debug panel (hidden by default)
-    if (showAprilDebug) {
-        Spacer(Modifier.height(2.dp))
-        Box(Modifier.bringIntoViewRequester(debugPanelBringIntoView)) {
-            af.DebugPanel()
-        }
-        Spacer(Modifier.height(2.dp))
+    } else {
+        SettingsSectionTitle(s.settingsSectionDiagnostics)
     }
 
     // Buttons need a visible body at rest; transparent containers


### PR DESCRIPTION
Two post-2.3.2 fixes. Both got more visible after PR 231's error-surface improvement stopped hiding the underlying failures.

## #1 April Fools debug panel does nothing on production builds

Production builds without \`-PauraAprilFools=true\` ship \`NoOpAprilFools\` whose \`DebugPanel()\` is intentionally empty. The 5-tap-Diagnostics-title unlock was wired unconditionally, so on production builds tap-5 toggled an internal flag, the panel emit rendered two 2dp Spacers and an empty composable, and the user saw the list jiggle a few pixels with nothing to show for it. PR 232's bringIntoView fix didn't help -- target was zero-content.

**Fix:** add \`AprilFoolsLifecycle.providesDebugPanel: Boolean\` capability flag. \`NoOpAprilFools\` returns false; \`RealAprilFools\` returns true. \`DiagnosticsSection\` only attaches the 5-tap and renders the panel emit when the active impl says it has one. On NoOp builds the title is a plain non-clickable header.

## #2 FileKit Linux dialog crashes with NoClassDefFoundError

\`FileKit\`'s Linux dialog backend dlopens \`com.sun.security.auth.module.UnixSystem\` for user/group lookup when resolving xdg-desktop-portal session context. Our customRuntime jlink list did not include \`jdk.security.auth\`, so the class is missing in bundled runtimes; first FilePicker call on Linux reports \`NoClassDefFoundError: com/sun/security/auth/module/UnixSystem\` via the \`showError\` UI added in PR 231. Surfaced by Голди on 2.3.2 from his own Linux installer.

**Fix:** add \`jdk.security.auth\` to both the \`compose.desktop.application\` modules block and the authoritative \`packaging.jlink\` modules list. Module weight is ~30 KB; cheaper than hand-wrapping the Linux backend.

## Test plan

- [ ] On 2.3.2 production build: 5-tap Diagnostics title now does nothing (no jiggle), title is a plain non-clickable section header.
- [ ] On dev build (\`-PauraAprilFools=true\`): 5-tap still works, panel opens, scroll-into-view still functions.
- [ ] On Linux AppImage 2.3.3: \"Move data directory\" picker opens the xdg-desktop-portal directory picker, no NoClassDefFoundError.