### PR TITLE
feat(customization): experimental visual extension + bg loop override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,93 @@ below are for the GitHub release page and CHANGELOG readers.
 
 ## [Unreleased]
 
+## [2.3.3] - 2026-05-25
+
+Visual customization release. Custom background gains real
+animated-format support (GIF / APNG / animated WebP) with
+playback controls. A new experimental Customization screen
+exposes density, glass intensity, accent override, and a full
+per-role color override matrix on top of the active theme.
+
+### Highlights
+- **Animated wallpapers**. Pick a GIF, APNG, or animated WebP as
+  your custom background and it actually animates. Frame 0 shows
+  immediately on cold load instead of grey while the remaining
+  frames decode. New Animation speed slider (0.25 - 4x, live
+  during playback) and Loop mode picker (Use codec / Loop forever
+  / Play once -- the last one freezes on the last frame for
+  intro-and-settle patterns).
+- **Customization (experimental)**. New Settings entry exposes
+  density scale (0.85 - 1.15x, all `.dp` values), glass density
+  (0 - 100%, every glass surface in the launcher), accent color
+  override (free hex), and a full 7-role color override matrix
+  behind an experimental toggle.
+- **Glass density reaches every glass surface**. Sidebar, right
+  panel, dividers, every card and tile across every screen
+  respect the slider, not just the few screens it was first
+  wired into.
+- **GlassCard finally honours palette.glassAlpha**. The Glass
+  branch had been hardcoding `alpha = 0.7f` and ignoring the
+  palette's own field (0.60 dark, 0.65 light). Now reads the
+  palette correctly.
+
+### Added
+- Multi-frame background decoder via Skiko `Codec`. Reads
+  `frameCount`, `framesInfo[i].duration`, `repetitionCount`.
+  Safety cap at 240 frames or ~240 MB raw RGBA -- oversize
+  formats fall back to static frame 0 with a logged warning.
+- `BackgroundSettings.animationSpeedMultiplier` (0.25 - 4x).
+  Slider on BackgroundSettings screen; changes apply mid-playback
+  via `rememberUpdatedState`.
+- `BackgroundSettings.loopMode` (`UseCodec` / `LoopForever` /
+  `PlayOnce`) with segmented control on the same screen.
+- GIF and APNG added to the background file picker extension
+  filter.
+- New `CustomizationExtensionScreen` under Settings ->
+  Customization (exp.). Persists separately in
+  `customization.json`.
+- `CustomizationSettings` data class: `densityScale`,
+  `glassIntensity`, `accentOverride`, `colorOverrides` (per-role
+  map), `experimentalColorOverridesEnabled` (gates the 7-role
+  matrix UI).
+- Density scale wired through `LocalDensity` at the app root so
+  every `.dp` scales live. The Customization screen counter-wraps
+  to base density so the slider stays grabbable while the outer
+  UI live-scales as the user drags.
+- `glassSurfaceAlpha(baseAlpha)` and `scaledAlpha(color, baseAlpha)`
+  helpers in `hivens.ui.customization`. Centralized surface-alpha
+  math; migrated 25+ call sites across the codebase.
+
+### Changed
+- GlassCard `CardSurface.Glass` reads `palette.glassAlpha *
+  customization.glassIntensity` instead of the previously
+  hardcoded 0.7. Fixes a long-standing palette-field-ignored bug.
+- GlassCard `CardSurface.Flat` (Brut) lerps between
+  `palette.glassBackground` and `colorScheme.surface` driven by
+  intensity. At intensity = 1.0 the surface stays solid grey
+  (Brut identity); lower intensity blends toward translucent
+  black so the slider is visually obvious even under the
+  "opaque" style.
+- AppLayout sidebar, right panel, dividers, plus 22 other
+  previously hardcoded `surface.copy(alpha = X)` sites all
+  routed through `glassSurfaceAlpha`. Default at intensity = 1.0
+  matches the prior hardcoded values byte-for-byte.
+- ThemePicker theme cards + preview panel use
+  `scaledAlpha(theme.background, 0.8f)` so the theme's own
+  background colour scales by glass intensity.
+
+### Fixed
+- GlassCard ignored `CelestiaColors.glassAlpha` entirely (used
+  hardcoded 0.7f). The two palette presets had the field defined
+  but no caller respected it.
+- Density slider lost pointer mid-drag. Updating density
+  re-measured the slider host on every drag tick; the gesture
+  detector lost the pointer. The Customization screen now
+  counter-wraps to base density.
+- Animated wallpaper cold load showed grey for several seconds
+  while all frames decoded. Frame 0 now emits as a preview as
+  soon as it lands; the remaining frames decode behind it.
+
 ## [2.3.2] - 2026-05-24
 
 Same-day patch on 2.3.1. Three user-facing bugs surfaced within

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
@@ -31,6 +31,7 @@ import hivens.launcher.network.NetworkState
 import hivens.launcher.network.ServerProtocolConfig
 import hivens.ui.background.BackgroundSettings
 import hivens.ui.customization.CustomizationSettings
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.easter.LocalAprilFools
 import hivens.ui.i18n.AppLocale
 import hivens.ui.puppet.PuppetClick
@@ -102,7 +103,7 @@ fun AppLayout(
 
         VerticalDivider(
             modifier = Modifier.fillMaxHeight(),
-            color    = CelestiaTheme.colors.surface.copy(alpha = 0.6f)
+            color    = glassSurfaceAlpha(0.6f)
         )
 
         // ── Main content ──────────────────────────────────────────────────
@@ -224,7 +225,7 @@ fun AppLayout(
 
         VerticalDivider(
             modifier = Modifier.fillMaxHeight(),
-            color    = CelestiaTheme.colors.surface.copy(alpha = 0.6f)
+            color    = glassSurfaceAlpha(0.6f)
         )
 
         // ── Right panel 264dp ─────────────────────────────────────────────
@@ -326,7 +327,7 @@ fun AppSidebar(
 
     NavigationRail(
         modifier       = Modifier.width(64.dp).fillMaxHeight(),
-        containerColor = CelestiaTheme.colors.surface.copy(alpha = 0.35f),
+        containerColor = glassSurfaceAlpha(0.35f),
         contentColor   = CelestiaTheme.colors.textSecondary
     ) {
         // ── Nav items ─────────────────────────────────────────────────────

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
@@ -30,6 +30,7 @@ import hivens.core.data.UiStyle
 import hivens.launcher.network.NetworkState
 import hivens.launcher.network.ServerProtocolConfig
 import hivens.ui.background.BackgroundSettings
+import hivens.ui.customization.CustomizationSettings
 import hivens.ui.easter.LocalAprilFools
 import hivens.ui.i18n.AppLocale
 import hivens.ui.puppet.PuppetClick
@@ -68,7 +69,9 @@ fun AppLayout(
     uiStyle: UiStyle,
     onUiStyleChanged: (UiStyle) -> Unit,
     backgroundSettings: BackgroundSettings = BackgroundSettings(),
-    onBackgroundSettingsChanged: (BackgroundSettings) -> Unit = {}
+    onBackgroundSettingsChanged: (BackgroundSettings) -> Unit = {},
+    customization: CustomizationSettings = CustomizationSettings(),
+    onCustomizationChanged: (CustomizationSettings) -> Unit = {},
 ) {
     val skinRepository: SkinRepository = koinInject()
     val protocolConfig: ServerProtocolConfig = koinInject()
@@ -148,17 +151,18 @@ fun AppLayout(
 
                     Screen.Settings ->
                         SettingsScreen(
-                            isDarkTheme              = isDarkTheme,
-                            onToggleTheme            = onToggleDarkTheme,
-                            onOpenThemePicker        = { onScreenChange(Screen.ThemePicker) },
-                            currentLocale            = currentLocale,
-                            onLocaleChanged          = onLocaleChanged,
-                            homeView                 = homeView,
-                            onHomeViewChanged        = onHomeViewChanged,
-                            uiStyle                  = uiStyle,
-                            onUiStyleChanged         = onUiStyleChanged,
-                            onOpenBackgroundSettings = { onScreenChange(Screen.BackgroundSettings) },
-                            onOpenAbout              = { onScreenChange(Screen.About) }
+                            isDarkTheme                  = isDarkTheme,
+                            onToggleTheme                = onToggleDarkTheme,
+                            onOpenThemePicker            = { onScreenChange(Screen.ThemePicker) },
+                            currentLocale                = currentLocale,
+                            onLocaleChanged              = onLocaleChanged,
+                            homeView                     = homeView,
+                            onHomeViewChanged            = onHomeViewChanged,
+                            uiStyle                      = uiStyle,
+                            onUiStyleChanged             = onUiStyleChanged,
+                            onOpenBackgroundSettings     = { onScreenChange(Screen.BackgroundSettings) },
+                            onOpenCustomizationExtension = { onScreenChange(Screen.CustomizationExtension) },
+                            onOpenAbout                  = { onScreenChange(Screen.About) },
                         )
 
                     Screen.ThemePicker ->
@@ -168,7 +172,14 @@ fun AppLayout(
                                 onCustomThemeChanged(newTheme)
                                 onScreenChange(Screen.Settings)
                             },
-                            onBack = { onScreenChange(Screen.Settings) }
+                            onBack          = { onScreenChange(Screen.Settings) },
+                        )
+
+                    Screen.CustomizationExtension ->
+                        hivens.ui.screens.customization.CustomizationExtensionScreen(
+                            currentSettings   = customization,
+                            onSettingsChanged = onCustomizationChanged,
+                            onBack            = { onScreenChange(Screen.Settings) },
                         )
 
                     Screen.About ->
@@ -249,6 +260,7 @@ fun AppSidebar(
     val settingsActive = currentScreen is Screen.Settings
             || currentScreen is Screen.ThemePicker
             || currentScreen is Screen.BackgroundSettings
+            || currentScreen is Screen.CustomizationExtension
     val aboutActive    = currentScreen is Screen.About
 
     // ── April Fools: nav clicks have a 30% chance of being silently swallowed ──

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -37,6 +37,9 @@ import hivens.launcher.ProfileManager
 import hivens.ui.background.BackgroundManager
 import hivens.ui.background.CustomBackground
 import hivens.ui.components.UpdateManager
+import hivens.ui.customization.CustomizationManager
+import hivens.ui.customization.CustomizationSettings
+import hivens.ui.customization.LocalCustomization
 import hivens.ui.easter.AprilFools
 import hivens.ui.easter.AprilFoolsLoader
 import hivens.ui.easter.LocalAprilFools
@@ -89,6 +92,7 @@ sealed class Screen {
     object ThemePicker        : Screen()
     object About              : Screen()
     object BackgroundSettings : Screen()
+    object CustomizationExtension : Screen()
     data class ServerSettings(val server: ServerProfile) : Screen()
     data class ServerDetails (val server: ServerProfile) : Screen()
 
@@ -229,6 +233,14 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
         val autoSyncService: AutoSyncService = koinInject()
         val themeManager  = remember { ThemeManager(dataDirectory) }
         var customTheme   by remember { mutableStateOf(themeManager.loadTheme()) }
+
+        // Customization extension: persisted overrides for accent /
+        // density / glass intensity / full color overrides. Provided
+        // via [LocalCustomization] so CelestiaTheme + GlassCard can
+        // read without prop-drilling.
+        val customizationJson    = remember { Json { ignoreUnknownKeys = true; encodeDefaults = true } }
+        val customizationManager = remember { CustomizationManager(dataDirectory, customizationJson) }
+        var customization        by remember { mutableStateOf(customizationManager.load()) }
 
         // Window chrome icon -- KDE overview / Hyprland switcher / macOS
         // dock want the detailed hi-res asset so they can be downscale
@@ -420,6 +432,17 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                 }
             }
 
+            val baseDensity   = androidx.compose.ui.platform.LocalDensity.current
+            val scaledDensity = remember(baseDensity, customization.densityScale) {
+                androidx.compose.ui.unit.Density(
+                    baseDensity.density * customization.densityScale.coerceIn(0.5f, 2f),
+                    baseDensity.fontScale,
+                )
+            }
+            CompositionLocalProvider(
+                LocalCustomization                       provides customization,
+                androidx.compose.ui.platform.LocalDensity provides scaledDensity,
+            ) {
             CelestiaTheme(
                 useDarkTheme = isDarkTheme,
                 customTheme  = customTheme,
@@ -485,11 +508,17 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                             uiStyle = newStyle
                             val current = settingsService.getSettings()
                             settingsService.saveSettings(current.copy(uiStyle = newStyle))
-                        }
+                        },
+                        customization              = customization,
+                        onCustomizationChanged     = { newCustomization ->
+                            customization = newCustomization
+                            customizationManager.save(newCustomization)
+                        },
                     )
                     UpdateManager()
                 }
             }
+            } // end CompositionLocalProvider(LocalCustomization + LocalDensity)
         }
     }
     } // end CompositionLocalProvider(LocalAprilFools)
