### PR TITLE
ci(portability): install ca-certificates explicitly on Debian-stable

### DIFF
--- a/.github/workflows/appimage-portability.yml
+++ b/.github/workflows/appimage-portability.yml
@@ -93,10 +93,14 @@ jobs:
           - distro_name: Debian-stable
             container: debian:stable
             expect_keyring: any
+            # ca-certificates is explicit because --no-install-recommends
+            # drops it from gh's dependency closure; the debian:stable image
+            # no longer ships a pre-installed CA bundle, so `gh release
+            # download` failed TLS verification against api.github.com.
             install_cmd: |
               apt-get update -qq
               apt-get install -y --no-install-recommends \
-                xvfb libfuse2 libsecret-1-0 gh \
+                ca-certificates xvfb libfuse2 libsecret-1-0 gh \
                 libxi6 libxrender1 libxtst6 libxext6 libxcursor1 libxxf86vm1 \
                 libfontconfig1 libfreetype6 libgl1 \
                 xauth


### PR DESCRIPTION
## What

\`AppImage Portability\` weekly run on Mondays started failing on the \`Debian-stable\` job (other distros pass). \`gh release download\` cannot reach api.github.com:

\`\`\`
Get "https://api.github.com/repos/Kitty-Hivens/Nexira/releases/latest":
  tls: failed to verify certificate:
  x509: certificate signed by unknown authority
\`\`\`

Root cause: the \`debian:stable\` upstream image no longer ships a pre-installed CA bundle, and our apt-get line uses \`--no-install-recommends\` which drops \`ca-certificates\` from \`gh\`'s dependency closure.

## How

Added \`ca-certificates\` to the explicit \`apt-get install\` list for the Debian-stable matrix entry. Inline comment explains the dependency.

## Scope

- One-line change, Debian only.
- Fedora and Arch unaffected -- their default images still bundle CA roots.
- Does not affect end-user Debian installs -- production Debian systems have ca-certificates as a base-system dependency; only the minimal container image is missing it.

## Test plan

- [ ] Re-run the workflow via workflow_dispatch on this branch and confirm Debian-stable passes.
- [ ] (Implicit) After merge, next Monday's scheduled run goes green again.