### PR TITLE
feat(core/data): pack-centric data model foundation

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/data/ContentToggle.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/ContentToggle.kt
@@ -1,0 +1,27 @@
+package hivens.core.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One optional-content entry's on/off state for a given
+ * [PackInstance]. Covers mods, shader packs, resource packs, configs
+ * -- whatever the pack manifest exposes as togglable.
+ *
+ * Stored as a list (not a map keyed by [entryId]) so the wire format
+ * preserves order. The UI groups by `display.category` from the
+ * manifest's [DisplayBlock], but within a category the user-set
+ * priority should match what they chose; map-based JSON doesn't
+ * guarantee that. The list is also smaller diffs in version control
+ * if the file ever lands in a profile-sharing flow.
+ */
+@Serializable
+data class ContentToggle(
+    /**
+     * Origin-defined identifier for the entry: the mod's `filename`,
+     * the asset's `dest`, or whatever the manifest uses as its
+     * primary key. Stable across pack versions so toggle state
+     * survives a pack-version bump.
+     */
+    val entryId: String,
+    val enabled: Boolean,
+)

--- a/client-core/src/main/kotlin/hivens/core/data/InstanceRuntime.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/InstanceRuntime.kt
@@ -1,0 +1,38 @@
+package hivens.core.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Per-instance runtime preferences: which JVM to use, how much heap
+ * to give it, JVM flags, window geometry, optional auto-connect on
+ * launch. Distinct from the existing server-centric `InstanceProfile`
+ * because the pack-centric model handles optional content separately
+ * via [PackInstance.optionalContent] (lists, not maps; covers mods +
+ * shaders + resource packs uniformly).
+ *
+ * All fields default to sensible values for a fresh instance so
+ * `InstanceRuntime()` is a valid starting state.
+ */
+@Serializable
+data class InstanceRuntime(
+    /**
+     * Absolute path to a `java` / `java.exe` executable. Null means
+     * "let JavaManagerService pick or download the version the pack
+     * declares it needs". User-overridable for advanced setups (a
+     * custom JDK with specific GC flags, a third-party Java with
+     * patched modules, etc).
+     */
+    val javaPath: String? = null,
+    val memoryMb: Int = 4096,
+    val jvmArgs: String? = null,
+    val windowWidth: Int = 925,
+    val windowHeight: Int = 530,
+    val fullScreen: Boolean = false,
+    /**
+     * Server identity (in whatever shape the pack's origin uses --
+     * SC server id, mirror server id, or `host:port` for a manual
+     * entry) to connect to immediately after launch. Null = stay on
+     * the in-game multiplayer screen for the user to pick.
+     */
+    val autoConnectServerId: String? = null,
+)

--- a/client-core/src/main/kotlin/hivens/core/data/Pack.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/Pack.kt
@@ -1,0 +1,50 @@
+package hivens.core.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One pack, identified within its origin. Pack identity is the pair
+ * `(origin, id)`; the same pack can exist twice in a user's library
+ * with different origins (e.g. an SC-mirrored copy and a user-forked
+ * Local copy share the same display name but are different packs).
+ *
+ * This is a data class. Repositories that find / list / persist packs
+ * live in separate files; this file deliberately stays free of any
+ * platform / IO concerns so it can be referenced from `:client-core`
+ * tests without dragging the world.
+ */
+@Serializable
+data class Pack(
+    val id: String,
+    val origin: PackOrigin,
+    val displayName: String,
+    val mcVersion: String,
+    val loader: PackLoader,
+    val loaderVersion: String? = null,
+    /**
+     * Java major version the pack needs (8 / 17 / 21). Derived from
+     * [mcVersion] by `JavaManagerService.detectJavaVersion` when not
+     * pinned; pack manifests MAY override this if their mod set has
+     * a known incompatibility with the default mapping.
+     */
+    val requiredJava: Int = 8,
+    val tagline: String? = null,
+    val description: String? = null,
+    val bannerUrl: String? = null,
+    val tags: List<String> = emptyList(),
+    /**
+     * Where to fetch the v2 pack manifest from. Set for [PackOrigin.Mirror]
+     * and [PackOrigin.Modrinth]; null for [PackOrigin.Smartycraft] (the
+     * SC API has its own manifest endpoint that the SC adapter knows
+     * about) and [PackOrigin.Local] (no remote manifest).
+     */
+    val manifestUrl: String? = null,
+    /**
+     * Last-known available pack version, in the source's own format
+     * (mirror's `pack_version`, Modrinth's version slug, etc).
+     * Used by the UI to badge "update available" vs the instance's
+     * `pinnedPackVersion`. Null when the source doesn't version packs
+     * (Local) or when the value hasn't been fetched yet.
+     */
+    val latestVersion: String? = null,
+)