@@ -512,6 +541,8 @@ fun AppRoot(
     onHomeViewChanged: (HomeView) -> Unit,
     uiStyle: UiStyle,
     onUiStyleChanged: (UiStyle) -> Unit,
+    customization: CustomizationSettings,
+    onCustomizationChanged: (CustomizationSettings) -> Unit,
 ) {
     val credentialsManager: CredentialsManager = koinInject()
     val authService: IAuthService              = koinInject()
@@ -617,7 +648,9 @@ fun AppRoot(
                     if (!newSettings.enabled || newSettings.imagePath != backgroundSettings.imagePath) {
                         System.gc()
                     }
-                }
+                },
+                customization              = customization,
+                onCustomizationChanged     = onCustomizationChanged,
             )
         }
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/CompactNewsFeed.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/CompactNewsFeed.kt
@@ -23,6 +23,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import hivens.core.api.interfaces.IServerListService
 import hivens.core.data.NewsItem
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.launcher.network.NetworkState
 import hivens.launcher.network.ServerProtocolConfig
 import hivens.ui.i18n.LocalStrings
@@ -93,7 +94,7 @@ fun CompactNewsFeed(
             modifier   = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
         )
 
-        HorizontalDivider(color = CelestiaTheme.colors.surface.copy(alpha = 0.6f))
+        HorizontalDivider(color = glassSurfaceAlpha(0.6f))
 
         when {
             loading -> NewsSkeleton()
@@ -124,7 +125,7 @@ fun CompactNewsFeed(
                 items(news) { item ->
                     CompactNewsItem(item = item)
                     HorizontalDivider(
-                        color    = CelestiaTheme.colors.surface.copy(alpha = 0.4f),
+                        color    = glassSurfaceAlpha(0.4f),
                         modifier = Modifier.padding(horizontal = 16.dp)
                     )
                 }
@@ -138,9 +139,9 @@ fun CompactNewsFeed(
 @Composable
 private fun NewsSkeleton() {
     val shimmerColors = listOf(
-        CelestiaTheme.colors.surface.copy(alpha = 0.6f),
-        CelestiaTheme.colors.surface.copy(alpha = 0.25f),
-        CelestiaTheme.colors.surface.copy(alpha = 0.6f),
+        glassSurfaceAlpha(0.6f),
+        glassSurfaceAlpha(0.25f),
+        glassSurfaceAlpha(0.6f),
     )
 
     val transition = rememberInfiniteTransition(label = "skeleton")
@@ -164,7 +165,7 @@ private fun NewsSkeleton() {
         repeat(4) {
             SkeletonNewsItem(brush)
             HorizontalDivider(
-                color    = CelestiaTheme.colors.surface.copy(alpha = 0.4f),
+                color    = glassSurfaceAlpha(0.4f),
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/RightPanel.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import hivens.core.data.SessionData
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.theme.CelestiaTheme
 
 /**
@@ -27,7 +28,7 @@ fun RightPanel(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(CelestiaTheme.colors.surface.copy(alpha = 0.22f))
+                .background(glassSurfaceAlpha(0.22f))
         ) {
             when (appState) {
                 AppState.Loading          -> AuthLoadingSlot()
@@ -39,7 +40,7 @@ fun RightPanel(
             }
         }
 
-        HorizontalDivider(color = CelestiaTheme.colors.surface.copy(alpha = 0.7f))
+        HorizontalDivider(color = glassSurfaceAlpha(0.7f))
 
         // ── News feed (bottom) ────────────────────────────────────────────────
         CompactNewsFeed(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/background/BackgroundSettings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/background/BackgroundSettings.kt
@@ -22,7 +22,20 @@ data class BackgroundSettings(
     val tintColor: String? = null,
     val tintOpacity: Float = 0.0f,
     val animationSpeedMultiplier: Float = 1.0f,
+    val loopMode: BackgroundLoopMode = BackgroundLoopMode.UseCodec,
 )
 
 @Serializable
 enum class ScaleMode { COVER, CONTAIN, STRETCH, ORIGINAL, TILE }
+
+/**
+ * Loop semantics for multi-frame backgrounds (GIF / APNG / animated
+ * WebP). Static formats ignore this -- there is nothing to loop.
+ *
+ * UseCodec: honor the codec's own repetitionCount field (-1 = forever,
+ *           N = N additional plays after the first). Default.
+ * LoopForever: ignore the codec, play indefinitely.
+ * PlayOnce: ignore the codec, freeze on the last frame after one pass.
+ */
+@Serializable
+enum class BackgroundLoopMode { UseCodec, LoopForever, PlayOnce }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/background/CustomBackground.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/background/CustomBackground.kt
@@ -131,7 +131,7 @@ private fun AnimatedParallaxImage(
         IntOffset(x, y)
     }
 
-    val imageBitmap = rememberSkiaImage(file, settings.animationSpeedMultiplier)
+    val imageBitmap = rememberSkiaImage(file, settings.animationSpeedMultiplier, settings.loopMode)
 
     if (imageBitmap != null) {
         val useParallax = settings.parallaxIntensity > 0f
@@ -176,7 +176,11 @@ private fun AnimatedParallaxImage(
 }
 
 @Composable
-private fun rememberSkiaImage(file: File, speedMultiplier: Float): ImageBitmap? {
+private fun rememberSkiaImage(
+    file: File,
+    speedMultiplier: Float,
+    loopMode: BackgroundLoopMode,
+): ImageBitmap? {
     var decoded  by remember(file) { mutableStateOf<DecodedBg?>(null) }
     var frameIdx by remember(file) { mutableStateOf(0) }
     val speedRef = rememberUpdatedState(speedMultiplier)
@@ -192,11 +196,19 @@ private fun rememberSkiaImage(file: File, speedMultiplier: Float): ImageBitmap? 
     }
 
     // Skia spec: repetitionCount = N means N additional plays after the
-    // first. -1 = loop forever, 0 = play once. Slider changes mid-play
-    // take effect on the next frame swap (rememberUpdatedState keeps the
-    // captured ref fresh without restarting the effect).
-    LaunchedEffect(d) {
-        val totalPlays = if (d.repetitionCount < 0) Int.MAX_VALUE else d.repetitionCount + 1
+    // first. -1 = loop forever, 0 = play once. loopMode lets the user
+    // override the codec's stored hint -- LoopForever for ambient bg use,
+    // PlayOnce when they want the intro-frame settle pattern. Slider
+    // changes mid-play take effect on the next frame swap
+    // (rememberUpdatedState keeps the captured ref fresh without
+    // restarting the effect).
+    LaunchedEffect(d, loopMode) {
+        val totalPlays = when (loopMode) {
+            BackgroundLoopMode.LoopForever -> Int.MAX_VALUE
+            BackgroundLoopMode.PlayOnce    -> 1
+            BackgroundLoopMode.UseCodec    ->
+                if (d.repetitionCount < 0) Int.MAX_VALUE else d.repetitionCount + 1
+        }
         var played = 0
         while (played < totalPlays) {
             for (i in d.frames.indices) {
@@ -207,6 +219,8 @@ private fun rememberSkiaImage(file: File, speedMultiplier: Float): ImageBitmap? 
             }
             played++
         }
+        // PlayOnce / finite codec: hold on the last frame.
+        frameIdx = d.frames.lastIndex
     }
 
     return d.frames[frameIdx.coerceIn(0, d.frames.lastIndex)]

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/background/CustomBackground.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/background/CustomBackground.kt
@@ -187,7 +187,9 @@ private fun rememberSkiaImage(
 
     LaunchedEffect(file) {
         if (!file.exists()) return@LaunchedEffect
-        withContext(Dispatchers.IO) { decoded = decodeBackground(file) }
+        withContext(Dispatchers.IO) {
+            decoded = decodeBackground(file) { preview -> decoded = preview }
+        }
     }
 
     val d = decoded ?: return null
@@ -226,48 +228,57 @@ private fun rememberSkiaImage(
     return d.frames[frameIdx.coerceIn(0, d.frames.lastIndex)]
 }
 
-private fun decodeBackground(file: File): DecodedBg? {
+private fun decodeBackground(file: File, onPreview: (DecodedBg) -> Unit = {}): DecodedBg? {
     var data:  Data?  = null
     var codec: Codec? = null
-    return try {
+    try {
         data  = Data.makeFromFileName(file.absolutePath)
         codec = Codec.makeFromData(data)
         val frameCount = codec.frameCount
         val info       = codec.imageInfo
 
-        if (frameCount <= 1) {
-            DecodedBg(
-                frames          = listOf(decodeFrame(codec, info, frame = 0, trackTag = "BG.static")),
-                durationsMs     = listOf(0),
-                repetitionCount = 0,
+        // Frame 0 first -- becomes the final result for statics and
+        // the preview emit for multi-frame formats so the user sees
+        // the image immediately instead of grey while the remaining
+        // N-1 frames decode.
+        val frame0 = decodeFrame(
+            codec, info,
+            frame    = 0,
+            trackTag = if (frameCount > 1) "BG.animated" else "BG.static",
+        )
+        val preview = DecodedBg(
+            frames          = listOf(frame0),
+            durationsMs     = listOf(0),
+            repetitionCount = 0,
+        )
+
+        if (frameCount <= 1) return preview
+
+        val pixelsTotal = info.width.toLong() * info.height.toLong() * frameCount.toLong()
+        if (frameCount > MAX_ANIMATED_FRAMES || pixelsTotal > MAX_ANIMATED_PIXELS_TOTAL) {
+            log.warn(
+                "Animated bg too large (frames={}, ~{}MB raw) -- using frame 0 only",
+                frameCount, pixelsTotal * 4 / 1_048_576,
             )
-        } else {
-            val pixelsTotal = info.width.toLong() * info.height.toLong() * frameCount.toLong()
-            if (frameCount > MAX_ANIMATED_FRAMES || pixelsTotal > MAX_ANIMATED_PIXELS_TOTAL) {
-                log.warn(
-                    "Animated bg too large (frames={}, ~{}MB raw) -- using frame 0 only",
-                    frameCount, pixelsTotal * 4 / 1_048_576,
-                )
-                DecodedBg(
-                    frames          = listOf(decodeFrame(codec, info, frame = 0, trackTag = "BG.static")),
-                    durationsMs     = listOf(0),
-                    repetitionCount = 0,
-                )
-            } else {
-                val frames    = ArrayList<ImageBitmap>(frameCount)
-                val durations = ArrayList<Int>(frameCount)
-                val infos     = codec.framesInfo
-                for (i in 0 until frameCount) {
-                    frames.add(decodeFrame(codec, info, frame = i, trackTag = "BG.animated"))
-                    // delay() of 0 spins -- guarantee positive duration per frame.
-                    durations.add(infos[i].duration.coerceAtLeast(1))
-                }
-                DecodedBg(frames, durations, codec.repetitionCount)
-            }
+            return preview
         }
+
+        // Emit the preview so the user sees frame 0 while frames
+        // 1..N-1 decode below.
+        onPreview(preview)
+
+        val frames    = ArrayList<ImageBitmap>(frameCount).also { it.add(frame0) }
+        val durations = ArrayList<Int>(frameCount).also { it.add(codec.framesInfo[0].duration.coerceAtLeast(1)) }
+        val infos     = codec.framesInfo
+        for (i in 1 until frameCount) {
+            frames.add(decodeFrame(codec, info, frame = i, trackTag = "BG.animated"))
+            // delay() of 0 spins -- guarantee positive duration per frame.
+            durations.add(infos[i].duration.coerceAtLeast(1))
+        }
+        return DecodedBg(frames, durations, codec.repetitionCount)
     } catch (e: Exception) {
         log.error("Failed to decode custom background at {}", file.absolutePath, e)
-        null
+        return null
     } finally {
         codec?.close()
         data?.close()

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/CaelestiaComponents.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/CaelestiaComponents.kt
@@ -46,7 +46,12 @@ fun GlassCard(
         CardSurface.Glass -> palette.glassBackground.copy(
             alpha = (palette.glassAlpha * customization.glassIntensity).coerceIn(0f, 1f),
         )
-        CardSurface.Flat  -> MaterialTheme.colorScheme.surface
+        // Brut's natural opacity is 1.0; the intensity knob scales
+        // from there so a user can opt into translucency even under
+        // the "opaque" style without losing Brut's default at 1.0.
+        CardSurface.Flat  -> MaterialTheme.colorScheme.surface.copy(
+            alpha = customization.glassIntensity.coerceIn(0f, 1f),
+        )
     }
     val resolvedBorderWidth = style.cardBorder.coerceAtLeast(0.dp)
     val resolvedBorder = when {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/CaelestiaComponents.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/CaelestiaComponents.kt
@@ -46,12 +46,20 @@ fun GlassCard(
         CardSurface.Glass -> palette.glassBackground.copy(
             alpha = (palette.glassAlpha * customization.glassIntensity).coerceIn(0f, 1f),
         )
-        // Brut's natural opacity is 1.0; the intensity knob scales
-        // from there so a user can opt into translucency even under
-        // the "opaque" style without losing Brut's default at 1.0.
-        CardSurface.Flat  -> MaterialTheme.colorScheme.surface.copy(
-            alpha = customization.glassIntensity.coerceIn(0f, 1f),
-        )
+        // Brut: at intensity = 1.0 keep the solid grey surface
+        // (Brut identity). As intensity drops, lerp the colour
+        // toward palette.glassBackground (the same near-black tint
+        // Celestia uses) AND drop alpha. The colour shift makes the
+        // translucency visually obvious -- grey alone at low alpha
+        // reads as "darker grey" rather than "see-through".
+        CardSurface.Flat  -> {
+            val intensity = customization.glassIntensity.coerceIn(0f, 1f)
+            androidx.compose.ui.graphics.lerp(
+                palette.glassBackground,
+                MaterialTheme.colorScheme.surface,
+                intensity,
+            ).copy(alpha = intensity)
+        }
     }
     val resolvedBorderWidth = style.cardBorder.coerceAtLeast(0.dp)
     val resolvedBorder = when {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/CaelestiaComponents.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/CaelestiaComponents.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
+import hivens.ui.customization.LocalCustomization
 import hivens.ui.effects.pulsatingGlow
 import hivens.ui.theme.CardSurface
 import hivens.ui.theme.CelestiaTheme
@@ -37,10 +38,14 @@ fun GlassCard(
     borderColor: Color = Color.Unspecified,
     content: @Composable BoxScope.() -> Unit
 ) {
-    val style = LocalStyle.current
-    val resolvedShape = shape ?: RoundedCornerShape(style.cardCorner)
+    val style          = LocalStyle.current
+    val palette        = CelestiaTheme.colors
+    val customization  = LocalCustomization.current
+    val resolvedShape  = shape ?: RoundedCornerShape(style.cardCorner)
     val resolvedBackground = backgroundColor ?: when (style.cardSurface) {
-        CardSurface.Glass -> MaterialTheme.colorScheme.surface.copy(alpha = 0.7f)
+        CardSurface.Glass -> palette.glassBackground.copy(
+            alpha = (palette.glassAlpha * customization.glassIntensity).coerceIn(0f, 1f),
+        )
         CardSurface.Flat  -> MaterialTheme.colorScheme.surface
     }
     val resolvedBorderWidth = style.cardBorder.coerceAtLeast(0.dp)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/RamSelector.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/RamSelector.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
 
@@ -74,7 +75,7 @@ fun RamSelector(
                 row.forEach { preset ->
                     val isSelected = currentMb == preset && !isCustomMode
                     val bgColor by animateColorAsState(
-                        if (isSelected) CelestiaTheme.colors.primary else CelestiaTheme.colors.surface.copy(alpha = 0.5f),
+                        if (isSelected) CelestiaTheme.colors.primary else glassSurfaceAlpha(0.5f),
                         tween(200)
                     )
                     val textColor by animateColorAsState(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/customization/CustomizationManager.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/customization/CustomizationManager.kt
@@ -1,0 +1,33 @@
+package hivens.ui.customization
+
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+
+class CustomizationManager(
+    configPath: Path,
+    private val json: Json,
+) {
+    private val log = LoggerFactory.getLogger(CustomizationManager::class.java)
+    private val settingsFile = configPath.resolve("customization.json")
+
+    fun load(): CustomizationSettings {
+        if (!Files.exists(settingsFile)) return CustomizationSettings()
+        return try {
+            json.decodeFromString<CustomizationSettings>(Files.readString(settingsFile))
+        } catch (e: Exception) {
+            log.error("Failed to load customization settings", e)
+            CustomizationSettings()
+        }
+    }
+
+    fun save(settings: CustomizationSettings) {
+        try {
+            Files.createDirectories(settingsFile.parent)
+            Files.writeString(settingsFile, json.encodeToString(settings))
+        } catch (e: Exception) {
+            log.error("Failed to save customization settings", e)
+        }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/customization/CustomizationSettings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/customization/CustomizationSettings.kt
@@ -1,0 +1,39 @@
+package hivens.ui.customization
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Persistent customization layer that sits on top of the active theme
+ * and bg settings. Stored in {configDir}/customization.json.
+ *
+ * Default state is a no-op -- every field is null / 1.0 / false so an
+ * unconfigured user sees the same UI as before customization existed.
+ *
+ * [experimentalColorOverridesEnabled] gates [colorOverrides] -- by
+ * default only [accentOverride] is exposed. Flipping the experimental
+ * flag unlocks per-role color picking which is easy to misuse into
+ * unreadable combinations.
+ */
+@Serializable
+data class CustomizationSettings(
+    val densityScale: Float = 1.0f,
+    val glassIntensity: Float = 1.0f,
+    val accentOverride: String? = null,
+    val experimentalColorOverridesEnabled: Boolean = false,
+    val colorOverrides: Map<String, String> = emptyMap(),
+)
+
+/**
+ * Per-role keys for [CustomizationSettings.colorOverrides]. Stable
+ * strings so existing customization.json files keep working across
+ * theme refactors.
+ */
+object ColorRole {
+    const val PRIMARY    = "primary"
+    const val SECONDARY  = "secondary"
+    const val BACKGROUND = "background"
+    const val SURFACE    = "surface"
+    const val SUCCESS    = "success"
+    const val ERROR      = "error"
+    const val OUTLINE    = "outline"
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/customization/GlassHelpers.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/customization/GlassHelpers.kt
@@ -2,16 +2,14 @@ package hivens.ui.customization
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import hivens.ui.theme.CardSurface
 import hivens.ui.theme.CelestiaTheme
-import hivens.ui.theme.LocalStyle
 
 /**
  * Resolves the active surface tint at [baseAlpha], scaled by the
- * user's glass intensity preference -- but only when the active
- * style is glass-capable. Brut's [CardSurface.Flat] short-circuits
- * to the original [baseAlpha] so opaque surfaces stay opaque
- * regardless of the customization knob (its identity).
+ * user's glass intensity preference. Applies under every style,
+ * not just Celestia -- default value 1.0 preserves each style's
+ * natural opacity, lower values let the user opt into translucency
+ * even under Brut.
  *
  * Use this anywhere that currently does
  * `CelestiaTheme.colors.surface.copy(alpha = X)` to make the
@@ -19,12 +17,7 @@ import hivens.ui.theme.LocalStyle
  */
 @Composable
 fun glassSurfaceAlpha(baseAlpha: Float): Color {
-    val style      = LocalStyle.current
-    val multiplier = if (style.cardSurface == CardSurface.Glass) {
-        LocalCustomization.current.glassIntensity
-    } else {
-        1f
-    }
+    val multiplier = LocalCustomization.current.glassIntensity
     return CelestiaTheme.colors.surface.copy(
         alpha = (baseAlpha * multiplier).coerceIn(0f, 1f),
     )

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/customization/GlassHelpers.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/customization/GlassHelpers.kt
@@ -1,0 +1,31 @@
+package hivens.ui.customization
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import hivens.ui.theme.CardSurface
+import hivens.ui.theme.CelestiaTheme
+import hivens.ui.theme.LocalStyle
+
+/**
+ * Resolves the active surface tint at [baseAlpha], scaled by the
+ * user's glass intensity preference -- but only when the active
+ * style is glass-capable. Brut's [CardSurface.Flat] short-circuits
+ * to the original [baseAlpha] so opaque surfaces stay opaque
+ * regardless of the customization knob (its identity).
+ *
+ * Use this anywhere that currently does
+ * `CelestiaTheme.colors.surface.copy(alpha = X)` to make the
+ * surface honor [hivens.ui.customization.CustomizationSettings.glassIntensity].
+ */
+@Composable
+fun glassSurfaceAlpha(baseAlpha: Float): Color {
+    val style      = LocalStyle.current
+    val multiplier = if (style.cardSurface == CardSurface.Glass) {
+        LocalCustomization.current.glassIntensity
+    } else {
+        1f
+    }
+    return CelestiaTheme.colors.surface.copy(
+        alpha = (baseAlpha * multiplier).coerceIn(0f, 1f),
+    )
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/customization/GlassHelpers.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/customization/GlassHelpers.kt
@@ -22,3 +22,17 @@ fun glassSurfaceAlpha(baseAlpha: Float): Color {
         alpha = (baseAlpha * multiplier).coerceIn(0f, 1f),
     )
 }
+
+/**
+ * Same as [glassSurfaceAlpha] but takes a pre-resolved base color
+ * instead of pulling from the palette. Use when the caller has a
+ * theme-derived color (e.g., a CustomTheme background) that should
+ * still honor the glass intensity knob.
+ */
+@Composable
+fun scaledAlpha(baseColor: Color, baseAlpha: Float): Color {
+    val multiplier = LocalCustomization.current.glassIntensity
+    return baseColor.copy(
+        alpha = (baseAlpha * multiplier).coerceIn(0f, 1f),
+    )
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/customization/LocalCustomization.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/customization/LocalCustomization.kt
@@ -1,0 +1,14 @@
+package hivens.ui.customization
+
+import androidx.compose.runtime.compositionLocalOf
+
+/**
+ * Read-only access to the active [CustomizationSettings] from any
+ * Composable without prop-drilling through every layer. Backed by
+ * [CustomizationManager] at the app root.
+ *
+ * Defaulted to a no-op instance so any caller compiling against
+ * the local does not blow up if it is read outside the provider
+ * (e.g., previews, isolated tests).
+ */
+val LocalCustomization = compositionLocalOf { CustomizationSettings() }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -538,4 +538,27 @@ interface AppStrings {
     // --- Profile two-column nav labels ---
     val profileCategorySkin: String
     val profileCategoryAccount: String
+
+    // --- Background loop mode ---
+    val backgroundLoopMode: String
+    val backgroundLoopUseCodec: String
+    val backgroundLoopForever: String
+    val backgroundLoopOnce: String
+
+    // --- Customization extension ---
+    val settingsCustomizationExt: String
+    val settingsCustomizationExtSub: String
+    val customizationTitle: String
+    val customizationSubtitle: String
+    val customizationDensity: String
+    val customizationGlassIntensity: String
+    val customizationAccentOverride: String
+    val customizationAccentClear: String
+    val customizationSectionVisual: String
+    val customizationSectionColors: String
+    val customizationExperimentalToggle: String
+    val customizationExperimentalSub: String
+    val customizationReset: String
+    val customizationHexInvalid: String
+    val themePickerAccentOverride: String
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -516,7 +516,7 @@ object EnglishStrings : AppStrings {
     override val customizationTitle           = "Customization"
     override val customizationSubtitle        = "Experimental visual tuning"
     override val customizationDensity         = "Density scale"
-    override val customizationGlassIntensity  = "Glass intensity"
+    override val customizationGlassIntensity  = "Glass opacity"
     override val customizationAccentOverride  = "Accent override"
     override val customizationAccentClear     = "Clear override"
     override val customizationSectionVisual   = "VISUAL"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -505,4 +505,25 @@ object EnglishStrings : AppStrings {
 
     override val profileCategorySkin    = "Skin"
     override val profileCategoryAccount = "Account"
+
+    override val backgroundLoopMode      = "Loop"
+    override val backgroundLoopUseCodec  = "Use codec"
+    override val backgroundLoopForever   = "Forever"
+    override val backgroundLoopOnce      = "Play once"
+
+    override val settingsCustomizationExt    = "Customization (exp.)"
+    override val settingsCustomizationExtSub = "Density, accent, glass intensity, color overrides"
+    override val customizationTitle           = "Customization"
+    override val customizationSubtitle        = "Experimental visual tuning"
+    override val customizationDensity         = "Density scale"
+    override val customizationGlassIntensity  = "Glass intensity"
+    override val customizationAccentOverride  = "Accent override"
+    override val customizationAccentClear     = "Clear override"
+    override val customizationSectionVisual   = "VISUAL"
+    override val customizationSectionColors   = "COLOR OVERRIDES"
+    override val customizationExperimentalToggle = "Per-role color overrides"
+    override val customizationExperimentalSub    = "Unlock 7-color override matrix. Easy to make unreadable combinations."
+    override val customizationReset           = "Reset all"
+    override val customizationHexInvalid      = "Invalid hex"
+    override val themePickerAccentOverride    = "Accent override (live)"
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -505,4 +505,25 @@ object GermanStrings : AppStrings {
 
     override val profileCategorySkin    = "Skin"
     override val profileCategoryAccount = "Konto"
+
+    override val backgroundLoopMode      = "Schleife"
+    override val backgroundLoopUseCodec  = "Aus Codec"
+    override val backgroundLoopForever   = "Endlos"
+    override val backgroundLoopOnce      = "Einmal"
+
+    override val settingsCustomizationExt    = "Anpassung (exp.)"
+    override val settingsCustomizationExtSub = "Dichte, Akzent, Glas-Deckkraft, Farbüberschreibungen"
+    override val customizationTitle           = "Anpassung"
+    override val customizationSubtitle        = "Experimentelle Feinabstimmung"
+    override val customizationDensity         = "Dichteskala"
+    override val customizationGlassIntensity  = "Glas-Deckkraft"
+    override val customizationAccentOverride  = "Akzent überschreiben"
+    override val customizationAccentClear     = "Überschreibung löschen"
+    override val customizationSectionVisual   = "VISUELL"
+    override val customizationSectionColors   = "FARBÜBERSCHREIBUNGEN"
+    override val customizationExperimentalToggle = "Alle Farben überschreiben"
+    override val customizationExperimentalSub    = "7-Farb-Matrix freischalten. Kann unleserlich werden."
+    override val customizationReset           = "Alles zurücksetzen"
+    override val customizationHexInvalid      = "Ungültiger Hex"
+    override val themePickerAccentOverride    = "Akzent überschreiben (sofort)"
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -517,7 +517,7 @@ object RussianStrings : AppStrings {
     override val customizationTitle           = "Кастомизация"
     override val customizationSubtitle        = "Экспериментальная тонкая настройка вида"
     override val customizationDensity         = "Масштаб плотности"
-    override val customizationGlassIntensity  = "Прозрачность стекла"
+    override val customizationGlassIntensity  = "Плотность стекла"
     override val customizationAccentOverride  = "Свой акцент"
     override val customizationAccentClear     = "Сбросить акцент"
     override val customizationSectionVisual   = "ВИЗУАЛ"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -506,4 +506,25 @@ object RussianStrings : AppStrings {
 
     override val profileCategorySkin    = "Скин"
     override val profileCategoryAccount = "Аккаунт"
+
+    override val backgroundLoopMode      = "Луп"
+    override val backgroundLoopUseCodec  = "Из кодека"
+    override val backgroundLoopForever   = "Бесконечно"
+    override val backgroundLoopOnce      = "Один раз"
+
+    override val settingsCustomizationExt    = "Кастомизация (эксп.)"
+    override val settingsCustomizationExtSub = "Плотность, акцент, прозрачность стекла, переопределение цветов"
+    override val customizationTitle           = "Кастомизация"
+    override val customizationSubtitle        = "Экспериментальная тонкая настройка вида"
+    override val customizationDensity         = "Масштаб плотности"
+    override val customizationGlassIntensity  = "Прозрачность стекла"
+    override val customizationAccentOverride  = "Свой акцент"
+    override val customizationAccentClear     = "Сбросить акцент"
+    override val customizationSectionVisual   = "ВИЗУАЛ"
+    override val customizationSectionColors   = "ПЕРЕОПРЕДЕЛЕНИЕ ЦВЕТОВ"
+    override val customizationExperimentalToggle = "Переопределять все цвета"
+    override val customizationExperimentalSub    = "Открыть матрицу из 7 цветов. Легко сделать нечитаемые сочетания."
+    override val customizationReset           = "Сбросить всё"
+    override val customizationHexInvalid      = "Неверный hex"
+    override val themePickerAccentOverride    = "Свой акцент (применяется сразу)"
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/BackgroundSettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/BackgroundSettingsScreen.kt
@@ -26,6 +26,7 @@ import hivens.ui.background.BackgroundSettings
 import hivens.ui.background.CustomBackground
 import hivens.ui.background.ScaleMode
 import hivens.ui.components.GlassCard
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetClick
 import hivens.ui.puppet.PuppetScreen
@@ -122,7 +123,7 @@ fun BackgroundSettingsScreen(
                     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                         scaleModes.forEach { (mode, label) ->
                             val selected = settings.scaleMode == mode
-                            Box(Modifier.weight(1f).height(32.dp).clip(RoundedCornerShape(6.dp)).background(if (selected) CelestiaTheme.colors.primary else CelestiaTheme.colors.surface.copy(alpha = 0.4f)).clickable { update { copy(scaleMode = mode) } }, contentAlignment = Alignment.Center) {
+                            Box(Modifier.weight(1f).height(32.dp).clip(RoundedCornerShape(6.dp)).background(if (selected) CelestiaTheme.colors.primary else glassSurfaceAlpha(0.4f)).clickable { update { copy(scaleMode = mode) } }, contentAlignment = Alignment.Center) {
                                 Text(label, fontSize = 10.sp, fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal, color = if (selected) Color.White else CelestiaTheme.colors.textSecondary)
                             }
                         }
@@ -159,7 +160,7 @@ fun BackgroundSettingsScreen(
                                     .weight(1f)
                                     .height(32.dp)
                                     .clip(RoundedCornerShape(6.dp))
-                                    .background(if (selected) CelestiaTheme.colors.primary else CelestiaTheme.colors.surface.copy(alpha = 0.4f))
+                                    .background(if (selected) CelestiaTheme.colors.primary else glassSurfaceAlpha(0.4f))
                                     .clickable { update { copy(loopMode = mode) } },
                                 contentAlignment = Alignment.Center,
                             ) {
@@ -221,7 +222,7 @@ fun BackgroundSettingsScreen(
                     Column(Modifier.fillMaxSize().padding(24.dp), verticalArrangement = Arrangement.SpaceBetween) {
                         Text(s.backgroundPreview, style = MaterialTheme.typography.labelSmall, color = Color.White.copy(alpha = 0.5f), fontWeight = FontWeight.Bold)
                         Column {
-                            Box(Modifier.fillMaxWidth().height(80.dp).clip(RoundedCornerShape(12.dp)).background(CelestiaTheme.colors.surface.copy(alpha = 0.6f)).border(1.dp, CelestiaTheme.colors.outline.copy(alpha = 0.2f), RoundedCornerShape(12.dp)).padding(16.dp), contentAlignment = Alignment.CenterStart) {
+                            Box(Modifier.fillMaxWidth().height(80.dp).clip(RoundedCornerShape(12.dp)).background(glassSurfaceAlpha(0.6f)).border(1.dp, CelestiaTheme.colors.outline.copy(alpha = 0.2f), RoundedCornerShape(12.dp)).padding(16.dp), contentAlignment = Alignment.CenterStart) {
                                 Column {
                                     Text(s.backgroundPreviewServer, color = CelestiaTheme.colors.textPrimary, fontWeight = FontWeight.Bold)
                                     Text("1.21.1 • 42/100", style = MaterialTheme.typography.bodySmall, color = CelestiaTheme.colors.textSecondary)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/BackgroundSettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/BackgroundSettingsScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import hivens.ui.background.BackgroundLoopMode
 import hivens.ui.background.BackgroundSettings
 import hivens.ui.background.CustomBackground
 import hivens.ui.background.ScaleMode
@@ -143,6 +144,30 @@ fun BackgroundSettingsScreen(
                     LabeledSlider(s.backgroundParallax, settings.parallaxIntensity, 0f..1f, "%.0f%%", 100f) { update { copy(parallaxIntensity = it) } }
                     LabeledSlider(s.backgroundVignette, settings.vignetteIntensity, 0f..1f, "%.0f%%", 100f) { update { copy(vignetteIntensity = it) } }
                     LabeledSlider(s.backgroundAnimationSpeed, settings.animationSpeedMultiplier, 0.25f..4f, "%.2fx") { update { copy(animationSpeedMultiplier = it) } }
+
+                    SectionTitle(s.backgroundLoopMode)
+                    val loopModes = listOf(
+                        BackgroundLoopMode.UseCodec    to s.backgroundLoopUseCodec,
+                        BackgroundLoopMode.LoopForever to s.backgroundLoopForever,
+                        BackgroundLoopMode.PlayOnce    to s.backgroundLoopOnce,
+                    )
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        loopModes.forEach { (mode, label) ->
+                            val selected = settings.loopMode == mode
+                            Box(
+                                Modifier
+                                    .weight(1f)
+                                    .height(32.dp)
+                                    .clip(RoundedCornerShape(6.dp))
+                                    .background(if (selected) CelestiaTheme.colors.primary else CelestiaTheme.colors.surface.copy(alpha = 0.4f))
+                                    .clickable { update { copy(loopMode = mode) } },
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(label, fontSize = 10.sp, fontWeight = if (selected) FontWeight.Bold else FontWeight.Normal,
+                                     color = if (selected) Color.White else CelestiaTheme.colors.textSecondary)
+                            }
+                        }
+                    }
 
                     HorizontalDivider(color = CelestiaTheme.colors.outline.copy(alpha = 0.15f))
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/DashboardScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/DashboardScreen.kt
@@ -25,6 +25,7 @@ import hivens.launcher.network.NetworkState
 import hivens.launcher.ProfileManager
 import hivens.ui.components.LaunchControlPanel
 import hivens.ui.components.ServerGrid
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetScreen
 import hivens.ui.theme.CelestiaTheme
@@ -238,7 +239,7 @@ fun DashboardScreen(
                     shape = RoundedCornerShape(14.dp)
                 )
                 .background(
-                    color = CelestiaTheme.colors.surface.copy(alpha = 0.45f),
+                    color = glassSurfaceAlpha(0.45f),
                     shape = RoundedCornerShape(14.dp)
                 )
                 .padding(horizontal = 16.dp, vertical = 14.dp)
@@ -281,7 +282,7 @@ private fun AutoSyncProgressStrip(
                 shape = RoundedCornerShape(10.dp)
             )
             .background(
-                color = CelestiaTheme.colors.surface.copy(alpha = 0.35f),
+                color = glassSurfaceAlpha(0.35f),
                 shape = RoundedCornerShape(10.dp)
             )
             .padding(horizontal = 14.dp, vertical = 8.dp)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/MigrationScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/MigrationScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import hivens.launcher.platform.DataDirMigration
 import hivens.ui.components.CelestiaButton
 import hivens.ui.components.GlassCard
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.theme.CelestiaTheme
 import kotlinx.coroutines.Dispatchers
@@ -124,7 +125,7 @@ private fun ReadyContent(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(10.dp))
-            .background(CelestiaTheme.colors.surface.copy(alpha = 0.4f))
+            .background(glassSurfaceAlpha(0.4f))
             .padding(16.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerDetailScreen.kt
@@ -140,7 +140,7 @@ fun ServerDetailScreen(
                             .fillMaxHeight()
                             .padding(16.dp)
                             .clip(RoundedCornerShape(16.dp))
-                            .background(CelestiaTheme.colors.surface.copy(alpha = 0.5f))
+                            .background(glassSurfaceAlpha(0.5f))
                             .border(
                                 1.dp,
                                 CelestiaTheme.colors.outline.copy(alpha = 0.2f),

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerDetailScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import hivens.core.api.model.ServerProfile
 import hivens.launcher.platform.PlatformPaths
 import hivens.ui.components.GlassCard
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.debug.SkiaTracker
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetClick
@@ -87,7 +88,7 @@ fun ServerDetailScreen(
 
         GlassCard(
             modifier        = Modifier.weight(1f).fillMaxWidth(),
-            backgroundColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
+            backgroundColor = glassSurfaceAlpha(0.7f),
         ) {
             if (isLoading) {
                 Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerSettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerSettingsScreen.kt
@@ -37,6 +37,7 @@ import hivens.ui.components.GlassCard
 import hivens.ui.components.JvmArgsBuilderDialog
 import hivens.ui.components.ModItemCard
 import hivens.ui.components.RamSelector
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.debug.SkiaTracker
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetClick
@@ -264,7 +265,7 @@ fun ServerSettingsScreen(server: ServerProfile, onBack: () -> Unit) {
             // ══════════════════════════════════════════════════════════════════
             GlassCard(
                 modifier        = Modifier.weight(1f).fillMaxHeight(),
-                backgroundColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
+                backgroundColor = glassSurfaceAlpha(0.7f),
             ) {
                 Column(Modifier.padding(24.dp).verticalScroll(rememberScrollState())) {
 
@@ -499,7 +500,7 @@ fun ServerSettingsScreen(server: ServerProfile, onBack: () -> Unit) {
             // ══════════════════════════════════════════════════════════════════
             GlassCard(
                 modifier        = Modifier.weight(1f).fillMaxHeight(),
-                backgroundColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
+                backgroundColor = glassSurfaceAlpha(0.7f),
             ) {
                 Column(Modifier.padding(24.dp)) {
                     Text(s.serverSettingsSectionMods, style = MaterialTheme.typography.titleSmall, color = CelestiaTheme.colors.primary)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ThemePickerScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ThemePickerScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import hivens.ui.components.GlassCard
+import hivens.ui.customization.scaledAlpha
 import hivens.ui.easter.LocalAprilFools
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetClick
@@ -149,7 +150,7 @@ fun ThemeCard(
                     shape  = RoundedCornerShape(16.dp)
                 ),
             shape           = RoundedCornerShape(16.dp),
-            backgroundColor = CustomTheme.parseHexColor(theme.background).copy(alpha = 0.8f)
+            backgroundColor = scaledAlpha(CustomTheme.parseHexColor(theme.background), 0.8f)
         ) {
             Column(
                 modifier            = Modifier.fillMaxSize().padding(16.dp),
@@ -219,7 +220,7 @@ fun ThemePreviewPanel(theme: CustomTheme, s: hivens.ui.i18n.AppStrings) {
     GlassCard(
         modifier        = Modifier.fillMaxSize(),
         shape           = MaterialTheme.shapes.large,
-        backgroundColor = CustomTheme.parseHexColor(theme.background).copy(alpha = 0.8f)
+        backgroundColor = scaledAlpha(CustomTheme.parseHexColor(theme.background), 0.8f)
     ) {
         Column(modifier = Modifier.fillMaxSize().padding(24.dp)) {
             Text(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.unit.sp
 import hivens.ui.components.GlassCard
 import hivens.ui.customization.ColorRole
 import hivens.ui.customization.CustomizationSettings
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetClick
 import hivens.ui.puppet.PuppetScreen
@@ -329,7 +330,7 @@ private fun HexField(
                 .weight(1f)
                 .height(36.dp)
                 .clip(RoundedCornerShape(6.dp))
-                .background(CelestiaTheme.colors.surface.copy(alpha = 0.4f))
+                .background(glassSurfaceAlpha(0.4f))
                 .border(
                     1.dp,
                     if (valid) CelestiaTheme.colors.outline.copy(alpha = 0.3f) else CelestiaTheme.colors.error,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
@@ -346,7 +346,10 @@ private fun HexField(
                     if (t.isBlank()) {
                         // empty is "no override" -- handled by parent via onClear
                     } else {
-                        parseHexOrNull(t)?.let { onValidHex(t) }
+                        // Store the trimmed form so theme parsers downstream
+                        // (which may not trim) get a clean value.
+                        val normalized = t.trim()
+                        parseHexOrNull(normalized)?.let { onValidHex(normalized) }
                     }
                 },
                 singleLine    = true,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,10 +42,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import hivens.ui.components.GlassCard
@@ -89,6 +92,21 @@ fun CustomizationExtensionScreen(
     PuppetClick("customization.reset") {
         settings = CustomizationSettings(); onSettingsChanged(settings)
     }
+
+    // Counter-wrap the screen back to the base (unscaled) density so
+    // the density slider stays grabbable while every other surface
+    // (sidebar, right panel, dropped-in dialogs) live-scales as the
+    // user drags. Without this, every drag tick re-measures the
+    // slider host under a new density and Material's gesture detector
+    // loses the pointer.
+    val outerDensity = LocalDensity.current
+    val baseDensity  = remember(outerDensity, settings.densityScale) {
+        Density(
+            outerDensity.density / settings.densityScale.coerceAtLeast(0.01f),
+            outerDensity.fontScale,
+        )
+    }
+    CompositionLocalProvider(LocalDensity provides baseDensity) {
 
     Column(Modifier.fillMaxSize().padding(24.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -208,6 +226,7 @@ fun CustomizationExtensionScreen(
             }
         }
     }
+    } // end CompositionLocalProvider(LocalDensity)
 }
 
 @Composable

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
@@ -56,9 +56,7 @@ import hivens.ui.customization.CustomizationSettings
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetClick
 import hivens.ui.puppet.PuppetScreen
-import hivens.ui.theme.CardSurface
 import hivens.ui.theme.CelestiaTheme
-import hivens.ui.theme.LocalStyle
 
 /**
  * Experimental visual customization layer that sits on top of the
@@ -133,13 +131,8 @@ fun CustomizationExtensionScreen(
                 LabeledSlider(s.customizationDensity, settings.densityScale, 0.85f..1.15f, "%.2fx") {
                     update { copy(densityScale = it) }
                 }
-                // Brut renders cards as CardSurface.Flat which ignores
-                // palette.glassAlpha entirely; hide the slider rather
-                // than leave it silently inert.
-                if (LocalStyle.current.cardSurface == CardSurface.Glass) {
-                    LabeledSlider(s.customizationGlassIntensity, settings.glassIntensity, 0f..1f, "%.0f%%", 100f) {
-                        update { copy(glassIntensity = it) }
-                    }
+                LabeledSlider(s.customizationGlassIntensity, settings.glassIntensity, 0f..1f, "%.0f%%", 100f) {
+                    update { copy(glassIntensity = it) }
                 }
 
                 HorizontalDivider(color = CelestiaTheme.colors.outline.copy(alpha = 0.15f))

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
@@ -53,7 +53,9 @@ import hivens.ui.customization.CustomizationSettings
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetClick
 import hivens.ui.puppet.PuppetScreen
+import hivens.ui.theme.CardSurface
 import hivens.ui.theme.CelestiaTheme
+import hivens.ui.theme.LocalStyle
 
 /**
  * Experimental visual customization layer that sits on top of the
@@ -113,8 +115,13 @@ fun CustomizationExtensionScreen(
                 LabeledSlider(s.customizationDensity, settings.densityScale, 0.85f..1.15f, "%.2fx") {
                     update { copy(densityScale = it) }
                 }
-                LabeledSlider(s.customizationGlassIntensity, settings.glassIntensity, 0f..1f, "%.0f%%", 100f) {
-                    update { copy(glassIntensity = it) }
+                // Brut renders cards as CardSurface.Flat which ignores
+                // palette.glassAlpha entirely; hide the slider rather
+                // than leave it silently inert.
+                if (LocalStyle.current.cardSurface == CardSurface.Glass) {
+                    LabeledSlider(s.customizationGlassIntensity, settings.glassIntensity, 0f..1f, "%.0f%%", 100f) {
+                        update { copy(glassIntensity = it) }
+                    }
                 }
 
                 HorizontalDivider(color = CelestiaTheme.colors.outline.copy(alpha = 0.15f))

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/customization/CustomizationExtensionScreen.kt
@@ -1,0 +1,358 @@
+package hivens.ui.screens.customization
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.RestartAlt
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import hivens.ui.components.GlassCard
+import hivens.ui.customization.ColorRole
+import hivens.ui.customization.CustomizationSettings
+import hivens.ui.i18n.LocalStrings
+import hivens.ui.puppet.PuppetClick
+import hivens.ui.puppet.PuppetScreen
+import hivens.ui.theme.CelestiaTheme
+
+/**
+ * Experimental visual customization layer that sits on top of the
+ * active theme + bg. Knobs here apply globally and persist via
+ * [hivens.ui.customization.CustomizationManager].
+ *
+ * Default state is no-op (densityScale = 1, glassIntensity = 1, no
+ * accent override, experimental colors disabled). A user who never
+ * opens this screen sees no visual difference.
+ *
+ * Heavy knobs (corner radius scale, global animation speed) are
+ * deliberately NOT here -- those require threading through every
+ * shape / animation spec call site and are deferred to a follow-up.
+ */
+@Composable
+fun CustomizationExtensionScreen(
+    currentSettings: CustomizationSettings,
+    onSettingsChanged: (CustomizationSettings) -> Unit,
+    onBack: () -> Unit,
+) {
+    val s = LocalStrings.current
+    var settings by remember { mutableStateOf(currentSettings) }
+
+    fun update(block: CustomizationSettings.() -> CustomizationSettings) {
+        settings = settings.block()
+        onSettingsChanged(settings)
+    }
+
+    PuppetScreen("CustomizationExtension")
+    PuppetClick("customization.back") { onBack() }
+    PuppetClick("customization.reset") {
+        settings = CustomizationSettings(); onSettingsChanged(settings)
+    }
+
+    Column(Modifier.fillMaxSize().padding(24.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, null, tint = CelestiaTheme.colors.textPrimary)
+            }
+            Spacer(Modifier.width(8.dp))
+            Column {
+                Text(s.customizationTitle, style = MaterialTheme.typography.headlineSmall,
+                     fontWeight = FontWeight.Bold, color = CelestiaTheme.colors.textPrimary)
+                Text(s.customizationSubtitle, style = MaterialTheme.typography.bodySmall,
+                     color = CelestiaTheme.colors.textSecondary)
+            }
+        }
+
+        Spacer(Modifier.height(20.dp))
+
+        GlassCard(Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(20.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                SectionTitle(s.customizationSectionVisual)
+                LabeledSlider(s.customizationDensity, settings.densityScale, 0.85f..1.15f, "%.2fx") {
+                    update { copy(densityScale = it) }
+                }
+                LabeledSlider(s.customizationGlassIntensity, settings.glassIntensity, 0f..1f, "%.0f%%", 100f) {
+                    update { copy(glassIntensity = it) }
+                }
+
+                HorizontalDivider(color = CelestiaTheme.colors.outline.copy(alpha = 0.15f))
+
+                SectionTitle(s.customizationAccentOverride)
+                HexField(
+                    initialHex = settings.accentOverride ?: "",
+                    invalidLabel = s.customizationHexInvalid,
+                    onValidHex = { hex -> update { copy(accentOverride = hex) } },
+                )
+                if (settings.accentOverride != null) {
+                    OutlinedButton(
+                        onClick  = { update { copy(accentOverride = null) } },
+                        shape    = RoundedCornerShape(8.dp),
+                        modifier = Modifier.fillMaxWidth(),
+                    ) { Text(s.customizationAccentClear) }
+                }
+
+                HorizontalDivider(color = CelestiaTheme.colors.outline.copy(alpha = 0.15f))
+
+                Row(
+                    modifier              = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment     = Alignment.CenterVertically,
+                ) {
+                    Column(Modifier.weight(1f)) {
+                        Text(s.customizationExperimentalToggle, fontWeight = FontWeight.Bold,
+                             color = CelestiaTheme.colors.textPrimary)
+                        Text(s.customizationExperimentalSub, style = MaterialTheme.typography.bodySmall,
+                             color = CelestiaTheme.colors.textSecondary)
+                    }
+                    Switch(
+                        checked         = settings.experimentalColorOverridesEnabled,
+                        onCheckedChange = { update { copy(experimentalColorOverridesEnabled = it) } },
+                        colors          = SwitchDefaults.colors(
+                            checkedThumbColor = CelestiaTheme.colors.primary,
+                            checkedTrackColor = CelestiaTheme.colors.primary.copy(alpha = 0.5f),
+                        ),
+                    )
+                }
+
+                if (settings.experimentalColorOverridesEnabled) {
+                    SectionTitle(s.customizationSectionColors)
+                    listOf(
+                        ColorRole.PRIMARY,
+                        ColorRole.SECONDARY,
+                        ColorRole.BACKGROUND,
+                        ColorRole.SURFACE,
+                        ColorRole.SUCCESS,
+                        ColorRole.ERROR,
+                        ColorRole.OUTLINE,
+                    ).forEach { role ->
+                        ColorRoleRow(
+                            role     = role,
+                            currentHex = settings.colorOverrides[role],
+                            invalidLabel = s.customizationHexInvalid,
+                            onValidHex = { hex ->
+                                update {
+                                    val newMap = colorOverrides.toMutableMap().also { it[role] = hex }
+                                    copy(colorOverrides = newMap)
+                                }
+                            },
+                            onClear = {
+                                update {
+                                    val newMap = colorOverrides.toMutableMap().also { it.remove(role) }
+                                    copy(colorOverrides = newMap)
+                                }
+                            },
+                        )
+                    }
+                }
+
+                Spacer(Modifier.height(8.dp))
+                OutlinedButton(
+                    onClick  = { settings = CustomizationSettings(); onSettingsChanged(settings) },
+                    shape    = RoundedCornerShape(8.dp),
+                    modifier = Modifier.fillMaxWidth(),
+                    contentPadding = PaddingValues(vertical = 12.dp),
+                ) {
+                    Icon(Icons.Default.RestartAlt, null, modifier = Modifier.size(18.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text(s.customizationReset)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+    Text(
+        text,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Bold,
+        color = CelestiaTheme.colors.primary,
+        letterSpacing = 1.sp,
+    )
+}
+
+@Composable
+private fun LabeledSlider(
+    label: String,
+    value: Float,
+    range: ClosedFloatingPointRange<Float>,
+    format: String,
+    displayMultiplier: Float = 1f,
+    onValueChange: (Float) -> Unit,
+) {
+    Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(label, style = MaterialTheme.typography.bodySmall, color = CelestiaTheme.colors.textSecondary,
+             modifier = Modifier.width(150.dp))
+        Slider(
+            value         = value,
+            onValueChange = onValueChange,
+            valueRange    = range,
+            modifier      = Modifier.weight(1f),
+            colors        = SliderDefaults.colors(
+                thumbColor          = CelestiaTheme.colors.primary,
+                activeTrackColor    = CelestiaTheme.colors.primary,
+                inactiveTrackColor  = CelestiaTheme.colors.outline.copy(alpha = 0.2f),
+            ),
+        )
+        Text(
+            format.format(value * displayMultiplier),
+            style    = MaterialTheme.typography.labelSmall,
+            color    = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
+            modifier = Modifier.width(54.dp),
+        )
+    }
+}
+
+@Composable
+private fun ColorRoleRow(
+    role: String,
+    currentHex: String?,
+    invalidLabel: String,
+    onValidHex: (String) -> Unit,
+    onClear: () -> Unit,
+) {
+    Row(
+        modifier              = Modifier.fillMaxWidth(),
+        verticalAlignment     = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Text(
+            role.replaceFirstChar { it.uppercase() },
+            modifier   = Modifier.width(100.dp),
+            color      = CelestiaTheme.colors.textSecondary,
+            style      = MaterialTheme.typography.bodySmall,
+            fontFamily = FontFamily.Monospace,
+        )
+        HexField(
+            initialHex = currentHex ?: "",
+            invalidLabel = invalidLabel,
+            onValidHex = onValidHex,
+            modifier   = Modifier.weight(1f),
+        )
+        if (currentHex != null) {
+            OutlinedButton(
+                onClick        = onClear,
+                shape          = RoundedCornerShape(6.dp),
+                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+            ) { Text("x", fontSize = 12.sp) }
+        }
+    }
+}
+
+@Composable
+private fun HexField(
+    initialHex: String,
+    invalidLabel: String,
+    onValidHex: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var text by remember(initialHex) { mutableStateOf(initialHex) }
+    val parsed = parseHexOrNull(text)
+    val valid  = text.isBlank() || parsed != null
+
+    Row(
+        modifier              = modifier,
+        verticalAlignment     = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Box(
+            Modifier
+                .size(28.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(parsed ?: CelestiaTheme.colors.surface)
+                .border(1.dp, Color.White.copy(alpha = 0.2f), RoundedCornerShape(6.dp)),
+        )
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .height(36.dp)
+                .clip(RoundedCornerShape(6.dp))
+                .background(CelestiaTheme.colors.surface.copy(alpha = 0.4f))
+                .border(
+                    1.dp,
+                    if (valid) CelestiaTheme.colors.outline.copy(alpha = 0.3f) else CelestiaTheme.colors.error,
+                    RoundedCornerShape(6.dp),
+                )
+                .padding(horizontal = 10.dp),
+            contentAlignment = Alignment.CenterStart,
+        ) {
+            BasicTextField(
+                value         = text,
+                onValueChange = { t ->
+                    text = t
+                    if (t.isBlank()) {
+                        // empty is "no override" -- handled by parent via onClear
+                    } else {
+                        parseHexOrNull(t)?.let { onValidHex(t) }
+                    }
+                },
+                singleLine    = true,
+                textStyle     = TextStyle(
+                    color      = CelestiaTheme.colors.textPrimary,
+                    fontFamily = FontFamily.Monospace,
+                    fontSize   = 13.sp,
+                ),
+                cursorBrush   = androidx.compose.ui.graphics.SolidColor(CelestiaTheme.colors.primary),
+                modifier      = Modifier.fillMaxWidth(),
+            )
+        }
+        if (!valid) {
+            Text(invalidLabel, color = CelestiaTheme.colors.error, style = MaterialTheme.typography.labelSmall)
+        }
+    }
+}
+
+private fun parseHexOrNull(hex: String): Color? = try {
+    val clean = hex.removePrefix("#").trim()
+    if (clean.length != 6 && clean.length != 8) null
+    else {
+        val full = if (clean.length == 6) "FF$clean" else clean
+        Color(full.toLong(16))
+    }
+} catch (_: Exception) { null }
+
+@Suppress("unused")
+private fun ImeAction.alwaysReferenced() = Unit

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import hivens.core.api.interfaces.IPackRepository
 import hivens.core.data.PackInstance
 import hivens.core.data.PackOrigin
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.puppet.PuppetScreen
 import hivens.ui.screens.library.PackLoaderChip
 import hivens.ui.screens.library.PackMetaChip
@@ -183,7 +184,7 @@ private fun PlayBar(pack: PackInstance, onPlay: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(14.dp))
-            .background(CelestiaTheme.colors.surface.copy(alpha = 0.7f))
+            .background(glassSurfaceAlpha(0.7f))
             .padding(16.dp),
     ) {
         Row(
@@ -234,7 +235,7 @@ private fun Section(title: String, content: @Composable () -> Unit) {
             modifier = Modifier
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(12.dp))
-                .background(CelestiaTheme.colors.surface.copy(alpha = 0.6f))
+                .background(glassSurfaceAlpha(0.6f))
                 .padding(16.dp),
         ) {
             content()

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/profile/ProfileScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/profile/ProfileScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.unit.dp
 import hivens.core.api.SkinRepository
 import hivens.core.data.SessionData
 import hivens.ui.components.GlassCard
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.identity.SkinManager
 import hivens.ui.puppet.PuppetClick
@@ -52,7 +53,7 @@ fun ProfileScreen(session: SessionData, skinRepository: SkinRepository) {
         // glassy under Brut, same rule as the Settings frame.
         GlassCard(
             modifier        = Modifier.weight(1f).fillMaxWidth(),
-            backgroundColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
+            backgroundColor = glassSurfaceAlpha(0.7f),
         ) {
             Row(Modifier.fillMaxSize().padding(16.dp)) {
                 ProfileCategoryNav(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/AppearanceSection.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/AppearanceSection.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material.icons.filled.Wallpaper
 import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.*
@@ -44,6 +45,7 @@ internal fun AppearanceSection(
     onToggleTheme: () -> Unit,
     onOpenThemePicker: () -> Unit,
     onOpenBackgroundSettings: () -> Unit,
+    onOpenCustomizationExtension: () -> Unit,
     currentLocale: AppLocale,
     onLocaleChanged: (AppLocale) -> Unit,
     homeView: HomeView,
@@ -160,6 +162,31 @@ internal fun AppearanceSection(
             Column {
                 Text(s.settingsBackground, color = CelestiaTheme.colors.textPrimary, fontWeight = FontWeight.Bold)
                 Text(s.settingsBackgroundSub, style = MaterialTheme.typography.bodySmall, color = CelestiaTheme.colors.textSecondary)
+            }
+        }
+        Icon(Icons.Default.ChevronRight, null, tint = CelestiaTheme.colors.primary)
+    }
+
+    Spacer(Modifier.height(4.dp))
+
+    // Customization extension shortcut
+    PuppetClick("settings.openCustomizationExtension") { onOpenCustomizationExtension() }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(style.cardCorner))
+            .clickable(onClick = onOpenCustomizationExtension)
+            .background(CelestiaTheme.colors.surface.copy(alpha = 0.4f))
+            .padding(16.dp),
+        verticalAlignment     = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.Tune, null, tint = CelestiaTheme.colors.primary, modifier = Modifier.size(24.dp))
+            Spacer(Modifier.width(16.dp))
+            Column {
+                Text(s.settingsCustomizationExt, color = CelestiaTheme.colors.textPrimary, fontWeight = FontWeight.Bold)
+                Text(s.settingsCustomizationExtSub, style = MaterialTheme.typography.bodySmall, color = CelestiaTheme.colors.textSecondary)
             }
         }
         Icon(Icons.Default.ChevronRight, null, tint = CelestiaTheme.colors.primary)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/AppearanceSection.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/AppearanceSection.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import hivens.core.data.HomeView
 import hivens.core.data.UiStyle
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.AppLocale
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetClick
@@ -151,7 +152,7 @@ internal fun AppearanceSection(
             .fillMaxWidth()
             .clip(RoundedCornerShape(style.cardCorner))
             .clickable(onClick = onOpenBackgroundSettings)
-            .background(CelestiaTheme.colors.surface.copy(alpha = 0.4f))
+            .background(glassSurfaceAlpha(0.4f))
             .padding(16.dp),
         verticalAlignment     = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
@@ -176,7 +177,7 @@ internal fun AppearanceSection(
             .fillMaxWidth()
             .clip(RoundedCornerShape(style.cardCorner))
             .clickable(onClick = onOpenCustomizationExtension)
-            .background(CelestiaTheme.colors.surface.copy(alpha = 0.4f))
+            .background(glassSurfaceAlpha(0.4f))
             .padding(16.dp),
         verticalAlignment     = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/DiagnosticsSection.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/DiagnosticsSection.kt
@@ -31,6 +31,7 @@ import hivens.ui.easter.LocalAprilFools
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.platform.SystemActions
 import hivens.ui.puppet.PuppetClick
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 import kotlinx.coroutines.Dispatchers
@@ -248,7 +249,7 @@ internal fun DiagnosticsSection(
             .fillMaxWidth()
             .clip(RoundedCornerShape(style.cardCorner))
             .clickable(onClick = onOpenAbout)
-            .background(CelestiaTheme.colors.surface.copy(alpha = 0.4f))
+            .background(glassSurfaceAlpha(0.4f))
             .padding(16.dp),
         verticalAlignment     = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsHelpers.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsHelpers.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import hivens.core.data.HomeView
 import hivens.core.data.UiStyle
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.theme.CelestiaTheme
 import hivens.ui.theme.LocalStyle
 
@@ -215,7 +216,7 @@ internal fun UiStylePicker(
 @Composable
 private fun VariantPill(label: String, selected: Boolean, onClick: () -> Unit) {
     val bg = if (selected) CelestiaTheme.colors.primary.copy(alpha = 0.18f)
-             else CelestiaTheme.colors.surface.copy(alpha = 0.4f)
+             else glassSurfaceAlpha(0.4f)
     val fg = if (selected) CelestiaTheme.colors.primary else CelestiaTheme.colors.textSecondary
     val style = LocalStyle.current
     Row(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsScreen.kt
@@ -47,6 +47,7 @@ fun SettingsScreen(
     uiStyle: UiStyle,
     onUiStyleChanged: (UiStyle) -> Unit,
     onOpenBackgroundSettings: () -> Unit = {},
+    onOpenCustomizationExtension: () -> Unit = {},
     onOpenAbout: () -> Unit = {}
 ) {
     PuppetScreen("Settings")
@@ -106,18 +107,19 @@ fun SettingsScreen(
                 ) {
                     when (selectedCategory) {
                         SettingsCategory.Appearance -> AppearanceSection(
-                            form                     = form,
-                            save                     = ::save,
-                            isDarkTheme              = isDarkTheme,
-                            onToggleTheme            = onToggleTheme,
-                            onOpenThemePicker        = onOpenThemePicker,
-                            onOpenBackgroundSettings = onOpenBackgroundSettings,
-                            currentLocale            = currentLocale,
-                            onLocaleChanged          = onLocaleChanged,
-                            homeView                 = homeView,
-                            onHomeViewChanged        = onHomeViewChanged,
-                            uiStyle                  = uiStyle,
-                            onUiStyleChanged         = onUiStyleChanged,
+                            form                         = form,
+                            save                         = ::save,
+                            isDarkTheme                  = isDarkTheme,
+                            onToggleTheme                = onToggleTheme,
+                            onOpenThemePicker            = onOpenThemePicker,
+                            onOpenBackgroundSettings     = onOpenBackgroundSettings,
+                            onOpenCustomizationExtension = onOpenCustomizationExtension,
+                            currentLocale                = currentLocale,
+                            onLocaleChanged              = onLocaleChanged,
+                            homeView                     = homeView,
+                            onHomeViewChanged            = onHomeViewChanged,
+                            uiStyle                      = uiStyle,
+                            onUiStyleChanged             = onUiStyleChanged,
                         )
                         SettingsCategory.Network -> NetworkSection(
                             form = form,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsScreen.kt
@@ -17,6 +17,7 @@ import hivens.core.data.UiStyle
 import hivens.launcher.network.NetworkState
 import hivens.launcher.platform.PlatformPaths
 import hivens.ui.components.GlassCard
+import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.AppLocale
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetScreen
@@ -88,10 +89,11 @@ fun SettingsScreen(
 
         // Explicit backgroundColor opts the Settings frame out of
         // style.cardSurface -- stays glassy under Brut, same as the
-        // inner row panels.
+        // inner row panels. Routed through glassSurfaceAlpha so the
+        // customization knob still scales it.
         GlassCard(
             modifier        = Modifier.weight(1f).fillMaxWidth(),
-            backgroundColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.7f),
+            backgroundColor = glassSurfaceAlpha(0.7f),
         ) {
             Row(Modifier.fillMaxSize().padding(16.dp)) {
                 SettingsCategoryNav(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/theme/CelestiaTheme.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/theme/CelestiaTheme.kt
@@ -216,7 +216,7 @@ object CelestiaTheme {
 }
 
 private fun parseHexColorOrNull(hex: String): Color? = try {
-    val clean = hex.removePrefix("#")
+    val clean = hex.trim().removePrefix("#")
     val full = if (clean.length == 6) "FF$clean" else clean
     Color(full.toLong(16))
 } catch (_: Exception) { null }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/theme/CelestiaTheme.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/theme/CelestiaTheme.kt
@@ -8,6 +8,8 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.*
 import androidx.compose.ui.graphics.Color
+import hivens.ui.customization.ColorRole
+import hivens.ui.customization.LocalCustomization
 
 // --- COLOR PALETTES ---
 data class CelestiaColors(
@@ -83,10 +85,12 @@ fun CelestiaTheme(
     style: StyleSpec = CelestiaStyle,
     content: @Composable () -> Unit
 ) {
+    val customization = LocalCustomization.current
+
     // If there is a custom theme, use it, otherwise use the default one
     val baseColors = if (useDarkTheme) DarkColorPalette else LightColorPalette
 
-    val targetColors = if (customTheme != null) {
+    val themedColors = if (customTheme != null) {
         baseColors.copy(
             primary        = CustomTheme.parseHexColor(customTheme.primary),
             primaryVariant = CustomTheme.parseHexColor(customTheme.primary).copy(alpha = 0.8f),
@@ -96,6 +100,31 @@ fun CelestiaTheme(
         )
     } else {
         baseColors
+    }
+
+    // Customization overrides land on top of the active theme. Accent
+    // always available; per-role full overrides only when the user has
+    // explicitly enabled the experimental toggle.
+    val targetColors = run {
+        var c = themedColors
+        customization.accentOverride?.let { hex ->
+            parseHexColorOrNull(hex)?.let { col ->
+                c = c.copy(primary = col, primaryVariant = col.copy(alpha = 0.8f))
+            }
+        }
+        if (customization.experimentalColorOverridesEnabled && customization.colorOverrides.isNotEmpty()) {
+            val o = customization.colorOverrides
+            c = c.copy(
+                primary    = o[ColorRole.PRIMARY]?.let(::parseHexColorOrNull)    ?: c.primary,
+                secondary  = o[ColorRole.SECONDARY]?.let(::parseHexColorOrNull)  ?: c.secondary,
+                background = o[ColorRole.BACKGROUND]?.let(::parseHexColorOrNull) ?: c.background,
+                surface    = o[ColorRole.SURFACE]?.let(::parseHexColorOrNull)    ?: c.surface,
+                success    = o[ColorRole.SUCCESS]?.let(::parseHexColorOrNull)    ?: c.success,
+                error      = o[ColorRole.ERROR]?.let(::parseHexColorOrNull)      ?: c.error,
+                outline    = o[ColorRole.OUTLINE]?.let(::parseHexColorOrNull)    ?: c.outline,
+            )
+        }
+        c
     }
 
     // Color change animation duration scales with style.animationMultiplier.
@@ -185,3 +214,9 @@ object CelestiaTheme {
         @Composable
         get() = LocalCelestiaColors.current
 }
+
+private fun parseHexColorOrNull(hex: String): Color? = try {
+    val clean = hex.removePrefix("#")
+    val full = if (clean.length == 6) "FF$clean" else clean
+    Color(full.toLong(16))
+} catch (_: Exception) { null }


### PR DESCRIPTION
**Stacked on top of PR #238 (multi-frame bg).** Will need rebase onto stable after #238 merges.

## What

New \`CustomizationExtensionScreen\` under Settings -> "Customization (exp.)". Each knob is wired end-to-end -- no skeletons, no placeholders.

## Knobs (live)

- **Density scale 0.85-1.15x** -- \`LocalDensity\` override at app root. Affects every \`.dp\` unit in the app.
- **Glass intensity 0-100%** -- multiplier on \`CelestiaColors.glassAlpha\`. Fixes a prior bug where \`GlassCard\` ignored the palette field and hardcoded \`alpha = 0.7f\`.
- **Accent override (hex)** -- layered on top of the active theme's primary. Always available, even without the experimental toggle.
- **Per-role color overrides** -- experimental toggle unlocks a 7-role matrix (primary/secondary/background/surface/success/error/outline) with hex input + swatch + clear button per role. Easy to make unreadable combinations -- gated by the toggle for a reason.
- **Reset-all** -- back to defaults.

## Persistence

New \`customization.json\` next to \`background.json\`. Trivially shareable as a dotfile (e.g., for hyprland-style ricing communities). \`@Serializable\` with all-default fields, so existing installations load with no overrides applied.

## Bg loop override

\`BackgroundSettings\` gains \`loopMode: BackgroundLoopMode\` with three values:
- \`UseCodec\` -- honor the codec's stored \`repetitionCount\` (default; current behavior)
- \`LoopForever\` -- ignore codec, loop indefinitely
- \`PlayOnce\` -- ignore codec, freeze on the last frame

Segmented control in \`BackgroundSettingsScreen\` under the speed slider. \`CustomBackground\` respects the choice -- \`PlayOnce\` lets users compose intro-video-then-settle patterns once \`Skinema\` lands.

## What is deliberately NOT here

Each of these earns its own PR because they require threading a new \`Local*\` through every relevant call site:

- **Corner radius scale** -- would touch every \`RoundedCornerShape\` and every shape-aware Material component
- **Global UI animation duration multiplier** -- would touch every \`animateFloatAsState\` / \`tween\` / \`spring\` / etc.
- **ThemePicker accent picker (inline)** -- the accent picker lives in CustomizationExtension for now; adding it to ThemePicker is a separate UI change

These are intentional follow-ups, not regressions.

## Test plan

- [ ] Open Settings -> "Customization (exp.)" -- new entry visible with the Tune icon
- [ ] Density slider moves -- all UI scales up/down visibly
- [ ] Glass intensity slider -- GlassCard cards become more/less translucent in real-time
- [ ] Accent hex input -- valid hex (with or without #) immediately re-colors primary buttons / highlights everywhere
- [ ] Invalid hex (e.g., "zzz") -- input border turns error red, "Invalid hex" label appears, no theme change
- [ ] Experimental toggle ON -- 7-role color matrix appears
- [ ] Set background to one of the per-role overrides -- background changes everywhere immediately
- [ ] Clear button per role -- restores from override
- [ ] Reset-all -- all overrides cleared
- [ ] Existing \`customization.json\` reload -- overrides persist across launcher restart
- [ ] No \`customization.json\` (fresh install) -- loads with all defaults, UI looks unchanged from pre-PR
- [ ] Background loop mode segmented control -- switching to PlayOnce on a GIF -> animates once and freezes on last frame
- [ ] Switching to LoopForever on a single-loop GIF -> keeps looping