### PR TITLE
refactor(settings): drop experimental "Hivens Mirror" toggle

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/SettingsData.kt
@@ -113,19 +113,6 @@ data class SettingsData(
     val mimicVersionOverride: String? = null,
 
     /**
-     * Route pack content delivery through the Hivens mirror
-     * (smrt.hivens.dev) instead of SmartyCraft's CDN. Auth and
-     * game-server addresses stay on SC regardless -- the mirror only
-     * publishes pack files. Currently scoped to Industrial, the sole
-     * pack with a smrt v2 manifest; other server packs ignore this
-     * flag and stay on the SC sync path. Mirror sync fails loudly on
-     * any error; there is no silent SC fallback for the affected
-     * pack, otherwise mirror regressions would hide behind a
-     * working-but-stale SC sync.
-     */
-    val experimentalMirrorEnabled: Boolean = false,
-
-    /**
      * Which Home surface to render after login. Lets the user explore
      * the new Library-first IA without committing the whole launcher
      * to it -- the toggle flips back at any time. See [HomeView] for

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -6,7 +6,6 @@ import hivens.core.api.model.ServerProfile
 import hivens.core.data.SessionData
 import hivens.core.data.SettingsData
 import hivens.core.diag.ActionRing
-import hivens.launcher.smrt.SmrtSyncService
 import hivens.launcher.CredentialsManager
 import hivens.launcher.ManifestCache
 import hivens.launcher.ProfileManager
@@ -50,7 +49,6 @@ class LauncherController(
     private val profileManager: ProfileManager,
     private val dataDirectory: Path,
     private val appScope: CoroutineScope,
-    private val smrtSyncService: SmrtSyncService,
 ) {
 
     private val logger = LoggerFactory.getLogger(LauncherController::class.java)
@@ -224,28 +222,6 @@ class LauncherController(
                         }
                     }
                     emit(LaunchLogEvent.OfflineSkipSync)
-                } else if (shouldUseMirror(settings, targetServerId)) {
-                    // Mirror sync path. Any error from the smrt side throws
-                    // through to the user; no silent fallback to the SC path,
-                    // otherwise mirror failures hide behind a working-but-
-                    // stale SC sync and the bug never surfaces.
-                    logger.info("Using Hivens Mirror for {} sync (experimental)", targetServerId)
-                    smrtSyncService.sync(
-                        packId = targetServerId,
-                        clientDir = clientDir,
-                        progress = { current, total, filename ->
-                            if (!isActive) return@sync
-                            _state.value = LaunchState.Downloading(
-                                currentFileIdx   = current,
-                                totalFiles       = total,
-                                downloadedBytes  = 0L,
-                                totalBytes       = 0L,
-                                speedBytesPerSec = 0L,
-                            )
-                            val fraction = if (total > 0) current.toFloat() / total else 0f
-                            setStage(PrepareStage.SYNC, 0.2f + 0.5f * fraction)
-                        },
-                    )
                 } else {
                     downloadService.processSession(
                         session = session,
@@ -351,24 +327,6 @@ class LauncherController(
     private fun calculateIgnoredFiles(server: ServerProfile): Set<String> {
         val userState = profileManager.getProfile(server.assetDir).optionalModsState
         return manifestProcessor.calculateIgnoredFiles(server, userState)
-    }
-
-    /**
-     * Mirror sync is gated by (a) the master experimental switch, (b) the
-     * Hivens Mirror per-feature toggle, and (c) the pack having a published
-     * smrt manifest. Only Industrial is on the mirror today, so the third
-     * gate is a hard-coded allowlist for now; a future iteration could
-     * probe `/v1/packs` instead and cache the result.
-     */
-    private fun shouldUseMirror(settings: SettingsData, serverId: String): Boolean {
-        if (!settings.experimentalFeaturesEnabled) return false
-        if (!settings.experimentalMirrorEnabled) return false
-        return serverId in MIRROR_PUBLISHED_PACKS
-    }
-
-    private companion object {
-        /** Packs we know have a v2 manifest on smrt.hivens.dev today. */
-        val MIRROR_PUBLISHED_PACKS = setOf("Industrial")
     }
 
     /**

--- a/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
@@ -15,7 +15,6 @@ import hivens.core.security.IKeyringStorage
 import hivens.launcher.CredentialsManager
 import hivens.launcher.ManifestCache
 import hivens.launcher.ProfileManager
-import hivens.launcher.smrt.SmrtSyncService
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
@@ -75,7 +74,6 @@ class LauncherControllerTest {
     private lateinit var credentialsManager: CredentialsManager
     private lateinit var manifestCache: ManifestCache
     private lateinit var profileManager: ProfileManager
-    private lateinit var smrtSyncService: SmrtSyncService
 
     private val server = ServerProfile(
         name     = "TestSrv",
@@ -97,7 +95,6 @@ class LauncherControllerTest {
         javaManagerService = mockk()
         launcherService    = mockk()
         manifestProcessor  = mockk()
-        smrtSyncService    = mockk()
 
         // Real instances: cheaper than fighting mockk on JDK 25, and the
         // default no-data behavior (empty profile map, missing manifest
@@ -129,7 +126,6 @@ class LauncherControllerTest {
         profileManager     = profileManager,
         dataDirectory      = sandbox,
         appScope           = scope,
-        smrtSyncService    = smrtSyncService,
     )
 
     @Test

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -316,8 +316,6 @@ interface AppStrings {
     val settingsAutoSyncAllPacksDesc: String
     val settingsJvmBuilder: String
     val settingsJvmBuilderDesc: String
-    val settingsExperimentalMirror: String
-    val settingsExperimentalMirrorDesc: String
     val settingsMimicVersion: String
     val settingsMimicVersionDesc: String
     /** Placeholder shown inside the mimic-version text field when override is empty. Receives the built-in default version, e.g. `Default: 3.6.5`. */

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -303,8 +303,6 @@ object EnglishStrings : AppStrings {
     override val settingsAutoSyncAllPacksDesc   = "Quietly refresh every server pack you've already installed when the launcher starts. Costs background bandwidth — useful if you switch between many servers and want fresh state without clicking each one."
     override val settingsJvmBuilder             = "Visual JVM args builder"
     override val settingsJvmBuilderDesc         = "Reveals a 'Build args' button in the per-server constructor. Pick a GC algorithm, tune heap regions, enable AppCDS or JFR profiling — without memorizing flags. Curated presets cover Aikar's recipe, GTNH-class heavy modded, ZGC for huge heaps, and more."
-    override val settingsExperimentalMirror     = "Hivens Mirror (alpha)"
-    override val settingsExperimentalMirrorDesc = "Route Industrial's pack files through smrt.hivens.dev instead of SmartyCraft's CDN. Auth and game-server addresses stay on SC; only the sync source changes. Alpha — only Industrial is published on the mirror, every other pack still syncs from SC. Loud failure on mirror error; no silent fallback to SC, so a broken mirror sync surfaces immediately rather than masking behind a working-but-stale SC sync."
     override val settingsMimicVersion           = "Mimic launcher version override"
     override val settingsMimicVersionDesc       = "Pin the version string sent to upstream in the handshake and User-Agent. Leave blank to use the shipped default — set this only when upstream has bumped its version pin faster than Nexira's release cycle. Takes effect on the next protocol call after save; no restart needed."
     override fun settingsMimicVersionPlaceholder(default: String) = "Default: $default"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -303,8 +303,6 @@ object GermanStrings : AppStrings {
     override val settingsAutoSyncAllPacksDesc   = "Aktualisiert beim Launcher-Start jedes bereits installierte Server-Pack im Hintergrund. Kostet Bandbreite — nützlich, wenn du zwischen mehreren Servern wechselst und frischen Stand ohne Klick auf jeden willst."
     override val settingsJvmBuilder             = "Visueller JVM-Argument-Builder"
     override val settingsJvmBuilderDesc         = "Zeigt einen „Argumente bauen“-Button in den Server-Einstellungen. Wähle Garbage Collector, justiere Heap-Regionen, aktiviere AppCDS oder JFR — ohne Flags auswendig zu lernen. Vorgaben: Aikar's Rezept, GTNH-Klasse, ZGC für große Heaps und mehr."
-    override val settingsExperimentalMirror     = "Hivens Mirror (alpha)"
-    override val settingsExperimentalMirrorDesc = "Pack-Dateien für Industrial über smrt.hivens.dev statt SmartyCraft's CDN abrufen. Authentifizierung und Spielserver-Adressen bleiben bei SC; nur die Sync-Quelle ändert sich. Alpha — nur Industrial ist auf dem Mirror verfügbar, jedes andere Pack läuft weiter über SC. Lauter Fehlschlag bei Mirror-Problemen; kein stiller Fallback auf SC, damit ein kaputter Mirror sofort sichtbar wird."
     override val settingsMimicVersion           = "Launcher-Version-Override"
     override val settingsMimicVersionDesc       = "Fixiert den Versions-String, der an den Upstream im Handshake und User-Agent gesendet wird. Leer lassen für den eingebauten Standard — nur setzen, wenn der Upstream seine Versions-Anforderung schneller anhebt als Nexiras Release-Zyklus. Wirkt beim nächsten Protokoll-Aufruf nach Speichern, kein Neustart nötig."
     override fun settingsMimicVersionPlaceholder(default: String) = "Standard: $default"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -304,8 +304,6 @@ object RussianStrings : AppStrings {
     override val settingsAutoSyncAllPacksDesc   = "Тихо обновлять все уже установленные сборки в фоне при старте лаунчера. Тратит фоновый трафик — полезно если играешь на нескольких серверах и хочешь свежее состояние без клика по каждому."
     override val settingsJvmBuilder             = "Визуальный конструктор JVM-аргументов"
     override val settingsJvmBuilderDesc         = "Показывает кнопку «Собрать аргументы» в настройках сервера. Выбираешь сборщик мусора, настраиваешь регионы хипа, включаешь AppCDS или JFR — без необходимости помнить флаги. Готовые пресеты: Aikar's recipe, GTNH-класс, ZGC для больших хипов и другие."
-    override val settingsExperimentalMirror     = "Hivens Mirror (alpha)"
-    override val settingsExperimentalMirrorDesc = "Качать файлы сборки Industrial через smrt.hivens.dev вместо CDN SmartyCraft. Авторизация и адреса игровых серверов идут через SC как обычно; меняется только источник синхронизации файлов. Alpha — пока только Industrial доступна на зеркале, остальные сборки качаются с SC. На любой ошибке зеркала — падаем громко с понятной ошибкой, без тихого фолбэка на SC, чтобы поломка зеркала была видна сразу."
     override val settingsMimicVersion           = "Подмена версии лаунчера"
     override val settingsMimicVersionDesc       = "Зафиксировать строку версии, которая отправляется в рукопожатии и User-Agent. Оставь пустым для стандартного значения — заполни только если апстрим успел поднять свою версию быстрее цикла релизов Nexira. Применяется на следующем запросе к протоколу после сохранения, перезапуск не требуется."
     override fun settingsMimicVersionPlaceholder(default: String) = "По умолчанию: $default"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/ExperimentalSection.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/ExperimentalSection.kt
@@ -2,7 +2,6 @@ package hivens.ui.screens.settings
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.NewReleases
 import androidx.compose.material.icons.filled.Science
 import androidx.compose.material.icons.filled.Sync
@@ -31,8 +30,8 @@ import kotlin.time.Duration.Companion.milliseconds
  * master is off, so the user can see what they're opting back into.
  *
  * Includes: mandatory-updates floor, prerelease channel, autosync,
- * JVM-args builder unlock, Hivens Mirror toggle, mimic-launcher-version
- * override (with a debounced text input revealed when its toggle is on).
+ * JVM-args builder unlock, mimic-launcher-version override (with a
+ * debounced text input revealed when its toggle is on).
  */
 @Composable
 internal fun ExperimentalSection(
@@ -115,26 +114,6 @@ internal fun ExperimentalSection(
     )
     PuppetToggle("settings.jvmBuilder", form.jvmBuilderEnabled, enabled = form.experimentalEnabled) {
         form.jvmBuilderEnabled = it; save()
-    }
-
-    Spacer(Modifier.height(4.dp))
-
-    // ── Hivens Mirror ─────────────────────────────────────────
-    // Routes Industrial's sync source to smrt.hivens.dev. Auth and
-    // game-server addresses stay on SC; only file delivery swaps.
-    // Other packs ignore the flag. Errors surface; no silent fallback
-    // to the SC sync path.
-    SettingsRowWithDescription(
-        title          = s.settingsExperimentalMirror,
-        description    = s.settingsExperimentalMirrorDesc,
-        icon           = Icons.Default.Cloud,
-        iconTint       = CelestiaTheme.colors.primary,
-        checked        = form.experimentalEnabled && form.experimentalMirror,
-        enabled        = form.experimentalEnabled,
-        onCheckedChange = { form.experimentalMirror = it; save() }
-    )
-    PuppetToggle("settings.experimentalMirror", form.experimentalMirror, enabled = form.experimentalEnabled) {
-        form.experimentalMirror = it; save()
     }
 
     Spacer(Modifier.height(4.dp))

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsFormState.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/settings/SettingsFormState.kt
@@ -36,7 +36,6 @@ internal class SettingsFormState(initial: SettingsData) {
     var prereleaseChannel      by mutableStateOf(initial.prereleaseChannelEnabled)
     var autoSyncAllPacks       by mutableStateOf(initial.autoSyncAllPacks)
     var jvmBuilderEnabled      by mutableStateOf(initial.jvmBuilderEnabled)
-    var experimentalMirror     by mutableStateOf(initial.experimentalMirrorEnabled)
     var forceProxyMode         by mutableStateOf(initial.forceProxyMode)
     var mimicOverrideEnabled   by mutableStateOf(!initial.mimicVersionOverride.isNullOrBlank())
     var mimicVersionText       by mutableStateOf(initial.mimicVersionOverride ?: "")
@@ -62,7 +61,6 @@ internal class SettingsFormState(initial: SettingsData) {
             prereleaseChannelEnabled    = prereleaseChannel,
             autoSyncAllPacks            = autoSyncAllPacks,
             jvmBuilderEnabled           = jvmBuilderEnabled,
-            experimentalMirrorEnabled   = experimentalMirror,
             forceProxyMode              = forceProxyMode,
             mimicVersionOverride        = normalisedMimic,
         )


### PR DESCRIPTION
## Summary

Removes the per-user "Hivens Mirror (alpha)" toggle in Settings → Experimental, plus its underlying flag and the mirror-sync branch it gated inside the legacy DashboardScreen launch flow.

## Why

The toggle routed Industrial's pack files through `smrt.hivens.dev` when launched from the legacy DashboardScreen. The mirror now lives entirely in **Browse + Library** as a first-class install source — mirror-installed packs always sync from the mirror, SC-installed servers always sync from SC. The dashboard-time toggle is a fossil: two paths that decide the same thing from different surfaces, with the toggle creating silent overlap and an "experimental" surface that no longer matches the architecture.

Old dashboard stays alive as before (per [[project_home_library_ia]] transition note — coexists during migration, not deleted until full move). The HomeView picker in **Settings → Appearance** already lets the user choose between **Classic** (old dashboard) and **Library First** as the landing surface, so nothing extra needs adding there.

## Removed across

- `SettingsData.experimentalMirrorEnabled` field
- `SettingsFormState.experimentalMirror` form binding
- `ExperimentalSection` "Hivens Mirror" toggle UI block (and the now-unused `Cloud` icon import + class KDoc reference)
- `LauncherController`:
  - `smrtSyncService` constructor parameter
  - `shouldUseMirror()` gate function
  - The mirror-sync branch in the launch flow
  - `MIRROR_PUBLISHED_PACKS` companion
- i18n strings: `settingsExperimentalMirror` + `settingsExperimentalMirrorDesc` in en/ru/de + `AppStrings` declarations
- `LauncherControllerTest`: `smrtSyncService` mock + ctor wiring

## Back-compat

Persisted settings with `"experimentalMirrorEnabled": true|false` still parse cleanly — the Json instance has `ignoreUnknownKeys = true`, so the unknown field is silently dropped and disappears on the next save. No migration needed.

`SmrtSyncService` stays in the Koin graph because `PackInstaller` still consumes it for Browse installs.

## Test plan

- [x] `:client-launcher:test` green (LauncherControllerTest still covers happy / offline-no-client / 2FA-expired / non-zero-exit paths; no test specifically exercised the removed mirror path)
- [x] Compile across `client-core` + `client-launcher` + `client-ui` clean
- [ ] Manual: open Settings → Experimental — Mirror toggle gone
- [ ] Manual: launch any SC server from Classic dashboard — flows through SC sync as before
- [ ] Manual: install a pack from Browse, launch from Library — flows through mirror sync as before
- [ ] Manual: load settings.json from an older version with `experimentalMirrorEnabled` present — loads cleanly, save drops the field