### PR TITLE
fix(tray): seed menu from disk cache before init

### DIFF
--- a/client-config/src/main/kotlin/hivens/config/Storage.kt
+++ b/client-config/src/main/kotlin/hivens/config/Storage.kt
@@ -7,4 +7,5 @@ object Storage {
     const val HASH_CACHE_FILE       = "smarty_hash.cache"
     const val PROTECTED_PATHS_FILE  = "protected-paths.json"
     const val PACKS_FILE            = "packs.json"
+    const val SERVERS_CACHE_FILE    = "servers-cache.json"
 }

--- a/client-launcher/src/main/kotlin/hivens/launcher/ServerListCacheStore.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/ServerListCacheStore.kt
@@ -1,0 +1,110 @@
+package hivens.launcher
+
+import hivens.core.api.model.ServerProfile
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * Disk snapshot of the most recently fetched dashboard server list.
+ *
+ * Read synchronously at process startup so the tray menu's first
+ * published DBusMenu layout already carries real servers, not the
+ * "(No servers)" placeholder users see when they right-click during
+ * the 0.5-3s window between [TrayManager.init] and the first
+ * successful [SmartyCraftServerListService.fetchDashboardData].
+ *
+ * Stale-while-revalidate: cached entries seed the tray; the live
+ * fetch then overwrites both the in-memory state and the cache.
+ * First-ever launch (no cache file yet) still shows the empty
+ * fallback -- honest, because we genuinely don't know the list yet.
+ */
+interface ServerListCacheStore {
+
+    /** Synchronous load. Safe to call before any background scheduler is up. */
+    fun load(): List<ServerProfile>
+
+    /** Atomic write. Invoked from a background coroutine after each successful fetch. */
+    suspend fun save(servers: List<ServerProfile>)
+
+    /**
+     * Discardable cache. Used by unit tests that exercise unrelated
+     * behaviour (single-flight, in-memory caching) and don't want
+     * to set up a temp file.
+     */
+    object NoOp : ServerListCacheStore {
+        override fun load(): List<ServerProfile> = emptyList()
+        override suspend fun save(servers: List<ServerProfile>) = Unit
+    }
+}
+
+/**
+ * JSON-on-disk [ServerListCacheStore].
+ *
+ * Wire format:
+ * ```
+ * { "schema_version": 1, "servers": [ <ServerProfile>, ... ] }
+ * ```
+ *
+ * The versioned envelope mirrors [JsonPackRepository] so the same
+ * schema-evolution story applies: a future bump branches on
+ * `schema_version` cleanly instead of guessing whether a bare array
+ * is "valid empty" or "v0 corruption".
+ *
+ * Behaviour contract:
+ *  - Missing file -> empty list, no log noise (cold start).
+ *  - Malformed JSON -> empty list AND error logged. The launcher
+ *    must not die on a half-written cache; the worst real cost is
+ *    the user seeing "(No servers)" on the next right-click until
+ *    the live fetch arrives.
+ *  - Save writes through a `<file>.tmp` rename so a crash mid-write
+ *    leaves either the previous valid cache or the new one, never
+ *    a half-baked file.
+ */
+class JsonServerListCacheStore(
+    private val file: Path,
+    private val json: Json,
+) : ServerListCacheStore {
+
+    private val log = LoggerFactory.getLogger(JsonServerListCacheStore::class.java)
+
+    override fun load(): List<ServerProfile> {
+        if (!Files.exists(file)) return emptyList()
+        return try {
+            json.decodeFromString<ServersCacheFile>(Files.readString(file)).servers
+        } catch (e: Exception) {
+            log.error("Failed to load servers cache at {} -- starting empty", file, e)
+            emptyList()
+        }
+    }
+
+    override suspend fun save(servers: List<ServerProfile>) {
+        withContext(Dispatchers.IO) {
+            try {
+                Files.createDirectories(file.parent)
+                val tmp = file.resolveSibling("${file.fileName}.tmp")
+                val snapshot = ServersCacheFile(schemaVersion = SCHEMA_VERSION, servers = servers)
+                Files.writeString(tmp, json.encodeToString(snapshot))
+                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+            } catch (e: Exception) {
+                log.error("Failed to persist servers cache at {}", file, e)
+            }
+        }
+    }
+
+    @Serializable
+    private data class ServersCacheFile(
+        @SerialName("schema_version") val schemaVersion: Int,
+        val servers: List<ServerProfile>,
+    )
+
+    private companion object {
+        const val SCHEMA_VERSION = 1
+    }
+}

