### PR TITLE
feat(background): multi-frame playback for GIF/APNG/animated WebP

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/background/BackgroundSettings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/background/BackgroundSettings.kt
@@ -20,7 +20,8 @@ data class BackgroundSettings(
     val parallaxIntensity: Float = 0.0f,
     val vignetteIntensity: Float = 0.2f,
     val tintColor: String? = null,
-    val tintOpacity: Float = 0.0f
+    val tintOpacity: Float = 0.0f,
+    val animationSpeedMultiplier: Float = 1.0f,
 )
 
 @Serializable

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/background/CustomBackground.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/background/CustomBackground.kt
@@ -24,17 +24,32 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import hivens.ui.debug.SkiaTracker
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.jetbrains.skia.Codec
 import org.jetbrains.skia.Data
+import org.jetbrains.skia.ImageInfo
 import org.jetbrains.skia.makeFromFileName
+import org.slf4j.LoggerFactory
 import java.io.File
+
+private val log = LoggerFactory.getLogger("CustomBackground")
+
+private const val MAX_ANIMATED_FRAMES        = 240
+private const val MAX_ANIMATED_PIXELS_TOTAL  = 1920L * 1080L * 60L
+
+private data class DecodedBg(
+    val frames: List<ImageBitmap>,
+    val durationsMs: List<Int>,
+    val repetitionCount: Int,
+)
 
 /**
  * Renders a custom background wallpaper behind the main app content.
  *
  * Supports: blur, darkening, opacity, parallax, vignette, color tint,
- * multiple scale modes, alignment control, and hardware-accelerated animated GIFs (via Skiko).
+ * multiple scale modes, alignment control, and multi-frame animated
+ * formats (GIF, APNG, animated WebP) decoded via Skiko Codec.
  */
 @Composable
 fun CustomBackground(
@@ -116,7 +131,7 @@ private fun AnimatedParallaxImage(
         IntOffset(x, y)
     }
 
-    val imageBitmap = rememberSkiaImage(file)
+    val imageBitmap = rememberSkiaImage(file, settings.animationSpeedMultiplier)
 
     if (imageBitmap != null) {
         val useParallax = settings.parallaxIntensity > 0f
@@ -161,39 +176,97 @@ private fun AnimatedParallaxImage(
 }
 
 @Composable
-private fun rememberSkiaImage(file: File): ImageBitmap? {
-    var bitmap by remember(file) { mutableStateOf<ImageBitmap?>(null) }
+private fun rememberSkiaImage(file: File, speedMultiplier: Float): ImageBitmap? {
+    var decoded  by remember(file) { mutableStateOf<DecodedBg?>(null) }
+    var frameIdx by remember(file) { mutableStateOf(0) }
+    val speedRef = rememberUpdatedState(speedMultiplier)
 
     LaunchedEffect(file) {
         if (!file.exists()) return@LaunchedEffect
+        withContext(Dispatchers.IO) { decoded = decodeBackground(file) }
+    }
 
-        withContext(Dispatchers.IO) {
-            var data:  Data?                      = null
-            var codec: Codec?                     = null
-            var bmp:   org.jetbrains.skia.Bitmap? = null
+    val d = decoded ?: return null
+    if (d.frames.size <= 1) {
+        return d.frames.firstOrNull()
+    }
 
-            try {
-                data  = Data.makeFromFileName(file.absolutePath)
-                codec = Codec.makeFromData(data)
-                bmp   = org.jetbrains.skia.Bitmap().apply { allocPixels(codec.imageInfo) }
-
-                codec.readPixels(bmp, 0)
-                val img = org.jetbrains.skia.Image.makeFromBitmap(bmp)
-                img.use { img ->
-                    bitmap = img.toComposeImageBitmap().also {
-                        SkiaTracker.track("BG.static", it)
-                    }
-                }
-
-            } catch (e: Exception) {
-                org.slf4j.LoggerFactory.getLogger("CustomBackground")
-                    .error("Failed to decode custom background image", e)
-            } finally {
-                bmp?.close()
-                codec?.close()
-                data?.close()
+    // Skia spec: repetitionCount = N means N additional plays after the
+    // first. -1 = loop forever, 0 = play once. Slider changes mid-play
+    // take effect on the next frame swap (rememberUpdatedState keeps the
+    // captured ref fresh without restarting the effect).
+    LaunchedEffect(d) {
+        val totalPlays = if (d.repetitionCount < 0) Int.MAX_VALUE else d.repetitionCount + 1
+        var played = 0
+        while (played < totalPlays) {
+            for (i in d.frames.indices) {
+                frameIdx = i
+                val speed   = speedRef.value.coerceAtLeast(0.01f)
+                val waitMs  = (d.durationsMs[i] / speed).toLong().coerceAtLeast(1L)
+                delay(waitMs)
             }
+            played++
         }
     }
-    return bitmap
+
+    return d.frames[frameIdx.coerceIn(0, d.frames.lastIndex)]
+}
+
+private fun decodeBackground(file: File): DecodedBg? {
+    var data:  Data?  = null
+    var codec: Codec? = null
+    return try {
+        data  = Data.makeFromFileName(file.absolutePath)
+        codec = Codec.makeFromData(data)
+        val frameCount = codec.frameCount
+        val info       = codec.imageInfo
+
+        if (frameCount <= 1) {
+            DecodedBg(
+                frames          = listOf(decodeFrame(codec, info, frame = 0, trackTag = "BG.static")),
+                durationsMs     = listOf(0),
+                repetitionCount = 0,
+            )
+        } else {
+            val pixelsTotal = info.width.toLong() * info.height.toLong() * frameCount.toLong()
+            if (frameCount > MAX_ANIMATED_FRAMES || pixelsTotal > MAX_ANIMATED_PIXELS_TOTAL) {
+                log.warn(
+                    "Animated bg too large (frames={}, ~{}MB raw) -- using frame 0 only",
+                    frameCount, pixelsTotal * 4 / 1_048_576,
+                )
+                DecodedBg(
+                    frames          = listOf(decodeFrame(codec, info, frame = 0, trackTag = "BG.static")),
+                    durationsMs     = listOf(0),
+                    repetitionCount = 0,
+                )
+            } else {
+                val frames    = ArrayList<ImageBitmap>(frameCount)
+                val durations = ArrayList<Int>(frameCount)
+                val infos     = codec.framesInfo
+                for (i in 0 until frameCount) {
+                    frames.add(decodeFrame(codec, info, frame = i, trackTag = "BG.animated"))
+                    // delay() of 0 spins -- guarantee positive duration per frame.
+                    durations.add(infos[i].duration.coerceAtLeast(1))
+                }
+                DecodedBg(frames, durations, codec.repetitionCount)
+            }
+        }
+    } catch (e: Exception) {
+        log.error("Failed to decode custom background at {}", file.absolutePath, e)
+        null
+    } finally {
+        codec?.close()
+        data?.close()
+    }
+}
+
+private fun decodeFrame(codec: Codec, info: ImageInfo, frame: Int, trackTag: String): ImageBitmap {
+    val bmp = org.jetbrains.skia.Bitmap().apply { allocPixels(info) }
+    return try {
+        codec.readPixels(bmp, frame)
+        val img = org.jetbrains.skia.Image.makeFromBitmap(bmp)
+        img.use { it.toComposeImageBitmap().also { ib -> SkiaTracker.track(trackTag, ib) } }
+    } finally {
+        bmp.close()
+    }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -238,6 +238,7 @@ interface AppStrings {
     val backgroundSaturation: String
     val backgroundParallax: String
     val backgroundVignette: String
+    val backgroundAnimationSpeed: String
     val backgroundSectionTint: String
     val backgroundTintNone: String
     val backgroundTintNavy: String

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -229,6 +229,7 @@ object EnglishStrings : AppStrings {
     override val backgroundSaturation     = "Saturation"
     override val backgroundParallax       = "Parallax"
     override val backgroundVignette       = "Vignette"
+    override val backgroundAnimationSpeed = "Animation speed"
     override val backgroundSectionTint    = "COLOR TINT"
     override val backgroundTintNone       = "None"
     override val backgroundTintNavy       = "Dark blue"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -229,6 +229,7 @@ object GermanStrings : AppStrings {
     override val backgroundSaturation     = "Sättigung"
     override val backgroundParallax       = "Parallaxe"
     override val backgroundVignette       = "Vignette"
+    override val backgroundAnimationSpeed = "Animationsgeschwindigkeit"
     override val backgroundSectionTint    = "FARBTÖNUNG"
     override val backgroundTintNone       = "Keine"
     override val backgroundTintNavy       = "Dunkelblau"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -229,6 +229,7 @@ object RussianStrings : AppStrings {
     override val backgroundSaturation     = "Насыщенность"
     override val backgroundParallax       = "Параллакс"
     override val backgroundVignette       = "Виньетка"
+    override val backgroundAnimationSpeed = "Скорость анимации"
     override val backgroundSectionTint    = "ЦВЕТОВОЙ ОТТЕНОК"
     override val backgroundTintNone       = "Нет"
     override val backgroundTintNavy       = "Тёмно-синий"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/BackgroundSettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/BackgroundSettingsScreen.kt
@@ -98,7 +98,7 @@ fun BackgroundSettingsScreen(
                     SectionTitle(s.backgroundSectionImage)
                     Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         OutlinedButton(onClick = { scope.launch {
-                            FileKit.openFilePicker(type = FileKitType.File(extensions = listOf("png", "jpg", "jpeg", "webp", "bmp")), dialogSettings = FileKitDialogSettings(
+                            FileKit.openFilePicker(type = FileKitType.File(extensions = listOf("png", "jpg", "jpeg", "webp", "bmp", "gif", "apng")), dialogSettings = FileKitDialogSettings(
                                 title = s.backgroundPickFile
                             )
                             )?.path?.let { path -> update { copy(imagePath = path, enabled = true) } }
@@ -142,6 +142,7 @@ fun BackgroundSettingsScreen(
                     LabeledSlider(s.backgroundSaturation, settings.saturation, -1f..1f, "%+.0f%%", 100f) { update { copy(saturation = it) } }
                     LabeledSlider(s.backgroundParallax, settings.parallaxIntensity, 0f..1f, "%.0f%%", 100f) { update { copy(parallaxIntensity = it) } }
                     LabeledSlider(s.backgroundVignette, settings.vignetteIntensity, 0f..1f, "%.0f%%", 100f) { update { copy(vignetteIntensity = it) } }
+                    LabeledSlider(s.backgroundAnimationSpeed, settings.animationSpeedMultiplier, 0.25f..4f, "%.2fx") { update { copy(animationSpeedMultiplier = it) } }
 
                     HorizontalDivider(color = CelestiaTheme.colors.outline.copy(alpha = 0.15f))
 


### PR DESCRIPTION
## What

\`CustomBackground\` decoded only frame 0 despite the KDoc already claiming "hardware-accelerated animated GIFs (via Skiko)". Multi-frame formats (GIF, APNG, animated WebP) now actually animate.

## How

- \`Codec.frameCount\` + \`Codec.framesInfo[i].duration\` drive a per-file decode that pre-builds a \`DecodedBg(frames, durationsMs, repetitionCount)\`.
- \`LaunchedEffect(d)\` walks the frames, \`delay\`'ing by per-frame duration, looping per the Skia spec for \`repetitionCount\` (-1 = forever, N = N additional plays after first).
- \`rememberUpdatedState\` for the speed multiplier so slider drags take effect on the next frame swap without restarting the animation.
- Safety cap: > 240 frames OR > 1080p x 60 frames (~240MB raw RGBA) falls back to static frame 0 with a logged warning. Stops an 8000-frame perfect-loop GIF from eating all heap.
- \`SkiaTracker.track("BG.animated", ...)\` for the existing leak tracker (distinct from \`"BG.static"\`).

## What else

- \`animationSpeedMultiplier\` (0.25-4x, default 1x) added to \`BackgroundSettings\` (\`@Serializable\` default keeps existing \`background.json\` loading fine).
- Slider in \`BackgroundSettingsScreen\` after Vignette. Format \`%.2fx\`.
- GIF + APNG added to the file picker extension filter (already had png/jpg/jpeg/webp/bmp).
- i18n strings (\`backgroundAnimationSpeed\`) in en/ru/de.

## Test plan

- [ ] Pick a GIF as wallpaper -- animates at natural rate
- [ ] Adjust speed slider during playback -- animation gets faster/slower, no restart from frame 0
- [ ] Pick an APNG -- animates
- [ ] Pick a static PNG -- renders once, no animation loop CPU
- [ ] Pick a huge GIF (>240 frames or >240MB raw) -- falls back to frame 0, log shows warning
- [ ] Open existing \`background.json\` with no \`animationSpeedMultiplier\` field -- loads with default 1.0x