--- a/client-core/src/main/kotlin/hivens/core/data/PackInstance.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/PackInstance.kt
@@ -1,0 +1,62 @@
+package hivens.core.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * One local installation of a [Pack]. Multiple instances of the
+ * same pack are allowed -- "Industrial vanilla" and "Industrial with
+ * shaders" can coexist as two PackInstances pointing at the same
+ * `(packRef.origin, packRef.id)` with different selected optional
+ * content and different runtime preferences.
+ *
+ * The instance's files live under
+ * `<dataDir>/instances/<instanceDirName>/`. The resolved [java.nio.file.Path]
+ * is not held here on purpose -- the data class stays pure data,
+ * path resolution is a repository concern.
+ *
+ * Identity is the UUID-string [id]. It's preferred over the slug-
+ * style `instanceDirName` because (a) two instances can legitimately
+ * want the same human-readable folder name across packs ("default")
+ * with disambiguation handled at fs-creation time, and (b) UUIDs
+ * never need a uniqueness check at create time.
+ */
+@Serializable
+data class PackInstance(
+    /** UUID-as-string, generated at create time via `UUID.randomUUID().toString()`. */
+    val id: String,
+    val packRef: PackReference,
+    val displayName: String,
+    /**
+     * Subdirectory name under `<dataDir>/instances/`. Repository
+     * resolves to the absolute path; this field never carries a
+     * leading separator or any path-traversal component.
+     */
+    val instanceDirName: String,
+    val createdAtEpoch: Long,
+    val lastPlayedEpochOrZero: Long = 0L,
+    /**
+     * Pack version this instance is pinned to. Null means "follow
+     * whatever [Pack.latestVersion] currently is". Pinning is the
+     * pack-centric analogue of a server-list snapshot -- the user
+     * explicitly opts out of auto-updates for this instance.
+     */
+    val pinnedPackVersion: String? = null,
+    val runtime: InstanceRuntime = InstanceRuntime(),
+    /**
+     * Per-entry on/off toggles for the pack's optional content.
+     * Entries the pack lists as required do not appear here (always
+     * installed); the manifest is the source of truth for what's
+     * required. Default empty = all-optional-off; the install flow
+     * may pre-populate this from manifest defaults at create time.
+     */
+    val optionalContent: List<ContentToggle> = emptyList(),
+    /**
+     * Set when this instance was forked from another (Modrinth-style
+     * "duplicate this pack and customise"). Tracks the source so the
+     * UI can show "forked from X", and so future cross-source
+     * import / sync flows have provenance to work with.
+     */
+    val forkedFrom: PackReference? = null,
+    /** User-editable free text. Shown on the instance detail surface. */
+    val notes: String = "",
+)

--- a/client-core/src/main/kotlin/hivens/core/data/PackLoader.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/PackLoader.kt
@@ -1,0 +1,23 @@
+package hivens.core.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Minecraft mod loader a pack runs against. Drives launch-time
+ * choices (classpath assembly, JVM flags, mod-folder layout) and
+ * mod-source compatibility (a Forge pack can't load a Fabric-only
+ * mod, etc).
+ *
+ * [Quilt] is included as a distinct value even though it's a
+ * Fabric superset at the protocol level -- pack manifests
+ * legitimately request Quilt-specific features (Quilt loader API,
+ * Quilted Fabric API) that a plain Fabric setup can't satisfy.
+ */
+@Serializable
+enum class PackLoader {
+    Forge,
+    NeoForge,
+    Fabric,
+    Quilt,
+    Vanilla,
+}

