### PR TITLE
fix(window): apply prophylactic min-size clamped to screen

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/platform/WindowMinSize.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/platform/WindowMinSize.kt
@@ -1,0 +1,31 @@
+package hivens.launcher.platform
+
+import java.awt.Dimension
+
+/**
+ * Clamps a design-intent minimum-size to a safe fraction of the user's
+ * native screen so a small laptop (e.g. 1366x768) does not end up with
+ * a minimum the user cannot actually shrink the window down to.
+ *
+ * The launcher's 2-column Library + sidebar layout breaks below roughly
+ * 960dp width / 600dp height; that's the design intent the caller is
+ * expected to pass in -- already density-converted to raw pixels via
+ * the Compose [androidx.compose.ui.platform.LocalDensity]. If the
+ * user's screen is smaller than the intent in either dimension, the
+ * intent gets clamped to [maxScreenFraction] of the available screen
+ * so the user retains headroom to drag the window edges.
+ *
+ * AWT's `Window.setMinimumSize` is a hint -- floating WMs (KDE, GNOME,
+ * Win11, macOS Quartz) respect it; tiling WMs (Sway, Hyprland) and
+ * some QML widget compositors typically override it entirely, in which
+ * case this function still runs cheaply and harmlessly.
+ */
+fun computeSafeWindowMinSize(
+    designWidthPx: Int,
+    designHeightPx: Int,
+    screen: Dimension,
+    maxScreenFraction: Float = 0.9f,
+): Dimension = Dimension(
+    minOf(designWidthPx,  (screen.width  * maxScreenFraction).toInt()),
+    minOf(designHeightPx, (screen.height * maxScreenFraction).toInt()),
+)

--- a/client-launcher/src/test/kotlin/hivens/launcher/platform/WindowMinSizeTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/platform/WindowMinSizeTest.kt
@@ -1,0 +1,77 @@
+package hivens.launcher.platform
+
+import java.awt.Dimension
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WindowMinSizeTest {
+
+    @Test
+    fun `large screen returns the design intent unchanged`() {
+        // Roomy 4K desktop -- the 960x600 dp design intent (here passed
+        // as the already-density-resolved pixel values) is well within
+        // 90% of the screen, so no clamp happens.
+        val result = computeSafeWindowMinSize(
+            designWidthPx = 1920,
+            designHeightPx = 1200,
+            screen = Dimension(3840, 2160),
+        )
+        assertEquals(Dimension(1920, 1200), result)
+    }
+
+    @Test
+    fun `tiny screen clamps both dimensions to fraction of screen`() {
+        // 13" laptop at 1366x768 -- a 1920x1200 design intent would
+        // exceed the screen entirely. Clamp leaves the user some
+        // headroom (90% default) to drag the window edges.
+        val result = computeSafeWindowMinSize(
+            designWidthPx = 1920,
+            designHeightPx = 1200,
+            screen = Dimension(1366, 768),
+        )
+        assertEquals(Dimension((1366 * 0.9f).toInt(), (768 * 0.9f).toInt()), result)
+    }
+
+    @Test
+    fun `clamp applies per-axis -- ultrawide retains design height, clamps width only when needed`() {
+        // 1280-wide design intent fits inside a 3440x1440 ultrawide
+        // (1280 < 3440 * 0.9). Height intent 1500 exceeds 1440 * 0.9
+        // = 1296, so only the height axis is clamped.
+        val result = computeSafeWindowMinSize(
+            designWidthPx = 1280,
+            designHeightPx = 1500,
+            screen = Dimension(3440, 1440),
+        )
+        assertEquals(1280, result.width, "width fit under the cap; should not be clamped")
+        assertEquals((1440 * 0.9f).toInt(), result.height, "height exceeded the cap; should be clamped")
+    }
+
+    @Test
+    fun `maxScreenFraction = 1f never clamps unless screen is strictly smaller`() {
+        // Edge case: with fraction = 1.0 the design intent passes
+        // through unless the screen is genuinely smaller. Validates
+        // the multiplication uses Float -> Int truncation correctly
+        // at the boundary.
+        val result = computeSafeWindowMinSize(
+            designWidthPx = 1366,
+            designHeightPx = 768,
+            screen = Dimension(1366, 768),
+            maxScreenFraction = 1.0f,
+        )
+        assertEquals(Dimension(1366, 768), result)
+    }
+
+    @Test
+    fun `aggressive clamp fraction reduces minimum even on roomy screens`() {
+        // A future caller could ask for a stricter clamp (say 0.5f) to
+        // give the user even more drag room. Verify the parameter
+        // actually drives the result, not just the screen size.
+        val result = computeSafeWindowMinSize(
+            designWidthPx = 1920,
+            designHeightPx = 1200,
+            screen = Dimension(3840, 2160),
+            maxScreenFraction = 0.5f,
+        )
+        assertEquals(Dimension(1920, 1080), result, "design width fits under 50% cap; height does not")
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -9,7 +9,9 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.ApplicationScope
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPlacement
@@ -34,6 +36,7 @@ import hivens.launcher.CredentialsManager
 import hivens.launcher.launch.LaunchState
 import hivens.launcher.launch.LauncherController
 import hivens.launcher.network.ServerProtocolConfig
+import hivens.launcher.platform.computeSafeWindowMinSize
 import hivens.launcher.ProfileManager
 import hivens.ui.background.BackgroundManager
 import hivens.ui.background.CustomBackground
@@ -71,8 +74,17 @@ import org.koin.compose.koinInject
 import org.koin.core.context.stopKoin
 import org.koin.core.qualifier.named
 import org.slf4j.LoggerFactory
+import java.awt.Dimension
+import java.awt.Toolkit
 import javax.swing.SwingUtilities
 import kotlin.time.Duration.Companion.milliseconds
+
+// 2-column Library + sidebar starts collapsing visibly below this width;
+// 600dp of height keeps PackDetail hero + sidebar both reachable. Held
+// as file-level consts so the prophylactic min-size effect inside
+// AppShell stays a one-liner.
+private const val MIN_WINDOW_WIDTH_DP  = 960
+private const val MIN_WINDOW_HEIGHT_DP = 600
 
 // ─── State ───────────────────────────────────────────────────────────────────
 
@@ -453,6 +465,25 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                     window.requestFocus()
                     window.isAlwaysOnTop = false
                 }
+            }
+
+            // Prophylactic minimum window size. Design intent is
+            // [MIN_WINDOW_WIDTH_DP] x [MIN_WINDOW_HEIGHT_DP] -- below
+            // those values multi-column screens collapse awkwardly.
+            // Clamped against the user's native screen so a small laptop
+            // can still drag the window edges. Floating WMs respect the
+            // hint; tiling WMs ignore it, which is fine.
+            val sizeDensity = LocalDensity.current
+            LaunchedEffect(Unit) {
+                val designPx = with(sizeDensity) {
+                    Dimension(
+                        MIN_WINDOW_WIDTH_DP.dp.toPx().toInt(),
+                        MIN_WINDOW_HEIGHT_DP.dp.toPx().toInt(),
+                    )
+                }
+                val screen = Toolkit.getDefaultToolkit().screenSize
+                val safe = computeSafeWindowMinSize(designPx.width, designPx.height, screen)
+                SwingUtilities.invokeLater { window.minimumSize = safe }
             }
 
             val baseDensity   = androidx.compose.ui.platform.LocalDensity.current


