### PR TITLE
fix(i18n): drop ALL CAPS across UI strings + .uppercase() call sites

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
@@ -127,7 +127,7 @@ fun LaunchControlPanel(
         // -- Action button --------------------------------------------------
         val btnText = when (state) {
             is LaunchState.Downloading, is LaunchState.Prepare -> s.launchAbort
-            is LaunchState.GameRunning                         -> s.launchRunning.uppercase()
+            is LaunchState.GameRunning                         -> s.launchRunning
             is LaunchState.Error                               -> s.launchResetError
             else                                               -> s.launchButton
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -10,7 +10,7 @@ object EnglishStrings : AppStrings {
     override val loginUsername     = "Username"
     override val loginPassword     = "Password"
     override val loginRemember     = "Remember password"
-    override val loginButton       = "LOG IN"
+    override val loginButton       = "Log in"
     override val loginErrorEmpty   = "Enter your username and password"
     override val loginErrorGeneric = "Login error"
     override val loginRegister     = "Create an account"
@@ -21,17 +21,17 @@ object EnglishStrings : AppStrings {
 
     // Dashboard
     override fun dashboardWelcome(name: String) = "WELCOME BACK, $name"
-    override val dashboardServers              = "AVAILABLE SERVERS"
+    override val dashboardServers              = "Available servers"
     override val dashboardServersEmpty         = "No servers found"
     override val dashboardLoginRequiredTitle   = "Sign in to see servers"
     override val dashboardLoginRequiredHint    = "Use the panel on the right to log in. The server list lives behind authentication on SMARTYcraft."
 
     // Launch Control
     override val launchReady       = "Ready to play"
-    override val launchButton      = "PLAY"
-    override val launchAbort       = "CANCEL"
+    override val launchButton      = "Play"
+    override val launchAbort       = "Cancel"
     override val launchRunning     = "Game running"
-    override val launchResetError  = "CLEAR ERROR"
+    override val launchResetError  = "Clear error"
     override val launchDownloading = "Downloading:"
 
     // Launcher States
@@ -47,7 +47,7 @@ object EnglishStrings : AppStrings {
     override fun authSuccess(uuid: String) = "Login successful. UUID: $uuid"
 
     // Profile
-    override val profileTitle              = "PROFILE"
+    override val profileTitle              = "Profile"
     override val profileStatusLabel        = "Status"
     override val profileStatusOnline       = "Authenticated"
     override val profileStatusOffline      = "Offline"
@@ -63,7 +63,7 @@ object EnglishStrings : AppStrings {
     override fun profileUploadError(msg: String) = "Upload error: $msg"
 
     // Settings
-    override val settingsTitle              = "GLOBAL SETTINGS"
+    override val settingsTitle              = "Global settings"
     override val settingsSectionUI          = "Interface"
     override val settingsSectionBehavior    = "Behavior"
     override val settingsThemePicker        = "Choose theme"
@@ -74,9 +74,9 @@ object EnglishStrings : AppStrings {
     override val settingsLanguage           = "Language"
 
     // Theme Picker
-    override val themePickerTitle           = "CHOOSE THEME"
-    override val themePickerApply           = "APPLY"
-    override val themePickerPreview         = "PREVIEW"
+    override val themePickerTitle           = "Choose theme"
+    override val themePickerApply           = "Apply"
+    override val themePickerPreview         = "Preview"
     override val themePickerSelected        = "Selected"
     override val themePickerColorPrimary    = "Primary"
     override val themePickerColorSecondary  = "Secondary"
@@ -89,11 +89,11 @@ object EnglishStrings : AppStrings {
     override val themePickerBtnOutlined     = "Outlined Button"
 
     // News
-    override val newsTitle   = "PROJECT NEWS"
+    override val newsTitle   = "Project news"
     override val newsEmpty   = "No news yet..."
 
     // Server Detail
-    override val serverDetailTitle         = "SERVER INFORMATION"
+    override val serverDetailTitle         = "Server information"
     override val serverDetailNoImage       = "No image"
     override val serverDetailNoImageHint   = "banner.png"
     override val serverDetailMissingTitle  = "Information missing"
@@ -101,8 +101,8 @@ object EnglishStrings : AppStrings {
 
     // Server Settings
     override val serverSettingsSubtitle        = "Launch settings"
-    override val serverSettingsSectionSystem   = "SYSTEM"
-    override val serverSettingsSectionMods     = "MODIFICATIONS"
+    override val serverSettingsSectionSystem   = "System"
+    override val serverSettingsSectionMods     = "Modifications"
     override val serverSettingsRam             = "RAM"
     override fun serverSettingsRamValue(mb: Int) = "RAM: $mb MB"
     override val serverSettingsJava            = "Java version"
@@ -115,8 +115,8 @@ object EnglishStrings : AppStrings {
 
     // Update
     override val updateTitle           = "Update available"
-    override val updateTitleCritical   = "CRITICAL UPDATE"
-    override val updateTitleMandatory  = "MANDATORY UPDATE"
+    override val updateTitleCritical   = "Critical update"
+    override val updateTitleMandatory  = "Mandatory update"
     override val updateCriticalBanner  = "This update contains critical security fixes."
     override val updateMandatoryBanner =
         "Server-side compatibility broke for older versions. The launcher cannot continue without this update."
@@ -128,7 +128,7 @@ object EnglishStrings : AppStrings {
     override val updateLater           = "Later"
     override val updateExit            = "Quit"
     override val updateDownload        = "Download and install"
-    override val updateDownloadNow     = "DOWNLOAD NOW"
+    override val updateDownloadNow     = "Download now"
     override val updateDownloading     = "Downloading..."
     override val updateInstall         = "Install and restart"
     override val updateRetry           = "Retry"
@@ -207,22 +207,22 @@ object EnglishStrings : AppStrings {
     // =========================================================================
     // Custom Background
     // =========================================================================
-    override val backgroundTitle          = "CUSTOM BACKGROUND"
+    override val backgroundTitle          = "Custom background"
     override val backgroundSubtitle       = "Customize the launcher wallpaper"
     override val backgroundEnable         = "Enable"
-    override val backgroundSectionImage   = "IMAGE"
+    override val backgroundSectionImage   = "Image"
     override val backgroundPickFile       = "Choose a background image"
     override val backgroundPickButton     = "Choose file"
-    override val backgroundSectionScale   = "SCALING"
+    override val backgroundSectionScale   = "Scaling"
     override val backgroundScaleCover     = "Cover"
     override val backgroundScaleContain   = "Contain"
     override val backgroundScaleStretch   = "Stretch"
     override val backgroundScaleOriginal  = "Original"
     override val backgroundScaleTile      = "Tile"
-    override val backgroundSectionPosition = "POSITION"
+    override val backgroundSectionPosition = "Position"
     override val backgroundAlignX         = "Horizontal"
     override val backgroundAlignY         = "Vertical"
-    override val backgroundSectionEffects = "EFFECTS"
+    override val backgroundSectionEffects = "Effects"
     override val backgroundBlur           = "Blur"
     override val backgroundDarken         = "Darken"
     override val backgroundOpacity        = "Opacity"
@@ -230,7 +230,7 @@ object EnglishStrings : AppStrings {
     override val backgroundParallax       = "Parallax"
     override val backgroundVignette       = "Vignette"
     override val backgroundAnimationSpeed = "Animation speed"
-    override val backgroundSectionTint    = "COLOR TINT"
+    override val backgroundSectionTint    = "Color tint"
     override val backgroundTintNone       = "None"
     override val backgroundTintNavy       = "Dark blue"
     override val backgroundTintViolet     = "Violet"
@@ -239,7 +239,7 @@ object EnglishStrings : AppStrings {
     override val backgroundTintSteel      = "Steel"
     override val backgroundTintIntensity  = "Intensity"
     override val backgroundReset          = "Reset to defaults"
-    override val backgroundPreview        = "PREVIEW"
+    override val backgroundPreview        = "Preview"
     override val backgroundPreviewServer  = "Example server"
     override val settingsBackground       = "Custom background"
     override val settingsBackgroundSub    = "Photo or GIF as launcher wallpaper"
@@ -247,14 +247,14 @@ object EnglishStrings : AppStrings {
     // =========================================================================
     // About Screen
     // =========================================================================
-    override val aboutTitle                = "ABOUT"
+    override val aboutTitle                = "About"
     override fun aboutDescription(branding: String) = "Unofficial launcher for $branding"
     override fun aboutBuildDate(date: String) = "Built: $date"
-    override val aboutSectionCreator       = "CREATOR"
-    override val aboutSectionTechnologies  = "TECHNOLOGIES"
-    override val aboutSectionLicense       = "LICENSE"
+    override val aboutSectionCreator       = "Creator"
+    override val aboutSectionTechnologies  = "Technologies"
+    override val aboutSectionLicense       = "License"
     override val aboutLicenseText          = "GPLv3 — Free and open source software"
-    override val aboutSectionUpdates       = "UPDATES"
+    override val aboutSectionUpdates       = "Updates"
     override val aboutCurrentVersion       = "Current version"
     override val aboutCheckUpdates         = "Check for updates"
     override val aboutChecking             = "Checking..."
@@ -262,13 +262,13 @@ object EnglishStrings : AppStrings {
     override val aboutCheckAgain           = "Check again"
     override fun aboutUpdateAvailable(version: String) = "Version $version available"
     override val aboutCriticalUpdate       = "Critical update"
-    override val aboutSectionSystem        = "SYSTEM"
+    override val aboutSectionSystem        = "System"
     override val aboutOs                   = "OS"
-    override val aboutSectionLinks         = "LINKS"
+    override val aboutSectionLinks         = "Links"
     override val aboutLinkGithub           = "GitHub"
     override val aboutLinkBugReport        = "Report a bug"
     override val aboutLinkReleases         = "Releases"
-    override val settingsSectionAbout      = "ABOUT"
+    override val settingsSectionAbout      = "About"
 
     // Tech stack descriptions
     override val techKotlinDesc  = "Primary language"
@@ -519,15 +519,15 @@ object EnglishStrings : AppStrings {
     override val customizationGlassIntensity  = "Glass opacity"
     override val customizationAccentOverride  = "Accent override"
     override val customizationAccentClear     = "Clear override"
-    override val customizationSectionVisual   = "VISUAL"
-    override val customizationSectionColors   = "COLOR OVERRIDES"
+    override val customizationSectionVisual   = "Visual"
+    override val customizationSectionColors   = "Color overrides"
     override val customizationExperimentalToggle = "Per-role color overrides"
     override val customizationExperimentalSub    = "Unlock 7-color override matrix. Easy to make unreadable combinations."
     override val customizationReset           = "Reset all"
     override val customizationHexInvalid      = "Invalid hex"
     override val themePickerAccentOverride    = "Accent override (live)"
 
-    override val browseTitle        = "BROWSE"
+    override val browseTitle        = "Browse"
     override val browseSubtitle     = "Packs published on the mirror"
     override val browseEmptyTitle   = "Catalog is empty"
     override val browseEmptyMessage = "The mirror is reachable but has not published any packs yet. Check back later."
@@ -539,7 +539,7 @@ object EnglishStrings : AppStrings {
     override val browseDetailErrorMessage  = "Could not fetch the manifest. Check your connection and retry."
     override val browseDetailInstallReady  = "Ready to install"
     override val browseDetailInstallHint   = "Creates a new instance under your data directory."
-    override val browseDetailInstallButton = "INSTALL"
+    override val browseDetailInstallButton = "Install"
     override val browseDetailTagsTitle     = "Tags"
     override val browseDetailAboutTitle       = "About this pack"
     override val browseDetailAboutPlaceholder = "This pack ships %d mods and %d assets."
@@ -555,7 +555,7 @@ object EnglishStrings : AppStrings {
     override val browseDetailInstallStarting      = "Starting..."
     override val browseDetailInstallDoneTitle     = "Installed"
     override val browseDetailInstallDoneHint      = "Added to your Library."
-    override val browseDetailInstallOpenLibrary   = "OPEN IN LIBRARY"
+    override val browseDetailInstallOpenLibrary   = "Open in Library"
     override val browseDetailInstallFailedTitle   = "Install failed"
     override val browseDetailInstallFailedGeneric = "Install failed for an unknown reason."
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -10,7 +10,7 @@ object GermanStrings : AppStrings {
     override val loginUsername     = "Benutzername"
     override val loginPassword     = "Passwort"
     override val loginRemember     = "Passwort speichern"
-    override val loginButton       = "ANMELDEN"
+    override val loginButton       = "Anmelden"
     override val loginErrorEmpty   = "Benutzername und Passwort eingeben"
     override val loginErrorGeneric = "Anmeldefehler"
     override val loginRegister     = "Konto erstellen"
@@ -28,8 +28,8 @@ object GermanStrings : AppStrings {
 
     // Launch Control
     override val launchReady       = "Bereit zum Spielen"
-    override val launchButton      = "SPIELEN"
-    override val launchAbort       = "ABBRECHEN"
+    override val launchButton      = "Spielen"
+    override val launchAbort       = "Abbrechen"
     override val launchRunning     = "Spiel läuft"
     override val launchResetError  = "FEHLER ZURÜCKSETZEN"
     override val launchDownloading = "Herunterladen:"
@@ -47,7 +47,7 @@ object GermanStrings : AppStrings {
     override fun authSuccess(uuid: String) = "Anmeldung erfolgreich. UUID: $uuid"
 
     // Profile
-    override val profileTitle              = "PROFIL"
+    override val profileTitle              = "Profil"
     override val profileStatusLabel        = "Status"
     override val profileStatusOnline       = "Angemeldet"
     override val profileStatusOffline      = "Offline"
@@ -63,7 +63,7 @@ object GermanStrings : AppStrings {
     override fun profileUploadError(msg: String) = "Upload-Fehler: $msg"
 
     // Settings
-    override val settingsTitle              = "GLOBALE EINSTELLUNGEN"
+    override val settingsTitle              = "Globale Einstellungen"
     override val settingsSectionUI          = "Oberfläche"
     override val settingsSectionBehavior    = "Verhalten"
     override val settingsThemePicker        = "Design auswählen"
@@ -75,8 +75,8 @@ object GermanStrings : AppStrings {
 
     // Theme Picker
     override val themePickerTitle           = "DESIGN WÄHLEN"
-    override val themePickerApply           = "ANWENDEN"
-    override val themePickerPreview         = "VORSCHAU"
+    override val themePickerApply           = "Anwenden"
+    override val themePickerPreview         = "Vorschau"
     override val themePickerSelected        = "Ausgewählt"
     override val themePickerColorPrimary    = "Primär"
     override val themePickerColorSecondary  = "Sekundär"
@@ -89,7 +89,7 @@ object GermanStrings : AppStrings {
     override val themePickerBtnOutlined     = "Umrandete Schaltfläche"
 
     // News
-    override val newsTitle   = "PROJEKTNEUIGKEITEN"
+    override val newsTitle   = "Projektneuigkeiten"
     override val newsEmpty   = "Noch keine Neuigkeiten..."
 
     // Server Detail
@@ -101,8 +101,8 @@ object GermanStrings : AppStrings {
 
     // Server Settings
     override val serverSettingsSubtitle        = "Starteinstellungen"
-    override val serverSettingsSectionSystem   = "SYSTEM"
-    override val serverSettingsSectionMods     = "MODIFIKATIONEN"
+    override val serverSettingsSectionSystem   = "System"
+    override val serverSettingsSectionMods     = "Modifikationen"
     override val serverSettingsRam             = "RAM"
     override fun serverSettingsRamValue(mb: Int) = "RAM: $mb MB"
     override val serverSettingsJava            = "Java-Version"
@@ -115,7 +115,7 @@ object GermanStrings : AppStrings {
 
     // Update
     override val updateTitle           = "Update verfügbar"
-    override val updateTitleCritical   = "KRITISCHES UPDATE"
+    override val updateTitleCritical   = "Kritisches Update"
     override val updateTitleMandatory  = "PFLICHT-UPDATE"
     override val updateCriticalBanner  = "Dieses Update enthält kritische Sicherheitskorrekturen."
     override val updateMandatoryBanner =
@@ -128,7 +128,7 @@ object GermanStrings : AppStrings {
     override val updateLater           = "Später"
     override val updateExit            = "Beenden"
     override val updateDownload        = "Herunterladen und installieren"
-    override val updateDownloadNow     = "JETZT HERUNTERLADEN"
+    override val updateDownloadNow     = "Jetzt herunterladen"
     override val updateDownloading     = "Herunterladen..."
     override val updateInstall         = "Installieren und neustarten"
     override val updateRetry           = "Erneut versuchen"
@@ -207,22 +207,22 @@ object GermanStrings : AppStrings {
     // =========================================================================
     // Custom Background
     // =========================================================================
-    override val backgroundTitle          = "BENUTZERDEFINIERTER HINTERGRUND"
+    override val backgroundTitle          = "Benutzerdefinierter Hintergrund"
     override val backgroundSubtitle       = "Launcher-Hintergrund anpassen"
     override val backgroundEnable         = "Aktivieren"
-    override val backgroundSectionImage   = "BILD"
+    override val backgroundSectionImage   = "Bild"
     override val backgroundPickFile       = "Hintergrundbild auswählen"
     override val backgroundPickButton     = "Datei auswählen"
-    override val backgroundSectionScale   = "SKALIERUNG"
+    override val backgroundSectionScale   = "Skalierung"
     override val backgroundScaleCover     = "Füllen"
     override val backgroundScaleContain   = "Einpassen"
     override val backgroundScaleStretch   = "Strecken"
     override val backgroundScaleOriginal  = "Original"
     override val backgroundScaleTile      = "Kacheln"
-    override val backgroundSectionPosition = "POSITION"
+    override val backgroundSectionPosition = "Position"
     override val backgroundAlignX         = "Horizontal"
     override val backgroundAlignY         = "Vertikal"
-    override val backgroundSectionEffects = "EFFEKTE"
+    override val backgroundSectionEffects = "Effekte"
     override val backgroundBlur           = "Unschärfe"
     override val backgroundDarken         = "Abdunkeln"
     override val backgroundOpacity        = "Deckkraft"
@@ -239,7 +239,7 @@ object GermanStrings : AppStrings {
     override val backgroundTintSteel      = "Stahl"
     override val backgroundTintIntensity  = "Intensität"
     override val backgroundReset          = "Auf Standardwerte zurücksetzen"
-    override val backgroundPreview        = "VORSCHAU"
+    override val backgroundPreview        = "Vorschau"
     override val backgroundPreviewServer  = "Beispielserver"
     override val settingsBackground       = "Benutzerdefinierter Hintergrund"
     override val settingsBackgroundSub    = "Foto oder GIF als Launcher-Hintergrund"
@@ -250,11 +250,11 @@ object GermanStrings : AppStrings {
     override val aboutTitle                = "ÜBER DEN LAUNCHER"
     override fun aboutDescription(branding: String) = "Inoffizieller Launcher für $branding"
     override fun aboutBuildDate(date: String) = "Erstellt: $date"
-    override val aboutSectionCreator       = "ERSTELLER"
-    override val aboutSectionTechnologies  = "TECHNOLOGIEN"
-    override val aboutSectionLicense       = "LIZENZ"
+    override val aboutSectionCreator       = "Ersteller"
+    override val aboutSectionTechnologies  = "Technologien"
+    override val aboutSectionLicense       = "Lizenz"
     override val aboutLicenseText          = "GPLv3 — Freie und quelloffene Software"
-    override val aboutSectionUpdates       = "UPDATES"
+    override val aboutSectionUpdates       = "Updates"
     override val aboutCurrentVersion       = "Aktuelle Version"
     override val aboutCheckUpdates         = "Auf Updates prüfen"
     override val aboutChecking             = "Prüfe..."
@@ -262,9 +262,9 @@ object GermanStrings : AppStrings {
     override val aboutCheckAgain           = "Erneut prüfen"
     override fun aboutUpdateAvailable(version: String) = "Version $version verfügbar"
     override val aboutCriticalUpdate       = "Kritisches Update"
-    override val aboutSectionSystem        = "SYSTEM"
+    override val aboutSectionSystem        = "System"
     override val aboutOs                   = "Betriebssystem"
-    override val aboutSectionLinks         = "LINKS"
+    override val aboutSectionLinks         = "Links"
     override val aboutLinkGithub           = "GitHub"
     override val aboutLinkBugReport        = "Fehler melden"
     override val aboutLinkReleases         = "Veröffentlichungen"
@@ -519,7 +519,7 @@ object GermanStrings : AppStrings {
     override val customizationGlassIntensity  = "Glas-Deckkraft"
     override val customizationAccentOverride  = "Akzent überschreiben"
     override val customizationAccentClear     = "Überschreibung löschen"
-    override val customizationSectionVisual   = "VISUELL"
+    override val customizationSectionVisual   = "Visuell"
     override val customizationSectionColors   = "FARBÜBERSCHREIBUNGEN"
     override val customizationExperimentalToggle = "Alle Farben überschreiben"
     override val customizationExperimentalSub    = "7-Farb-Matrix freischalten. Kann unleserlich werden."
@@ -527,7 +527,7 @@ object GermanStrings : AppStrings {
     override val customizationHexInvalid      = "Ungültiger Hex"
     override val themePickerAccentOverride    = "Akzent überschreiben (sofort)"
 
-    override val browseTitle        = "KATALOG"
+    override val browseTitle        = "Katalog"
     override val browseSubtitle     = "Auf dem Mirror veröffentlichte Packs"
     override val browseEmptyTitle   = "Katalog ist leer"
     override val browseEmptyMessage = "Der Mirror ist erreichbar, hat aber noch keine Packs veröffentlicht. Schau später wieder vorbei."
@@ -539,7 +539,7 @@ object GermanStrings : AppStrings {
     override val browseDetailErrorMessage  = "Manifest konnte nicht geladen werden. Verbindung prüfen und erneut versuchen."
     override val browseDetailInstallReady  = "Bereit zur Installation"
     override val browseDetailInstallHint   = "Erstellt eine neue Instanz in deinem Datenverzeichnis."
-    override val browseDetailInstallButton = "INSTALLIEREN"
+    override val browseDetailInstallButton = "Installieren"
     override val browseDetailTagsTitle     = "Tags"
     override val browseDetailAboutTitle       = "Über dieses Pack"
     override val browseDetailAboutPlaceholder = "Dieses Pack enthält %d Mods und %d Assets."
@@ -555,7 +555,7 @@ object GermanStrings : AppStrings {
     override val browseDetailInstallStarting      = "Wird gestartet..."
     override val browseDetailInstallDoneTitle     = "Installiert"
     override val browseDetailInstallDoneHint      = "Zur Library hinzugefügt."
-    override val browseDetailInstallOpenLibrary   = "IN LIBRARY ÖFFNEN"
+    override val browseDetailInstallOpenLibrary   = "In Library öffnen"
     override val browseDetailInstallFailedTitle   = "Installation fehlgeschlagen"
     override val browseDetailInstallFailedGeneric = "Installation aus unbekanntem Grund fehlgeschlagen."
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -10,7 +10,7 @@ object RussianStrings : AppStrings {
     override val loginUsername     = "Логин"
     override val loginPassword     = "Пароль"
     override val loginRemember     = "Запомнить пароль"
-    override val loginButton       = "ВОЙТИ"
+    override val loginButton       = "Войти"
     override val loginErrorEmpty   = "Введите логин и пароль"
     override val loginErrorGeneric = "Ошибка входа"
     override val loginRegister     = "Зарегистрироваться"
@@ -21,17 +21,17 @@ object RussianStrings : AppStrings {
 
     // Dashboard
     override fun dashboardWelcome(name: String) = "ДОБРО ПОЖАЛОВАТЬ, $name"
-    override val dashboardServers              = "ДОСТУПНЫЕ СЕРВЕРЫ"
+    override val dashboardServers              = "Доступные серверы"
     override val dashboardServersEmpty         = "Серверы не найдены"
     override val dashboardLoginRequiredTitle   = "Войдите, чтобы увидеть серверы"
     override val dashboardLoginRequiredHint    = "Воспользуйтесь панелью справа. Список серверов на SMARTYcraft скрыт за авторизацией."
 
     // Launch Control
     override val launchReady       = "Готов к игре"
-    override val launchButton      = "ИГРАТЬ"
-    override val launchAbort       = "ОТМЕНА"
+    override val launchButton      = "Играть"
+    override val launchAbort       = "Отмена"
     override val launchRunning     = "Игра запущена"
-    override val launchResetError  = "СБРОСИТЬ ОШИБКУ"
+    override val launchResetError  = "Сбросить ошибку"
     override val launchDownloading = "Загрузка:"
 
     // Launcher States
@@ -47,7 +47,7 @@ object RussianStrings : AppStrings {
     override fun authSuccess(uuid: String) = "Успешный вход. UUID: $uuid"
 
     // Profile
-    override val profileTitle              = "ПРОФИЛЬ"
+    override val profileTitle              = "Профиль"
     override val profileStatusLabel        = "Статус"
     override val profileStatusOnline       = "Авторизован"
     override val profileStatusOffline      = "Оффлайн"
@@ -63,7 +63,7 @@ object RussianStrings : AppStrings {
     override fun profileUploadError(msg: String) = "Ошибка загрузки: $msg"
 
     // Settings
-    override val settingsTitle              = "ГЛОБАЛЬНЫЕ НАСТРОЙКИ"
+    override val settingsTitle              = "Глобальные настройки"
     override val settingsSectionUI          = "Интерфейс"
     override val settingsSectionBehavior    = "Поведение"
     override val settingsThemePicker        = "Выбор темы"
@@ -74,9 +74,9 @@ object RussianStrings : AppStrings {
     override val settingsLanguage           = "Язык"
 
     // Theme Picker
-    override val themePickerTitle           = "ВЫБОР ТЕМЫ"
-    override val themePickerApply           = "ПРИМЕНИТЬ"
-    override val themePickerPreview         = "ПРЕДПРОСМОТР"
+    override val themePickerTitle           = "Выбор темы"
+    override val themePickerApply           = "Применить"
+    override val themePickerPreview         = "Предпросмотр"
     override val themePickerSelected        = "Выбрана"
     override val themePickerColorPrimary    = "Основной"
     override val themePickerColorSecondary  = "Дополнительный"
@@ -89,11 +89,11 @@ object RussianStrings : AppStrings {
     override val themePickerBtnOutlined     = "Кнопка с рамкой"
 
     // News
-    override val newsTitle   = "НОВОСТИ ПРОЕКТА"
+    override val newsTitle   = "Новости проекта"
     override val newsEmpty   = "Новостей пока нет..."
 
     // Server Detail
-    override val serverDetailTitle         = "ИНФОРМАЦИЯ О СЕРВЕРЕ"
+    override val serverDetailTitle         = "Информация о сервере"
     override val serverDetailNoImage       = "Нет изображения"
     override val serverDetailNoImageHint   = "banner.png"
     override val serverDetailMissingTitle  = "Информация отсутствует"
@@ -101,8 +101,8 @@ object RussianStrings : AppStrings {
 
     // Server Settings
     override val serverSettingsSubtitle        = "Настройки запуска"
-    override val serverSettingsSectionSystem   = "СИСТЕМА"
-    override val serverSettingsSectionMods     = "МОДИФИКАЦИИ"
+    override val serverSettingsSectionSystem   = "Система"
+    override val serverSettingsSectionMods     = "Модификации"
     override val serverSettingsRam             = "ОЗУ"
     override fun serverSettingsRamValue(mb: Int) = "ОЗУ: $mb МБ"
     override val serverSettingsJava            = "Версия Java"
@@ -115,8 +115,8 @@ object RussianStrings : AppStrings {
 
     // Update
     override val updateTitle           = "Доступно обновление"
-    override val updateTitleCritical   = "КРИТИЧЕСКОЕ ОБНОВЛЕНИЕ"
-    override val updateTitleMandatory  = "ОБЯЗАТЕЛЬНОЕ ОБНОВЛЕНИЕ"
+    override val updateTitleCritical   = "Критическое обновление"
+    override val updateTitleMandatory  = "Обязательное обновление"
     override val updateCriticalBanner  = "Это обновление содержит критические исправления безопасности."
     override val updateMandatoryBanner =
         "Совместимость со старыми версиями нарушена на стороне сервера. Запуск без обновления невозможен."
@@ -128,7 +128,7 @@ object RussianStrings : AppStrings {
     override val updateLater           = "Позже"
     override val updateExit            = "Выйти"
     override val updateDownload        = "Скачать и установить"
-    override val updateDownloadNow     = "СКАЧАТЬ СЕЙЧАС"
+    override val updateDownloadNow     = "Скачать сейчас"
     override val updateDownloading     = "Загрузка..."
     override val updateInstall         = "Установить и перезапустить"
     override val updateRetry           = "Повторить"
@@ -207,22 +207,22 @@ object RussianStrings : AppStrings {
     // =========================================================================
     // Custom Background
     // =========================================================================
-    override val backgroundTitle          = "ПОЛЬЗОВАТЕЛЬСКИЙ ФОН"
+    override val backgroundTitle          = "Пользовательский фон"
     override val backgroundSubtitle       = "Настройте обои лаунчера"
     override val backgroundEnable         = "Включить"
-    override val backgroundSectionImage   = "ИЗОБРАЖЕНИЕ"
+    override val backgroundSectionImage   = "Изображение"
     override val backgroundPickFile       = "Выберите изображение для фона"
     override val backgroundPickButton     = "Выбрать файл"
-    override val backgroundSectionScale   = "МАСШТАБИРОВАНИЕ"
+    override val backgroundSectionScale   = "Масштабирование"
     override val backgroundScaleCover     = "Заполнить"
     override val backgroundScaleContain   = "Вписать"
     override val backgroundScaleStretch   = "Растянуть"
     override val backgroundScaleOriginal  = "Оригинал"
     override val backgroundScaleTile      = "Плитка"
-    override val backgroundSectionPosition = "ПОЗИЦИЯ"
+    override val backgroundSectionPosition = "Позиция"
     override val backgroundAlignX         = "Горизонтально"
     override val backgroundAlignY         = "Вертикально"
-    override val backgroundSectionEffects = "ЭФФЕКТЫ"
+    override val backgroundSectionEffects = "Эффекты"
     override val backgroundBlur           = "Размытие"
     override val backgroundDarken         = "Затемнение"
     override val backgroundOpacity        = "Прозрачность"
@@ -230,7 +230,7 @@ object RussianStrings : AppStrings {
     override val backgroundParallax       = "Параллакс"
     override val backgroundVignette       = "Виньетка"
     override val backgroundAnimationSpeed = "Скорость анимации"
-    override val backgroundSectionTint    = "ЦВЕТОВОЙ ОТТЕНОК"
+    override val backgroundSectionTint    = "Цветовой оттенок"
     override val backgroundTintNone       = "Нет"
     override val backgroundTintNavy       = "Тёмно-синий"
     override val backgroundTintViolet     = "Фиолет"
@@ -239,7 +239,7 @@ object RussianStrings : AppStrings {
     override val backgroundTintSteel      = "Сталь"
     override val backgroundTintIntensity  = "Интенсивность"
     override val backgroundReset          = "Сбросить к значениям по умолчанию"
-    override val backgroundPreview        = "ПРЕДПРОСМОТР"
+    override val backgroundPreview        = "Предпросмотр"
     override val backgroundPreviewServer  = "Пример сервера"
     override val settingsBackground       = "Пользовательский фон"
     override val settingsBackgroundSub    = "Фото или GIF на фон лаунчера"
@@ -250,11 +250,11 @@ object RussianStrings : AppStrings {
     override val aboutTitle                = "О ЛАУНЧЕРЕ"
     override fun aboutDescription(branding: String) = "Неофициальный лаунчер для $branding"
     override fun aboutBuildDate(date: String) = "Собрано: $date"
-    override val aboutSectionCreator       = "СОЗДАТЕЛЬ"
-    override val aboutSectionTechnologies  = "ТЕХНОЛОГИИ"
-    override val aboutSectionLicense       = "ЛИЦЕНЗИЯ"
+    override val aboutSectionCreator       = "Создатель"
+    override val aboutSectionTechnologies  = "Технологии"
+    override val aboutSectionLicense       = "Лицензия"
     override val aboutLicenseText          = "GPLv3 — Свободное программное обеспечение"
-    override val aboutSectionUpdates       = "ОБНОВЛЕНИЯ"
+    override val aboutSectionUpdates       = "Обновления"
     override val aboutCurrentVersion       = "Текущая версия"
     override val aboutCheckUpdates         = "Проверить обновления"
     override val aboutChecking             = "Проверяем..."
@@ -262,9 +262,9 @@ object RussianStrings : AppStrings {
     override val aboutCheckAgain           = "Проверить ещё раз"
     override fun aboutUpdateAvailable(version: String) = "Доступна версия $version"
     override val aboutCriticalUpdate       = "Критическое обновление"
-    override val aboutSectionSystem        = "СИСТЕМА"
+    override val aboutSectionSystem        = "Система"
     override val aboutOs                   = "ОС"
-    override val aboutSectionLinks         = "ССЫЛКИ"
+    override val aboutSectionLinks         = "Ссылки"
     override val aboutLinkGithub           = "GitHub"
     override val aboutLinkBugReport        = "Сообщить о баге"
     override val aboutLinkReleases         = "Релизы"
@@ -520,15 +520,15 @@ object RussianStrings : AppStrings {
     override val customizationGlassIntensity  = "Плотность стекла"
     override val customizationAccentOverride  = "Свой акцент"
     override val customizationAccentClear     = "Сбросить акцент"
-    override val customizationSectionVisual   = "ВИЗУАЛ"
-    override val customizationSectionColors   = "ПЕРЕОПРЕДЕЛЕНИЕ ЦВЕТОВ"
+    override val customizationSectionVisual   = "Визуал"
+    override val customizationSectionColors   = "Переопределение цветов"
     override val customizationExperimentalToggle = "Переопределять все цвета"
     override val customizationExperimentalSub    = "Открыть матрицу из 7 цветов. Легко сделать нечитаемые сочетания."
     override val customizationReset           = "Сбросить всё"
     override val customizationHexInvalid      = "Неверный hex"
     override val themePickerAccentOverride    = "Свой акцент (применяется сразу)"
 
-    override val browseTitle        = "КАТАЛОГ"
+    override val browseTitle        = "Каталог"
     override val browseSubtitle     = "Сборки опубликованные на зеркале"
     override val browseEmptyTitle   = "Каталог пуст"
     override val browseEmptyMessage = "Зеркало доступно, но пока не публикует сборки. Загляни позже."
@@ -540,7 +540,7 @@ object RussianStrings : AppStrings {
     override val browseDetailErrorMessage  = "Не удалось получить manifest. Проверь соединение и повтори."
     override val browseDetailInstallReady  = "Готово к установке"
     override val browseDetailInstallHint   = "Создаст новый instance в твоей data-папке."
-    override val browseDetailInstallButton = "УСТАНОВИТЬ"
+    override val browseDetailInstallButton = "Установить"
     override val browseDetailTagsTitle     = "Теги"
     override val browseDetailAboutTitle       = "О сборке"
     override val browseDetailAboutPlaceholder = "Сборка включает %d модов и %d ассетов."
@@ -556,7 +556,7 @@ object RussianStrings : AppStrings {
     override val browseDetailInstallStarting      = "Запуск..."
     override val browseDetailInstallDoneTitle     = "Установлено"
     override val browseDetailInstallDoneHint      = "Добавлено в Library."
-    override val browseDetailInstallOpenLibrary   = "ОТКРЫТЬ В LIBRARY"
+    override val browseDetailInstallOpenLibrary   = "Открыть в Library"
     override val browseDetailInstallFailedTitle   = "Ошибка установки"
     override val browseDetailInstallFailedGeneric = "Установка не удалась по неизвестной причине."
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerDetailScreen.kt
@@ -99,7 +99,7 @@ fun ServerDetailScreen(
                     // Left: text
                     Column(Modifier.weight(1.5f).padding(32.dp)) {
                         Text(
-                            text       = server.title?.uppercase() ?: server.name,
+                            text       = server.title ?: server.name,
                             style      = MaterialTheme.typography.displaySmall,
                             fontWeight = FontWeight.Black,
                             color      = CelestiaTheme.colors.textPrimary

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerSettingsScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/ServerSettingsScreen.kt
@@ -252,7 +252,7 @@ fun ServerSettingsScreen(server: ServerProfile, onBack: () -> Unit) {
             Spacer(Modifier.width(12.dp))
 
             Column {
-                Text(server.title?.uppercase() ?: "SERVER", style = MaterialTheme.typography.headlineSmall, color = CelestiaTheme.colors.textPrimary)
+                Text(server.title ?: "Server", style = MaterialTheme.typography.headlineSmall, color = CelestiaTheme.colors.textPrimary)
                 Text(s.serverSettingsSubtitle, style = MaterialTheme.typography.bodySmall, color = CelestiaTheme.colors.textSecondary)
             }
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/browse/BrowsePackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/browse/BrowsePackDetailScreen.kt
@@ -510,7 +510,7 @@ private fun MetaRow(label: String, value: String) {
 private fun Section(title: String, content: @Composable () -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(
-            text          = title.uppercase(),
+            text          = title,
             style         = MaterialTheme.typography.titleSmall,
             color         = CelestiaTheme.colors.primary,
             fontWeight    = FontWeight.Bold,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
@@ -226,7 +226,7 @@ private fun PlayBar(pack: PackInstance, onPlay: () -> Unit) {
 private fun Section(title: String, content: @Composable () -> Unit) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(
-            text       = title.uppercase(),
+            text       = title,
             style      = MaterialTheme.typography.titleSmall,
             color      = CelestiaTheme.colors.primary,
             fontWeight = FontWeight.Bold,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsHelpers.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsHelpers.kt
@@ -50,7 +50,7 @@ internal fun settingsRowBackground(): androidx.compose.ui.graphics.Color =
 @Composable
 internal fun SettingsSectionTitle(text: String) {
     Text(
-        text.uppercase(),
+        text,
         style      = MaterialTheme.typography.bodySmall,
         color      = CelestiaTheme.colors.primary,
         fontWeight = FontWeight.Bold


### PR DESCRIPTION
## What

Real-user feedback flagged the launcher's use of ALL CAPS in buttons / screen titles / section headers as "немного странно". Russian uppercase reads as **shouting** in CIS UX convention; Latin uppercase reads as 80s-shareware register against the rest of the launcher's lowercase-first text. Modrinth / Steam / most Russian-language UIs use sentence case for exactly this reason.

## Sweep

- **93 i18n entries** across en / ru / de converted to sentence case (first word capitalised, rest lowercase, proper nouns preserved). German keeps native noun capitalisation. Library / other launcher-screen proper nouns stay capitalised in context (\`"Open in Library"\`, \`"Открыть в Library"\`).
- **6 .uppercase() call sites** in code dropped -- they were forcing caps at render time on already-stored i18n strings (Section headers in BrowsePackDetail / PackDetail, the global \`SettingsSectionTitle\` helper, the \`launchRunning\` state in LaunchControlPanel, server-title in ServerDetail / ServerSettings).

## Preserved exceptions

- Acronyms: \`RAM\` / \`ОЗУ\` / \`GC\` / \`JIT\` / \`JFR\` / \`OS\` / \`ОС\`.
- Single-letter avatar initials (\`AccountPanel\`, \`SquareServerCard\`).
- \`replaceFirstChar { it.uppercase() }\` in \`CustomizationExtensionScreen\` -- sentence-cases a single word, that's the desired pattern, not the anti-pattern.

## Going forward

Rule lives in \`memory/feedback_no_all_caps_in_ui.md\` to prevent re-introduction in future i18n entries.

## Test plan

- [ ] Launch the app, scan each screen for screaming text -- none should be present.
- [ ] RU locale especially: buttons / section headers all read in sentence case.
- [ ] DE locale: nouns still capitalised mid-sentence ("Globale Einstellungen").