### PR TITLE
feat(smrt-spec): rich pack metadata + per-mod dep DAG + role grouping

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/api/dto/smrt/SmrtManifest.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/dto/smrt/SmrtManifest.kt
@@ -75,6 +75,13 @@ sealed class SmrtSource {
 /**
  * Advisory display metadata. All fields optional; a launcher renders
  * sensible defaults derived from filename / dest when absent.
+ *
+ * [iconUrl], [role], and [requires] enable richer browse/library UX:
+ * per-item icons, role-grouped pickers ("Recipe viewer" with a JEI ⇄
+ * REI ⇄ EMI dropdown), and a dependency DAG the launcher can render
+ * as a tree under each mod row. All three additive -- a manifest
+ * without them parses cleanly and the launcher falls back to its
+ * current rendering.
  */
 @Serializable
 data class SmrtDisplay(
@@ -84,8 +91,51 @@ data class SmrtDisplay(
     @SerialName("incompatible_with") val incompatibleWith: List<String> = emptyList(),
     val license: String? = null,
     val url: String? = null,
+    /**
+     * Per-item icon. Mirror serves directly for smrt_cache / smrt_static
+     * entries; Modrinth-sourced entries leave this null and the launcher
+     * resolves the project icon via the source's `project_id` on first
+     * render (Coil caches the result).
+     */
+    @SerialName("icon_url") val iconUrl: String? = null,
+    /**
+     * Short tag for grouping interchangeable mods. Launcher renders all
+     * mods with the same role as a single dropdown ("Recipe viewer: JEI
+     * [v]" lets the user swap to REI / JER / EMI). Canonical values are
+     * mirror-curated; the launcher does not enumerate them.
+     */
+    val role: String? = null,
+    /**
+     * DAG of same-manifest dependencies. Resolver validates every entry's
+     * `filename` references an actual mods[] entry; missing references
+     * surface as broken-manifest warnings at install time.
+     */
+    val requires: List<SmrtRequirement> = emptyList(),
 )
 
+/**
+ * Single edge in a mod's dependency DAG. [filename] points at another
+ * entry in the same manifest's mods[] list. [versionRange] follows
+ * Maven-style range syntax (`>=4.0`, `[1.0,2.0)`); null means "any
+ * version present is acceptable". [optional] = true means the consumer
+ * works without the dep but works better with it -- the launcher shows
+ * it greyed-out in the dep tree.
+ */
+@Serializable
+data class SmrtRequirement(
+    val filename: String,
+    @SerialName("version_range") val versionRange: String? = null,
+    val optional: Boolean = false,
+)
+
+/**
+ * Catalogue card payload for the Browse surface.
+ *
+ * [iconUrl] / [bannerUrl] / [galleryUrls] / [descriptionMd] are the
+ * "polish layer" -- a tagline-only catalogue reads as scaffolding even
+ * when the engine underneath is solid. All four optional, additive,
+ * and mirror-authored per pack release.
+ */
 @Serializable
 data class SmrtPackSummary(
     @SerialName("pack_id") val packId: String,
@@ -95,6 +145,14 @@ data class SmrtPackSummary(
     @SerialName("latest_pack_version") val latestPackVersion: String,
     val tags: List<String> = emptyList(),
     val featured: Boolean = false,
+    /** Square pack icon. Renders in BrowsePackCard avatar slot + BrowsePackDetail hero. */
+    @SerialName("icon_url") val iconUrl: String? = null,
+    /** Wide hero image. Renders behind BrowsePackDetail hero text; falls back to the mirror gradient when absent. */
+    @SerialName("banner_url") val bannerUrl: String? = null,
+    /** Optional marketing screenshots. Rendered in a horizontal scroller on BrowsePackDetail when non-empty. */
+    @SerialName("gallery_urls") val galleryUrls: List<String> = emptyList(),
+    /** Long-form CommonMark description for the BrowsePackDetail About section. HTML is not parsed. */
+    @SerialName("description_md") val descriptionMd: String? = null,
 )
 
 @Serializable

--- a/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtManifestParseTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/smrt/SmrtManifestParseTest.kt
@@ -1,10 +1,12 @@
 package hivens.launcher.smrt
 
 import hivens.core.api.dto.smrt.SmrtPackManifest
+import hivens.core.api.dto.smrt.SmrtPackSummary
 import hivens.core.api.dto.smrt.SmrtSource
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -42,6 +44,15 @@ class SmrtManifestParseTest {
         assertNotNull(modrinthMod.display)
         assertEquals("Appleskin", modrinthMod.display!!.name)
         assertEquals("performance", modrinthMod.display!!.category)
+        // Rich display fields round-trip
+        assertEquals("https://cdn.modrinth.com/data/EsAfCjCV/icon.png", modrinthMod.display!!.iconUrl)
+        assertEquals("recipe_viewer", modrinthMod.display!!.role)
+        assertEquals(1, modrinthMod.display!!.requires.size)
+        modrinthMod.display!!.requires[0].let { req ->
+            assertEquals("AdvancedMachines.jar", req.filename)
+            assertEquals(">=1.0", req.versionRange)
+            assertFalse(req.optional)
+        }
 
         val cacheMod = pm.mods.first { it.filename == "AdvancedMachines.jar" }
         val cacheSrc = cacheMod.source
@@ -57,6 +68,54 @@ class SmrtManifestParseTest {
         // URL must be percent-encoded (smrt-pack fix for spaces in rel_path)
         assertTrue(staticSrc.url.contains("%20"),
             "smrt_static URL must percent-encode spaces; got: ${staticSrc.url}")
+    }
+
+    @Test
+    fun `parses pack summary with rich metadata`() {
+        val payload = """
+        {
+            "pack_id": "Industrial",
+            "display_name": "Industrial",
+            "tagline": "Heavy industry and automation.",
+            "minecraft_version": "1.12.2",
+            "latest_pack_version": "2026.05.22.9",
+            "tags": ["industry", "automation"],
+            "featured": true,
+            "icon_url": "https://smrt.hivens.dev/v1/packs/Industrial/static/_nexira/icon.png",
+            "banner_url": "https://smrt.hivens.dev/v1/packs/Industrial/static/_nexira/banner.png",
+            "gallery_urls": [
+                "https://smrt.hivens.dev/v1/packs/Industrial/static/_nexira/g1.png",
+                "https://smrt.hivens.dev/v1/packs/Industrial/static/_nexira/g2.png"
+            ],
+            "description_md": "# Industrial\n\nLong-form pack copy."
+        }
+        """.trimIndent()
+        val s: SmrtPackSummary = json.decodeFromString(payload)
+        assertEquals("Industrial", s.packId)
+        assertEquals("https://smrt.hivens.dev/v1/packs/Industrial/static/_nexira/icon.png", s.iconUrl)
+        assertEquals("https://smrt.hivens.dev/v1/packs/Industrial/static/_nexira/banner.png", s.bannerUrl)
+        assertEquals(2, s.galleryUrls.size)
+        assertTrue(s.descriptionMd!!.startsWith("# Industrial"))
+    }
+
+    @Test
+    fun `parses pack summary without rich metadata`() {
+        // Mirror manifests authored before the rich-metadata extension still
+        // parse with all new fields defaulted to null / empty.
+        val bare = """
+        {
+            "pack_id": "Bare",
+            "display_name": "Bare",
+            "tagline": "",
+            "minecraft_version": "1.12.2",
+            "latest_pack_version": "2026.06.01"
+        }
+        """.trimIndent()
+        val s: SmrtPackSummary = json.decodeFromString(bare)
+        assertNull(s.iconUrl)
+        assertNull(s.bannerUrl)
+        assertTrue(s.galleryUrls.isEmpty())
+        assertNull(s.descriptionMd)
     }
 
     @Test
@@ -124,7 +183,12 @@ class SmrtManifestParseTest {
                     "name": "Appleskin",
                     "description": "Hunger and saturation visualization.",
                     "category": "performance",
-                    "url": "https://modrinth.com/mod/appleskin"
+                    "url": "https://modrinth.com/mod/appleskin",
+                    "icon_url": "https://cdn.modrinth.com/data/EsAfCjCV/icon.png",
+                    "role": "recipe_viewer",
+                    "requires": [
+                        {"filename": "AdvancedMachines.jar", "version_range": ">=1.0", "optional": false}
+                    ]
                 }
             },
             {


### PR DESCRIPTION
## Summary

Additive v2-manifest extensions, all nullable / default-empty so the existing mirror manifests parse unchanged.

### SmrtDisplay (per-mod / per-asset)

- `icon_url` — per-item icon URL. Modrinth-sourced entries can omit; the launcher resolves via the source's `project_id` and caches through Coil.
- `role` — short tag like `recipe_viewer`, `minimap`, `waila`. Launcher groups same-role entries into a single dropdown ("Recipe viewer: JEI [v]" with REI / JER / EMI alternatives).
- `requires` — per-mod dependency DAG against same-manifest filenames. Each `SmrtRequirement` carries `filename` + Maven-style `version_range` + `optional` flag.

### SmrtPackSummary (per-pack)

- `icon_url` — square card icon (Browse + hero slot)
- `banner_url` — wide hero
- `gallery_urls` — marketing screenshots
- `description_md` — long-form CommonMark for the About block

### New type

`SmrtRequirement` — single edge in a dep DAG.

## Why this shape

- **`role` over `interchangeable_with`** — mirror groups by role on its side; launcher just reads "all entries with role=X" rather than reconciling N×N lists. Per project direction "missing on mirror → modify mirror, don't write workarounds in the launcher".
- **Nullable / default-empty everywhere** — existing manifests parse as-is; no schema_version bump required.
- **No UI consumption in this PR** — BrowsePackCard / BrowsePackDetail / BrowseScreen keep current renders. The new fields feed the upcoming Library PackDetail rework (Content tab with mod browser + dep tree + role-swap UX).

## Test plan

- [x] `parses manifest with all three source types` extended with new SmrtDisplay fields on one entry (assertions for icon_url, role, requires)
- [x] New `parses pack summary with rich metadata` covering all four pack-level fields
- [x] New `parses pack summary without rich metadata` pinning back-compat (all new fields default null / empty)
- [x] Existing `tolerates absent display block and unknown fields` still passes (display block remains fully optional)