### PR TITLE
feat(library): real Library screen + PackDetail + in-memory pack repo

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/api/interfaces/IPackRepository.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/interfaces/IPackRepository.kt
@@ -1,0 +1,41 @@
+package hivens.core.api.interfaces
+
+import hivens.core.data.PackInstance
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Local store of installed [PackInstance]s. Library screen consumes
+ * [observe] for live updates; install / fork / delete flows go
+ * through the mutation methods so the underlying Flow re-emits.
+ *
+ * Implementations choose their own persistence shape (in-memory for
+ * dev / tests, JSON-on-disk for production). Repository contract
+ * does not constrain that.
+ *
+ * Concurrency: implementations must be safe to call from multiple
+ * coroutines. Mutations are serialised so a concurrent install +
+ * delete cannot leave the store in a half-applied state.
+ */
+interface IPackRepository {
+    /**
+     * Cold-start snapshot, then re-emits the full list on any
+     * mutation. Library / Home screens collect this directly.
+     */
+    fun observe(): Flow<List<PackInstance>>
+
+    /** One-shot snapshot. Useful for non-Compose call sites. */
+    suspend fun list(): List<PackInstance>
+
+    /** Fetch a specific instance by its UUID id. Null when not installed. */
+    suspend fun get(id: String): PackInstance?
+
+    /**
+     * Persist [instance]. Creates if its id is unknown, replaces if
+     * known. The id is the source of truth for identity, NOT the
+     * displayName (the user can rename instances freely).
+     */
+    suspend fun put(instance: PackInstance)
+
+    /** Remove the instance with [id]. No-op when not present. */
+    suspend fun delete(id: String)
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/InMemoryPackRepository.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/InMemoryPackRepository.kt
@@ -1,0 +1,112 @@
+package hivens.launcher
+
+import hivens.core.api.interfaces.IPackRepository
+import hivens.core.data.ContentToggle
+import hivens.core.data.InstanceRuntime
+import hivens.core.data.PackInstance
+import hivens.core.data.PackLoader
+import hivens.core.data.PackOrigin
+import hivens.core.data.PackReference
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.time.Instant
+
+/**
+ * In-memory implementation of [IPackRepository]. Seeded with a small
+ * fixture of representative [PackInstance]s so the Library screen has
+ * something to render before the persistence layer + real install
+ * flow exist.
+ *
+ * Seed deliberately covers every [PackOrigin] value so a UI run
+ * shows all four source-badge variants at once. Versions and meta
+ * are plausible (real-ish) but invented; nothing here implies an
+ * actual install on disk -- the [PackInstance.instanceDirName]s
+ * resolve to non-existent paths until the install flow lands.
+ *
+ * Replaced by a JSON-on-disk repository in a follow-up PR. Keep
+ * the contract identical so callers don't need changes.
+ */
+class InMemoryPackRepository : IPackRepository {
+
+    private val mutex = Mutex()
+    private val state: MutableStateFlow<List<PackInstance>> = MutableStateFlow(seed())
+
+    override fun observe(): StateFlow<List<PackInstance>> = state.asStateFlow()
+
+    override suspend fun list(): List<PackInstance> = state.value
+
+    override suspend fun get(id: String): PackInstance? = state.value.firstOrNull { it.id == id }
+
+    override suspend fun put(instance: PackInstance) = mutex.withLock {
+        state.update { current ->
+            val replaced = current.map { if (it.id == instance.id) instance else it }
+            if (replaced.any { it.id == instance.id }) replaced else replaced + instance
+        }
+    }
+
+    override suspend fun delete(id: String) = mutex.withLock {
+        state.update { current -> current.filterNot { it.id == id } }
+    }
+
+    private fun seed(): List<PackInstance> {
+        val now = Instant.now().epochSecond
+        val daysAgo: (Long) -> Long = { d -> now - d * 86_400 }
+        return listOf(
+            PackInstance(
+                id = "00000000-0000-0000-0000-00000000aaaa",
+                packRef = PackReference(PackOrigin.Smartycraft, "Industrial", "2026.04.18"),
+                displayName = "Industrial",
+                instanceDirName = "industrial-default",
+                createdAtEpoch = daysAgo(28),
+                lastPlayedEpochOrZero = daysAgo(1),
+                runtime = InstanceRuntime(memoryMb = 6144),
+            ),
+            PackInstance(
+                id = "00000000-0000-0000-0000-00000000bbbb",
+                packRef = PackReference(PackOrigin.Smartycraft, "SkyBlock", "2026.05.02"),
+                displayName = "SkyBlock",
+                instanceDirName = "skyblock-default",
+                createdAtEpoch = daysAgo(14),
+                lastPlayedEpochOrZero = daysAgo(3),
+                runtime = InstanceRuntime(memoryMb = 4096),
+            ),
+            PackInstance(
+                id = "00000000-0000-0000-0000-00000000cccc",
+                packRef = PackReference(PackOrigin.Mirror, "Create", "2026.05.20"),
+                displayName = "Create (Hivens improved)",
+                instanceDirName = "create-hivens",
+                createdAtEpoch = daysAgo(7),
+                lastPlayedEpochOrZero = daysAgo(0),
+                runtime = InstanceRuntime(memoryMb = 8192),
+                optionalContent = listOf(
+                    ContentToggle("Sodium.jar", enabled = true),
+                    ContentToggle("ComplementaryShaders.zip", enabled = true),
+                ),
+            ),
+            PackInstance(
+                id = "00000000-0000-0000-0000-00000000dddd",
+                packRef = PackReference(PackOrigin.Modrinth, "AbcDef12", "1.3.4"),
+                displayName = "Better Minecraft",
+                instanceDirName = "better-minecraft",
+                createdAtEpoch = daysAgo(3),
+                lastPlayedEpochOrZero = 0L,
+                runtime = InstanceRuntime(memoryMb = 6144),
+            ),
+            PackInstance(
+                id = "00000000-0000-0000-0000-00000000eeee",
+                packRef = PackReference(PackOrigin.Local, "11111111-aaaa-bbbb-cccc-222222222222"),
+                displayName = "Create Tinker (my fork)",
+                instanceDirName = "create-tinker-fork",
+                createdAtEpoch = daysAgo(2),
+                lastPlayedEpochOrZero = daysAgo(0),
+                runtime = InstanceRuntime(memoryMb = 8192),
+                forkedFrom = PackReference(PackOrigin.Mirror, "Create", "2026.05.20"),
+                notes = "Added Tinker's Construct + Iron Jetpacks; removed quark sound. Personal use.",
+            ),
+        )
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -412,6 +412,13 @@ val appModule = module {
 
     single<IServerListService> { SmartyCraftServerListService(get(), get()) }
 
+    // In-memory pack repository: seeded fixture of representative
+    // PackInstances so the Library screen has something to render
+    // before the persistence layer + real install flow exist. Replaced
+    // by a JSON-on-disk repository in a follow-up PR; binding shape
+    // stays single<IPackRepository> so consumers don't need changes.
+    single<IPackRepository> { InMemoryPackRepository() }
+
     single {
         val dataDir: Path = get()
         val profiles: ProfileManager = get()

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
@@ -126,7 +126,10 @@ fun AppLayout(
                                     onOpenServerSettings  = { onScreenChange(Screen.ServerSettings(it)) },
                                     onOpenDetails         = { onScreenChange(Screen.ServerDetails(it)) }
                                 )
-                                HomeView.LibraryFirst -> LibraryScreen()
+                                HomeView.LibraryFirst -> LibraryScreen(
+                                    appState       = appState,
+                                    onScreenChange = onScreenChange,
+                                )
                             }
                             // `Loading` is the brief window between startup and resolved
                             // credentials -- spinner is appropriate. `Unauthenticated` is
@@ -192,14 +195,17 @@ fun AppLayout(
                             onBack = { onScreenChange(Screen.Home) }
                         )
 
-                    Screen.Library -> LibraryScreen()
+                    Screen.Library -> LibraryScreen(
+                        appState       = appState,
+                        onScreenChange = onScreenChange,
+                    )
 
                     Screen.Browse  -> BrowseScreen()
 
                     is Screen.PackDetail ->
                         PackDetailScreen(
-                            server = screen.server,
-                            onBack = { onScreenChange(Screen.Home) }
+                            instanceId = screen.instanceId,
+                            onBack     = { onScreenChange(Screen.Library) },
                         )
                 }
             }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -91,7 +91,15 @@ sealed class Screen {
     object BackgroundSettings : Screen()
     data class ServerSettings(val server: ServerProfile) : Screen()
     data class ServerDetails (val server: ServerProfile) : Screen()
-    data class PackDetail    (val server: ServerProfile) : Screen()
+
+    /**
+     * Library card click target. Carries the PackInstance UUID; the
+     * detail screen resolves it via [hivens.core.api.interfaces.IPackRepository]
+     * so the Screen sealed class stays free of domain types and the
+     * back-stack item stays small (a UUID string, not a PackInstance
+     * graph).
+     */
+    data class PackDetail    (val instanceId: String) : Screen()
 }
 
 // ─── App Shell ───────────────────────────────────────────────────────────────

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
@@ -1,24 +1,273 @@
 package hivens.ui.screens.detail
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import hivens.core.api.model.ServerProfile
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.core.api.interfaces.IPackRepository
+import hivens.core.data.PackInstance
+import hivens.core.data.PackOrigin
 import hivens.ui.puppet.PuppetScreen
-import hivens.ui.screens.common.PlaceholderScreen
+import hivens.ui.screens.library.PackLoaderChip
+import hivens.ui.screens.library.PackMetaChip
+import hivens.ui.theme.CelestiaTheme
+import kotlinx.coroutines.flow.firstOrNull
+import org.koin.compose.koinInject
 
 /**
- * PackDetail = full-screen Modrinth-style detail page for a Library card
- * per [[project_home_library_ia]]. Holds: banner, summary, mod list with
- * display.name/category, Play action, Settings tab (instance prefs),
- * Logs tab.
+ * Full-screen Modrinth-style detail page for one [PackInstance].
+ * Banner-as-hero up top, identity + meta chips below, large Play
+ * button, then placeholder sections for Mods / Servers / Runtime
+ * settings that fill in once the manifest reader and per-instance
+ * settings split land.
  *
- * Stub for now; routed to when Library mode is active and the user clicks
- * into a card. Classic mode still uses the existing ServerDetailScreen.
+ * Resolves the instance via [IPackRepository] from the
+ * [Screen.PackDetail.instanceId] in the navigation entry, so the
+ * Screen data class itself stays small (just a UUID string).
+ * Renders a not-found placeholder for the brief race window where
+ * the instance was deleted while the user was on its detail page.
  */
 @Composable
 fun PackDetailScreen(
-    @Suppress("UNUSED_PARAMETER") server: ServerProfile,
-    @Suppress("UNUSED_PARAMETER") onBack: () -> Unit,
+    instanceId: String,
+    onBack: () -> Unit,
 ) {
-    PuppetScreen("PackDetail")
-    PlaceholderScreen(screenName = "Pack detail")
+    PuppetScreen("PackDetail.$instanceId")
+
+    val repo: IPackRepository = koinInject()
+    var instance by remember { mutableStateOf<PackInstance?>(null) }
+    var resolved by remember { mutableStateOf(false) }
+    LaunchedEffect(instanceId) {
+        instance = repo.observe().firstOrNull()?.firstOrNull { it.id == instanceId }
+            ?: repo.get(instanceId)
+        resolved = true
+    }
+
+    if (!resolved) {
+        // Cold fetch -- usually <1 frame. Plain empty box is fine.
+        Box(Modifier.fillMaxSize())
+        return
+    }
+    val pack = instance
+    if (pack == null) {
+        NotFound(onBack = onBack)
+        return
+    }
+
+    Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+        Hero(pack = pack, onBack = onBack)
+
+        Column(
+            modifier            = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            MetaRow(pack)
+            PlayBar(pack = pack, onPlay = { /* TODO pack-centric launch flow */ })
+            Section(title = "Описание") {
+                Text(
+                    text  = pack.notes.ifBlank { "(описание появится когда manifest reader подтянет данные из источника)" },
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = CelestiaTheme.colors.textPrimary,
+                )
+            }
+            Section(title = "Моды") {
+                ComingSoon("Список модов с category / license / source-link рендерится " +
+                    "после того как manifest reader появится в следующем PR.")
+            }
+            Section(title = "Серверы") {
+                ComingSoon("Привязанные серверы (autoConnect + быстрый join) " +
+                    "появятся когда mirror server-list flow дойдёт до UI.")
+            }
+            Section(title = "Запуск") {
+                ComingSoon("Per-instance runtime overrides (RAM, JVM args, Java path, " +
+                    "window size) рендерятся в отдельной вкладке после миграции " +
+                    "ServerSettingsScreen на pack-centric.")
+            }
+        }
+    }
+}
+
+@Composable
+private fun Hero(pack: PackInstance, onBack: () -> Unit) {
+    val bg = originGradient(pack.packRef.origin)
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(220.dp)
+            .background(bg),
+    ) {
+        Box(Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.35f)))
+
+        IconButton(
+            onClick  = onBack,
+            modifier = Modifier.padding(12.dp),
+        ) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад", tint = Color.White)
+        }
+
+        Column(
+            modifier              = Modifier.fillMaxSize().padding(start = 24.dp, end = 24.dp, top = 24.dp, bottom = 20.dp),
+            verticalArrangement   = Arrangement.Bottom,
+        ) {
+            Text(
+                text       = pack.displayName,
+                style      = MaterialTheme.typography.headlineLarge,
+                color      = Color.White,
+                fontWeight = FontWeight.Bold,
+            )
+            pack.forkedFrom?.let {
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    text  = "Форк: ${it.origin.name} / ${it.id}" + (it.version?.let { v -> " @ $v" } ?: ""),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.White.copy(alpha = 0.85f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetaRow(pack: PackInstance) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment     = Alignment.CenterVertically,
+    ) {
+        PackMetaChip(pack.packRef.origin.name)
+        PackMetaChip(pack.packRef.version ?: "—")
+        // pack.packRef doesn't carry MC / loader / requiredJava on its
+        // own (those live on Pack, not PackInstance). Once the
+        // catalogue service can lookup Pack by ref we surface them
+        // here; for now the instance-side fields are what we have.
+        PackMetaChip(pack.instanceDirName, emphasis = false)
+    }
+}
+
+@Composable
+private fun PlayBar(pack: PackInstance, onPlay: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(14.dp))
+            .background(CelestiaTheme.colors.surface.copy(alpha = 0.7f))
+            .padding(16.dp),
+    ) {
+        Row(
+            modifier              = Modifier.fillMaxWidth(),
+            verticalAlignment     = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column {
+                Text(
+                    text       = "Готов к запуску",
+                    style      = MaterialTheme.typography.titleMedium,
+                    color      = CelestiaTheme.colors.textPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    text  = "Папка экземпляра: instances/${pack.instanceDirName}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = CelestiaTheme.colors.textSecondary,
+                )
+            }
+            Button(
+                onClick        = onPlay,
+                shape          = RoundedCornerShape(12.dp),
+                contentPadding = PaddingValues(horizontal = 24.dp, vertical = 12.dp),
+                colors         = ButtonDefaults.buttonColors(
+                    containerColor = CelestiaTheme.colors.primary,
+                    contentColor   = Color.White,
+                ),
+            ) {
+                Icon(Icons.Default.PlayArrow, contentDescription = null, modifier = Modifier.size(22.dp))
+                Spacer(Modifier.size(8.dp))
+                Text("ИГРАТЬ", fontWeight = FontWeight.Bold)
+            }
+        }
+    }
+}
+
+@Composable
+private fun Section(title: String, content: @Composable () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text       = title.uppercase(),
+            style      = MaterialTheme.typography.titleSmall,
+            color      = CelestiaTheme.colors.primary,
+            fontWeight = FontWeight.Bold,
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .background(CelestiaTheme.colors.surface.copy(alpha = 0.6f))
+                .padding(16.dp),
+        ) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun ComingSoon(text: String) {
+    Text(
+        text  = text,
+        style = MaterialTheme.typography.bodySmall,
+        color = CelestiaTheme.colors.textSecondary,
+    )
+}
+
+@Composable
+private fun NotFound(onBack: () -> Unit) {
+    Box(Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            Text("Экземпляр не найден", style = MaterialTheme.typography.titleLarge, color = CelestiaTheme.colors.textPrimary)
+            Text("Возможно, удалён в другой вкладке.", style = MaterialTheme.typography.bodyMedium, color = CelestiaTheme.colors.textSecondary)
+            Button(onClick = onBack) { Text("Назад в библиотеку") }
+        }
+    }
+}
+
+private fun originGradient(origin: PackOrigin): Brush {
+    val pair = when (origin) {
+        PackOrigin.Smartycraft -> Color(0xFF4C1D95) to Color(0xFF6D28D9)
+        PackOrigin.Mirror      -> Color(0xFF1E3A8A) to Color(0xFF1D4ED8)
+        PackOrigin.Modrinth    -> Color(0xFF14532D) to Color(0xFF15803D)
+        PackOrigin.Local       -> Color(0xFF374151) to Color(0xFF4B5563)
+    }
+    return Brush.linearGradient(listOf(pair.first, pair.second))
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
@@ -1,19 +1,150 @@
 package hivens.ui.screens.library
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import hivens.core.api.interfaces.IPackRepository
+import hivens.core.data.PackInstance
+import hivens.ui.AppState
+import hivens.ui.Screen
 import hivens.ui.puppet.PuppetScreen
-import hivens.ui.screens.common.PlaceholderScreen
+import hivens.ui.theme.CelestiaTheme
+import org.koin.compose.koinInject
 
 /**
- * Library = the user's personal collection per [[project_home_library_ia]]:
- * SC favorites + recently-played + installed Hivens packs, all as the same
- * unified card with a source badge.
+ * Library = user's collection of installed [PackInstance]s.
+ * Renders [PackCard] rows for each instance the [IPackRepository]
+ * is aware of. Card click navigates to [hivens.ui.Screen.PackDetail];
+ * quick-actions (Play / Settings / More) bypass the detail hop.
  *
- * Stub for now; the real implementation lands under the Atelier UI rework.
- * Reachable via the LibraryFirst view-variant toggle in Settings.
+ * Empty state when the repository has nothing to show -- by design
+ * this is the cold-start view for a fresh install (no packs yet);
+ * the Browse screen is the entry point for installing.
+ *
+ * Currently the per-card Play / Settings / More actions only
+ * navigate; the actual launch wiring goes through the existing
+ * server-bound launch flow which the pack-centric installer hasn't
+ * replaced yet. Wiring those to the real launch happens in the next
+ * subtask of [project_pack_centric_direction]; for now they route
+ * to PackDetail like the whole-card click.
  */
 @Composable
-fun LibraryScreen() {
+fun LibraryScreen(
+    @Suppress("UNUSED_PARAMETER") appState: AppState,
+    onScreenChange: (Screen) -> Unit,
+) {
     PuppetScreen("Library")
-    PlaceholderScreen(screenName = "Library")
+
+    val repo: IPackRepository = koinInject()
+    val instances by remember { repo.observe() }.collectAsState(initial = emptyList())
+
+    Column(Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 20.dp)) {
+        Text(
+            text       = "БИБЛИОТЕКА",
+            style      = MaterialTheme.typography.headlineSmall,
+            color      = CelestiaTheme.colors.textPrimary,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text  = "Установленные сборки",
+            style = MaterialTheme.typography.bodyMedium,
+            color = CelestiaTheme.colors.textSecondary,
+        )
+        Spacer(Modifier.height(16.dp))
+
+        if (instances.isEmpty()) {
+            LibraryEmpty(onBrowse = { onScreenChange(Screen.Browse) })
+        } else {
+            LibraryList(
+                instances = instances,
+                onOpenDetail = { onScreenChange(Screen.PackDetail(it.id)) },
+                onPlay = { /* TODO: pack-centric launch flow not wired yet */ onScreenChange(Screen.PackDetail(it.id)) },
+                onSettings = { onScreenChange(Screen.PackDetail(it.id)) },
+                onMore = { onScreenChange(Screen.PackDetail(it.id)) },
+            )
+        }
+    }
 }
+
+@Composable
+private fun LibraryList(
+    instances: List<PackInstance>,
+    onOpenDetail: (PackInstance) -> Unit,
+    onPlay: (PackInstance) -> Unit,
+    onSettings: (PackInstance) -> Unit,
+    onMore: (PackInstance) -> Unit,
+) {
+    LazyColumn(
+        modifier              = Modifier.fillMaxSize(),
+        contentPadding        = PaddingValues(bottom = 16.dp),
+        verticalArrangement   = Arrangement.spacedBy(10.dp),
+    ) {
+        items(items = instances, key = { it.id }) { instance ->
+            PackCard(
+                instance      = instance,
+                onOpenDetail  = { onOpenDetail(instance) },
+                onPlay        = { onPlay(instance) },
+                onSettings    = { onSettings(instance) },
+                onMore        = { onMore(instance) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun LibraryEmpty(onBrowse: () -> Unit) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            Text(
+                text       = "Пока пусто",
+                style      = MaterialTheme.typography.titleLarge,
+                color      = CelestiaTheme.colors.textPrimary,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text      = "Установите сборку через Browse — она появится здесь.",
+                style     = MaterialTheme.typography.bodyMedium,
+                color     = CelestiaTheme.colors.textSecondary,
+                textAlign = TextAlign.Center,
+                modifier  = Modifier.widthIn(max = 360.dp),
+            )
+            Button(
+                onClick = onBrowse,
+                shape   = RoundedCornerShape(10.dp),
+                colors  = ButtonDefaults.buttonColors(
+                    containerColor = CelestiaTheme.colors.primary,
+                    contentColor   = Color.White,
+                ),
+            ) { Text("Открыть Browse", fontWeight = FontWeight.SemiBold) }
+        }
+    }
+}
+

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/PackCard.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/PackCard.kt
@@ -1,0 +1,261 @@
+package hivens.ui.screens.library
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import hivens.core.data.PackInstance
+import hivens.core.data.PackLoader
+import hivens.core.data.PackOrigin
+import hivens.ui.theme.CelestiaTheme
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * One Library row. Banner-as-background (placeholder gradient until
+ * AsyncImage plumbing lands -- bannerUrl will be honored when the
+ * catalogue service starts populating it from manifests), avatar +
+ * title + metadata chips overlaid on top, quick actions on the
+ * right. Whole card click-routes to [PackDetailScreen]; the explicit
+ * Play / Settings / Overflow buttons short-circuit common actions
+ * without the detail hop.
+ *
+ * Source-badge is the small chip next to the title; it differentiates
+ * cards from the four [PackOrigin] values at a glance per
+ * [[project_home_library_ia]]'s unified-entity-with-source-badge
+ * rule.
+ *
+ * Sizes are deliberately defaulted, not pinned to a design spec --
+ * Atelier visual rework will revisit; this is the working baseline.
+ */
+@Composable
+fun PackCard(
+    instance: PackInstance,
+    onOpenDetail: () -> Unit,
+    onPlay: () -> Unit,
+    onSettings: () -> Unit,
+    onMore: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val bg = originGradient(instance.packRef.origin)
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(132.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(bg)
+            .clickable(onClick = onOpenDetail),
+    ) {
+        // Dim overlay so any future banner image stays legible behind
+        // the title / chips. With the placeholder gradient the dim is
+        // visually redundant but keeps the layering consistent when
+        // bannerUrl support lands.
+        Box(Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.35f)))
+
+        Row(
+            modifier              = Modifier.fillMaxSize().padding(14.dp),
+            verticalAlignment     = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(14.dp),
+        ) {
+            PackAvatar(instance)
+
+            Column(
+                modifier              = Modifier.weight(1f),
+                verticalArrangement   = Arrangement.spacedBy(6.dp),
+            ) {
+                Row(
+                    verticalAlignment     = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text       = instance.displayName,
+                        style      = MaterialTheme.typography.titleMedium,
+                        color      = Color.White,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines   = 1,
+                        overflow   = TextOverflow.Ellipsis,
+                        modifier   = Modifier.weight(1f, fill = false),
+                    )
+                    SourceBadge(instance.packRef.origin)
+                }
+
+                Row(
+                    verticalAlignment     = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                ) {
+                    MetaChip(instance.packRef.version ?: "—")
+                    instance.forkedFrom?.let {
+                        MetaChip("fork", emphasis = true)
+                    }
+                    LastPlayedChip(instance.lastPlayedEpochOrZero)
+                }
+            }
+
+            Row(
+                verticalAlignment     = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Button(
+                    onClick        = onPlay,
+                    shape          = RoundedCornerShape(10.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+                    colors         = ButtonDefaults.buttonColors(
+                        containerColor = CelestiaTheme.colors.primary,
+                        contentColor   = Color.White,
+                    ),
+                ) {
+                    Icon(Icons.Default.PlayArrow, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(6.dp))
+                    Text("Играть", fontWeight = FontWeight.SemiBold)
+                }
+                IconButton(onClick = onSettings) {
+                    Icon(Icons.Default.Settings, contentDescription = "Settings", tint = Color.White)
+                }
+                IconButton(onClick = onMore) {
+                    Icon(Icons.Default.MoreVert, contentDescription = "More", tint = Color.White)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PackAvatar(instance: PackInstance) {
+    val initials = instance.displayName
+        .split(' ', '-', '_')
+        .filter { it.isNotBlank() }
+        .take(2)
+        .joinToString("") { it.first().uppercaseChar().toString() }
+        .ifEmpty { "?" }
+    Box(
+        modifier         = Modifier
+            .size(64.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(originAvatarColor(instance.packRef.origin)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text       = initials,
+            color      = Color.White,
+            style      = MaterialTheme.typography.titleLarge,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun SourceBadge(origin: PackOrigin) {
+    val (label, color) = when (origin) {
+        PackOrigin.Smartycraft -> "SC"       to Color(0xFF8B5CF6)
+        PackOrigin.Mirror      -> "Mirror"   to Color(0xFF3B82F6)
+        PackOrigin.Modrinth    -> "Modrinth" to Color(0xFF22C55E)
+        PackOrigin.Local       -> "Local"    to Color(0xFF9CA3AF)
+    }
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(color.copy(alpha = 0.85f))
+            .padding(horizontal = 8.dp, vertical = 2.dp),
+    ) {
+        Text(label, style = MaterialTheme.typography.labelSmall, color = Color.White, fontWeight = FontWeight.Bold)
+    }
+}
+
+@Composable
+private fun MetaChip(text: String, emphasis: Boolean = false) {
+    AssistChip(
+        onClick   = {},
+        enabled   = false,
+        shape     = RoundedCornerShape(8.dp),
+        label     = { Text(text, style = MaterialTheme.typography.labelSmall, color = Color.White) },
+        colors    = AssistChipDefaults.assistChipColors(
+            disabledContainerColor = if (emphasis) CelestiaTheme.colors.primary.copy(alpha = 0.85f)
+                                     else          Color.Black.copy(alpha = 0.35f),
+            disabledLabelColor     = Color.White,
+        ),
+        border    = null,
+    )
+}
+
+@Composable
+private fun LastPlayedChip(lastPlayedEpoch: Long) {
+    if (lastPlayedEpoch <= 0L) {
+        MetaChip("Не запускался")
+        return
+    }
+    val now = Instant.now()
+    val then = Instant.ofEpochSecond(lastPlayedEpoch)
+    val dur = Duration.between(then, now)
+    val label = when {
+        dur.toMinutes() < 1   -> "только что"
+        dur.toHours()   < 1   -> "${dur.toMinutes()} мин назад"
+        dur.toDays()    < 1   -> "${dur.toHours()} ч назад"
+        dur.toDays()    < 14  -> "${dur.toDays()} дн назад"
+        else                  -> "давно"
+    }
+    MetaChip(label)
+}
+
+private fun originGradient(origin: PackOrigin): Brush {
+    val pair = when (origin) {
+        PackOrigin.Smartycraft -> Color(0xFF4C1D95) to Color(0xFF6D28D9)
+        PackOrigin.Mirror      -> Color(0xFF1E3A8A) to Color(0xFF1D4ED8)
+        PackOrigin.Modrinth    -> Color(0xFF14532D) to Color(0xFF15803D)
+        PackOrigin.Local       -> Color(0xFF374151) to Color(0xFF4B5563)
+    }
+    return Brush.linearGradient(listOf(pair.first, pair.second))
+}
+
+private fun originAvatarColor(origin: PackOrigin): Color = when (origin) {
+    PackOrigin.Smartycraft -> Color(0xFF7C3AED)
+    PackOrigin.Mirror      -> Color(0xFF2563EB)
+    PackOrigin.Modrinth    -> Color(0xFF16A34A)
+    PackOrigin.Local       -> Color(0xFF6B7280)
+}
+
+/**
+ * Workaround helper for the `requiredJava` chip on the detail screen
+ * (PackDetailScreen reuses [MetaChip] via this re-exported alias so
+ * it doesn't have to duplicate the chip styling).
+ */
+@Composable
+internal fun PackMetaChip(text: String, emphasis: Boolean = false) {
+    MetaChip(text, emphasis = emphasis)
+}
+
+@Composable
+internal fun PackLoaderChip(loader: PackLoader) {
+    MetaChip(loader.name)
+}


### PR DESCRIPTION
Stacks on #236 (data model). First visible piece of the pack-centric UI track per [[project_home_library_ia]] and issue #224.

## New surfaces

- **\`IPackRepository\`** (client-core) -- \`Flow<List<PackInstance>>\` + put/delete/get/list. Implementations choose persistence shape.
- **\`InMemoryPackRepository\`** (client-launcher) -- seeded with 5 fixture \`PackInstance\`s covering all four \`PackOrigin\` values so the source-badge variants are visible at a glance. Replaced by a JSON repository in a follow-up PR; binding shape stays unchanged.
- **\`LibraryScreen\`** -- \`LazyColumn\` of \`PackCard\` rows fed off the repository Flow. Empty state with a CTA into Browse. Whole-card click + Play / Settings / Overflow quick actions route to PackDetail (real launch flow lands later).
- **\`PackCard\`** -- banner-as-background row card with avatar + title + meta chips + Source badge + quick-action buttons. Sizes are a working baseline, not pinned to a design spec (Atelier visual rework will revisit). Banner placeholder is a per-origin gradient until AsyncImage plumbing for real banner URLs lands.
- **\`PackDetailScreen\`** -- replaces the placeholder. Full-screen Modrinth-style page: hero banner up top, meta chip row, Play bar, then placeholder sections for Description / Mods / Servers / Runtime that fill in as catalogue + manifest reader land.

## Navigation change

\`Screen.PackDetail\` goes from carrying a \`ServerProfile\` to carrying a \`PackInstance\` UUID string. The Screen sealed class stays free of domain types and the back-stack item is small. \`AppLayout\` routing resolves the instance via the repository inside the detail screen.

## Out of scope

- Real launch flow (needs pack-centric installer; the per-card Play button currently navigates to PackDetail).
- JSON persistence (next subtask of #224).
- AsyncImage for banner URLs (currently a per-origin gradient placeholder).
- Mods / Servers / Runtime detail sections (need manifest reader).
- Sidebar / nav redesign (separate Atelier-scope PR).

## Test plan

- [x] \`./gradlew :client-ui:compileKotlinDesktop\` passes.
- [ ] Launch with \`HomeView.LibraryFirst\` toggled in Settings: Library screen renders 5 fixture cards, all four source-badges visible.
- [ ] Click any card: PackDetail opens with banner, title, Play button, placeholder sections.
- [ ] Empty-state path: clear the seed (in dev or after a JSON-repo PR), Library shows \"Пока пусто\" + \"Открыть Browse\" CTA.

## Merge plan

Merges after #236 (data model dependency). If 236 lands first, this rebases cleanly on stable. If 236 needs revisions, those carry forward here.