--- a/client-launcher/src/main/kotlin/hivens/launcher/SmartyCraftServerListService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/SmartyCraftServerListService.kt
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture
 class SmartyCraftServerListService(
     private val repository: ServerRepository,
     private val protocolConfig: ServerProtocolConfig = ServerProtocolConfig(),
+    private val cache: ServerListCacheStore = ServerListCacheStore.NoOp,
 ) : IServerListService {
 
     private val logger = LoggerFactory.getLogger(SmartyCraftServerListService::class.java)
@@ -77,6 +78,11 @@ class SmartyCraftServerListService(
                     val data = DashboardData(servers, news)
                     if (servers.isNotEmpty()) {
                         synchronized(lock) { cachedData = data }
+                        // Disk cache feeds [TrayManager] at the next launch
+                        // before the network round-trip; only persist on
+                        // success so a transient outage cannot overwrite
+                        // the last-known-good list with an empty one.
+                        cache.save(servers)
                     }
                     data
                 } catch (e: Exception) {

--- a/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/di/Modules.kt
@@ -411,7 +411,18 @@ val appModule = module {
         AuthService(get<IServerProtocol>(named("insecure")))
     }
 
-    single<IServerListService> { SmartyCraftServerListService(get(), get()) }
+    // Cache feeds the tray menu's first published DBusMenu layout before
+    // the live fetch returns -- see [ServerListCacheStore] KDoc for the
+    // "(No servers)" placeholder bug it fixes.
+    single<ServerListCacheStore> {
+        val dataDir: Path = get()
+        JsonServerListCacheStore(
+            file = dataDir.resolve(Storage.SERVERS_CACHE_FILE),
+            json = get(),
+        )
+    }
+
+    single<IServerListService> { SmartyCraftServerListService(get(), get(), get()) }
 
     // JSON-on-disk pack registry. Persists installed PackInstances
     // to <dataDir>/packs.json so Library reflects real state across

--- a/client-launcher/src/test/kotlin/hivens/launcher/JsonServerListCacheStoreTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/JsonServerListCacheStoreTest.kt
@@ -1,0 +1,144 @@
+package hivens.launcher
+
+import hivens.core.api.model.ServerProfile
+import hivens.core.api.model.ServerSource
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class JsonServerListCacheStoreTest {
+
+    private lateinit var tmpDir: Path
+    private lateinit var file: Path
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    @BeforeTest
+    fun setUp() {
+        tmpDir = Files.createTempDirectory("servers-cache-test")
+        tmpDir.toFile().deleteOnExit()
+        file = tmpDir.resolve("servers-cache.json")
+    }
+
+    @AfterTest
+    fun tearDown() {
+        tmpDir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun `missing file -- load returns empty without raising`() {
+        assertFalse(Files.exists(file))
+        val store = JsonServerListCacheStore(file, json)
+        assertEquals(emptyList(), store.load())
+    }
+
+    @Test
+    fun `save then reload returns the same servers`() = runBlocking {
+        val store = JsonServerListCacheStore(file, json)
+        val servers = listOf(
+            sampleServer("industrial", "Industrial"),
+            sampleServer("survival", "Survival"),
+        )
+        store.save(servers)
+
+        val reloaded = JsonServerListCacheStore(file, json)
+        assertEquals(servers, reloaded.load())
+    }
+
+    @Test
+    fun `save replaces previous contents, does not append`() = runBlocking {
+        val store = JsonServerListCacheStore(file, json)
+        store.save(listOf(sampleServer("a", "Alpha")))
+        store.save(listOf(sampleServer("b", "Beta")))
+
+        val reloaded = JsonServerListCacheStore(file, json).load()
+        assertEquals(1, reloaded.size)
+        assertEquals("b", reloaded[0].name)
+    }
+
+    @Test
+    fun `save with empty list persists empty`() = runBlocking {
+        val store = JsonServerListCacheStore(file, json)
+        store.save(listOf(sampleServer("a", "Alpha")))
+        store.save(emptyList())
+
+        // Production code never calls save() with empty -- the call site
+        // guards on `if (servers.isNotEmpty())` so a transient outage
+        // does not wipe the cache. This test pins the contract that the
+        // store itself does NOT add a defensive empty-guard; the guard
+        // belongs to the caller. If a future caller wants to wipe the
+        // cache, save(emptyList()) is the way.
+        val reloaded = JsonServerListCacheStore(file, json).load()
+        assertEquals(emptyList(), reloaded)
+    }
+
+    @Test
+    fun `corrupt file -- load returns empty rather than crashing`() {
+        Files.writeString(file, "{this is not valid json")
+        val store = JsonServerListCacheStore(file, json)
+        // Loud failure here would block tray init at startup. The cache
+        // recoverably degrades to "no seed" instead -- the live fetch
+        // still runs and the cache rewrites on success.
+        assertEquals(emptyList(), store.load())
+    }
+
+    @Test
+    fun `corrupt file is overwritten on next successful save`() = runBlocking {
+        Files.writeString(file, "{garbage")
+        val store = JsonServerListCacheStore(file, json)
+        store.save(listOf(sampleServer("a", "Alpha")))
+
+        val reloaded = JsonServerListCacheStore(file, json).load()
+        assertEquals(1, reloaded.size)
+    }
+
+    @Test
+    fun `atomic write does not leave a tmp sibling behind`() = runBlocking {
+        val store = JsonServerListCacheStore(file, json)
+        store.save(listOf(sampleServer("a", "Alpha")))
+
+        val tmp = file.resolveSibling("${file.fileName}.tmp")
+        assertFalse(Files.exists(tmp), "tmp file should be moved into place, not left behind")
+    }
+
+    @Test
+    fun `persisted file is wrapped in versioned envelope`() = runBlocking {
+        val store = JsonServerListCacheStore(file, json)
+        store.save(listOf(sampleServer("a", "Alpha")))
+        val text = Files.readString(file)
+        assertTrue("schema_version" in text, "expected schema_version envelope in $text")
+        assertTrue("servers" in text, "expected servers array in $text")
+    }
+
+    @Test
+    fun `save creates parent directories if absent`() = runBlocking {
+        val nested = tmpDir.resolve("nested/deep/servers-cache.json")
+        val store = JsonServerListCacheStore(nested, json)
+        store.save(listOf(sampleServer("a", "Alpha")))
+        assertTrue(Files.exists(nested))
+    }
+
+    @Test
+    fun `NoOp load returns empty and save is a no-op`() = runBlocking {
+        val noop = ServerListCacheStore.NoOp
+        assertEquals(emptyList(), noop.load())
+        noop.save(listOf(sampleServer("a", "Alpha")))
+        assertEquals(emptyList(), noop.load())
+    }
+
+    private fun sampleServer(id: String, title: String) = ServerProfile(
+        name      = id,
+        title     = title,
+        version   = "1.12.2",
+        ip        = "127.0.0.1",
+        port      = 25566,
+        assetDir  = id,
+        source    = ServerSource.Smartycraft,
+    )
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -27,6 +27,7 @@ import hivens.core.data.HomeView
 import hivens.core.data.SessionData
 import hivens.core.data.UiStyle
 import hivens.launcher.AutoSyncService
+import hivens.launcher.ServerListCacheStore
 import hivens.launcher.bootstrap.AutoLoginCoordinator
 import hivens.launcher.bootstrap.LauncherBootstrap
 import hivens.launcher.CredentialsManager
@@ -140,6 +141,7 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
     val windowState      = rememberWindowState(placement = WindowPlacement.Maximized)
     val settingsService: ISettingsService      = koinInject()
     val serverListService: IServerListService  = koinInject()
+    val serverListCache: ServerListCacheStore  = koinInject()
     val controller: LauncherController         = koinInject()
     val credentialsManager: CredentialsManager = koinInject()
     val authService: IAuthService              = koinInject()
@@ -261,6 +263,18 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
         // ── Tray init on background thread ────────────────────────────
         LaunchedEffect(Unit) {
             withContext(Dispatchers.IO) {
+                // Stale-while-revalidate: seed [TrayManager] from the disk
+                // cache BEFORE init() so libtray's first published DBusMenu
+                // layout already carries real servers. Without this seed,
+                // a user right-clicking the tray icon during the 0.5-3s
+                // window before [fetchDashboardData] returns sees the
+                // "(No servers)" placeholder and concludes the tray is
+                // broken. The live fetch below overwrites the seed.
+                val cachedServers = serverListCache.load()
+                if (cachedServers.isNotEmpty()) {
+                    TrayManager.updateServers(cachedServers)
+                }
+
                 try {
                     val iconBytes = Res.readBytes("drawable/favicon.png")
                     TrayManager.init(


### PR DESCRIPTION
## Summary

- Persist the last successful dashboard server list to `<dataDir>/servers-cache.json` (versioned envelope, atomic write through `<file>.tmp` rename).
- Load synchronously before `TrayManager.init` so libtray's first published DBusMenu layout already carries real servers instead of the "(No servers)" placeholder.
- Live `fetchDashboardData` then overwrites both in-memory state and the cache. Failed fetches do not touch the cache, so a transient outage cannot wipe the last-known-good list.

## Why

Tray init runs on the background thread immediately, but the server list arrives only after the 0.5-3s network round-trip to SC. A user right-clicking the icon in that window sees `Show / Console / Servers > (No servers) / Exit` and concludes the tray is broken. Cache restore closes that window for every launch after the first.

## Behaviour

- First-ever launch (no cache file): still shows the empty fallback. Honest, because we genuinely don't know the list yet.
- Subsequent launches: instant population from cache, refreshed by the live fetch when it returns.
- Corrupt cache: logged + empty list, launcher continues. The next successful fetch overwrites.

## Test plan

- [ ] Cold start with empty `<dataDir>/servers-cache.json`: tray menu shows empty, then populates after fetch
- [ ] Cold start with populated cache: tray menu shows cached servers immediately on right-click, refreshes when fetch lands
- [ ] Cold start with disconnected network: tray menu shows cached servers, no crash
- [ ] Manual corruption of `servers-cache.json`: launcher boots, log warns, tray menu shows empty until next successful fetch