### PR DESCRIPTION
## Summary

The main Window had no `minimumSize` -- users could drag past the breakpoint where multi-column screens (Library + sidebar, Browse, PackDetail) collapse awkwardly. No concrete bug report driving this; it's a guardrail to set before someone hits it.

### Design

- **Intent:** 960dp x 600dp -- the breakpoint where the 2-col Library + sidebar visibly slips.
- **Clamp:** never exceed 90% of the user's native screen, so a 13" laptop at 1366x768 still has drag headroom.
- **DPI handling:** dp -> px through Compose's `LocalDensity`, so the physical size matches design intent across DPIs (4K @ 200% scaling renders the same physical minimum as 1080p @ 100%).
- **WM behaviour:** `setMinimumSize` is a hint. Floating WMs (KDE, GNOME, Win11, macOS Quartz) respect it; tiling WMs (Sway, Hyprland, Quickshell-mode) typically override it. Harmless either way.

### Code shape

- New pure function `computeSafeWindowMinSize(designW, designH, screen, frac)` in `client-launcher/.../platform/WindowMinSize.kt` -- testable without spinning up AWT or Compose.
- `LaunchedEffect` inside the `Window {}` block resolves the design intent through `LocalDensity`, calls the pure function, and applies the result on the EDT.
- File-level `MIN_WINDOW_WIDTH_DP` / `MIN_WINDOW_HEIGHT_DP` consts so the call site stays a one-liner.

## Test plan

- [x] Unit tests cover: roomy screen passes intent through, tiny screen clamps both dimensions, per-axis clamp (one dimension fits, the other does not), boundary at `maxScreenFraction = 1.0f`, aggressive `0.5f` clamp.
- [ ] Manual: launch on a floating WM (KDE), drag window edges -- minimum honoured at design intent
- [ ] Manual: launch with `--scale-factor 2.0` (or 4K @ 200% scaling) -- physical minimum still matches the design intent visually
- [ ] Manual: launch on Hyprland -- min-size ignored, no crash, no log noise