--- a/client-core/src/main/kotlin/hivens/core/data/PackOrigin.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/PackOrigin.kt
@@ -1,0 +1,66 @@
+package hivens.core.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Where a [Pack] comes from. Drives downstream choices that depend
+ * on the source: which manifest format to parse, which adapter to
+ * use for fetching files, which auth (if any) is required to play
+ * on the bound server, which UI badges to show.
+ *
+ * Currently four shipped values. Adding a new origin is additive
+ * (existing serialized packs continue to decode); removing one is
+ * a wire break -- don't.
+ */
+@Serializable
+enum class PackOrigin {
+    /**
+     * SmartyCraft launcher API. Pack identity is the SC `assetDir`
+     * string. Requires SC auth at play time. SC's manifest format
+     * is its own thing -- see SmartyCraftServerListService and the
+     * legacy manifest-processor.
+     */
+    Smartycraft,
+
+    /**
+     * Hivens mirror at `smrt.hivens.dev`. Pack identity is the
+     * mirror's `pack_id`. Manifest is the v2 spec in
+     * `docs/src/content/docs/dev/smrt-api-spec.md`. Public read,
+     * no auth required to browse / install.
+     */
+    Mirror,
+
+    /**
+     * Modrinth modpack. Pack identity is the Modrinth project id.
+     * Public read via Modrinth's documented API. License-friendly
+     * (Modrinth requires open redistribution by default).
+     */
+    Modrinth,
+
+    /**
+     * User-local pack. Created by the user (custom mod selection)
+     * or forked from another origin. Identity is a generated id; no
+     * remote manifest. Lives only on the user's machine until they
+     * choose to publish.
+     */
+    Local,
+}
+
+/**
+ * Cross-origin pack identifier. Used wherever a piece of state has
+ * to point at a pack regardless of which source it came from --
+ * notably [PackInstance.forkedFrom] for fork-tracking, and any
+ * future cross-source operation (import-from-X, share-instance).
+ */
+@Serializable
+data class PackReference(
+    val origin: PackOrigin,
+    /** Origin-specific identifier, same shape as [Pack.id]. */
+    val id: String,
+    /**
+     * Specific pack version this reference points at, in the
+     * origin's own version format. Null when the reference is
+     * intentionally floating ("latest" semantics).
+     */
+    val version: String? = null,
+)


### PR DESCRIPTION
First subtask of the pack-centric architecture roadmap (#224). Data classes only -- repository, persistence, UI primitives, and disk-layout migration land in follow-up PRs.

## New types in \`client-core/data/\`

| Type | Purpose |
|---|---|
| \`Pack\` | One pack identified by \`(origin, id)\`. Display + manifest-source + Java/MC/loader metadata. Origin-agnostic. |
| \`PackOrigin\` | Enum: \`Smartycraft\` / \`Mirror\` / \`Modrinth\` / \`Local\`. |
| \`PackReference\` | Cross-origin identifier for fork-tracking and cross-source operations. |
| \`PackLoader\` | Enum: \`Forge\` / \`NeoForge\` / \`Fabric\` / \`Quilt\` / \`Vanilla\`. |
| \`PackInstance\` | One local install. UUID-keyed. Holds display, instance subdir, pinned version, optional-content toggles, runtime prefs, fork provenance, free-text notes. Multiple instances per pack supported by design. |
| \`InstanceRuntime\` | Per-instance JVM / memory / window / auto-connect prefs. New type, deliberately not sharing with the server-centric \`InstanceProfile\` because the architectures diverge enough that consolidation would harm both. |
| \`ContentToggle\` | One optional-content entry on/off state. List not Map so wire format preserves order. |

## Design notes

- **CurseForge intentionally out of \`PackOrigin\`** for now (Overwolf API restrictions + FTB monopoly). The enum is additive -- adding it later if the situation changes does not break existing serialized state.
- **\`Quilt\` is a distinct loader value** even though it's a Fabric superset at the protocol level. Pack manifests legitimately request Quilt-specific features (Quilted Fabric API).
- **\`PackInstance.id\` is UUID-as-string** rather than a slug. Two instances can want the same human-readable folder name across packs (\"default\"); UUIDs never need a uniqueness check at create time.
- **\`PackInstance.instanceDirName\` is a string, not \`Path\`.** Repository resolves it to absolute path at use time. Keeps the data class pure data with no java.nio dependency leaking through the serialization layer.
- **\`forkedFrom: PackReference?\`** ships with the data model so the Modrinth-style fork story is wired from day one.

## Out of scope (follow-ups)

- \`IPackRepository\` / \`IPackCatalogueService\` interfaces and impls.
- JSON / SQLite persistence layer.
- Migration from server-centric \`clients/<assetDir>/\` to \`instances/<uuid>/\`.
- UI primitives consuming this model.
- Consolidating with the existing server-centric \`InstanceProfile\` (separate concern, requires careful migration path).

## Test plan

- [x] \`./gradlew :client-core:compileKotlin\` passes.
- [ ] When the next PR adds the repository, it round-trip serializes a \`PackInstance\` populated with every field set (catches any missed \`@Serializable\` or non-default-friendly type).