### PR TITLE
fix(bootstrap): re-resolve PlatformPaths after data-dir move applies

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/bootstrap/LauncherBootstrap.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/bootstrap/LauncherBootstrap.kt
@@ -69,23 +69,45 @@ object LauncherBootstrap {
         // BootstrapConf both have lazy log fields specifically so this
         // ordering works without their applyPending() / read() touching
         // logback first.
-        val paths = PlatformPaths.system()
-        System.setProperty("nexira.logs.dir", paths.logsDir.toString())
+        //
+        // The initial resolution is a temporary value: applyPending below
+        // can commit a brand-new `data-dir` into BootstrapConf, in which
+        // case the second PlatformPaths.system() call right after picks
+        // up the new path and that becomes [paths] for the rest of the
+        // session. Holding only [initialPaths] across applyPending was a
+        // race: the move would copy + commit, then the rest of preBoot
+        // (Files.createDirectories, NetworkState.initialize, Koin) used
+        // the stale captured path -- recreating an empty old dir and
+        // wiring every singleton against it. The user observed:
+        // "files moved but the launcher still uses the old (now empty)
+        // path", logged out, fresh-login surfaced trustAnchors / network
+        // errors because the cache / creds / ssl-bypasses landed at the
+        // wrong location. The re-resolve below is the fix.
+        val initialPaths = PlatformPaths.system()
+        System.setProperty("nexira.logs.dir", initialPaths.logsDir.toString())
 
         // NOW safe to apply any pending data-dir move scheduled from the
         // Settings UI. If user clicked "Move data directory" -> picker ->
         // restart, this is where the relocation actually happens. Operation
         // is idempotent; safe to call on every startup. The first log line
         // it produces (only in the actual-move case, no-op otherwise) lands
-        // in `paths.logsDir/launcher.log`, not `./logs/launcher.log`.
+        // in `initialPaths.logsDir/launcher.log`.
         //
-        // Edge case: if applyPending DOES move the data dir, paths.logsDir
+        // Edge case: if applyPending DOES move the data dir, initialPaths.logsDir
         // points at the old location and logback opens the file there --
         // log entries about the move itself stream to the old path right
-        // up until the source dir is deleted. Next startup uses the new
-        // path correctly. The user opted into this two-restart flow when
-        // they clicked Move, so the one-time misdirect is acceptable.
+        // up until the source dir is deleted. Logback's rolling-file
+        // appender keeps writing to the old (now-deleted on Linux /
+        // unlinked-but-handle-held on Windows) file for the rest of this
+        // session; the next launch starts fresh under the new path.
         DataDirMover.applyPending()
+
+        // Re-resolve so the rest of preBoot uses the post-move data-dir.
+        // No-op when applyPending didn't change anything (steady state).
+        val paths = PlatformPaths.system()
+        if (paths.dataDir != initialPaths.dataDir) {
+            System.setProperty("nexira.logs.dir", paths.logsDir.toString())
+        }
 
         // Pulse: tag every log line in this process with a stable 8-char sessionId
         // so a multi-launch user dump can be sliced per process invocation

--- a/client-launcher/src/test/kotlin/hivens/launcher/platform/DataDirMoverTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/platform/DataDirMoverTest.kt
@@ -148,6 +148,31 @@ class DataDirMoverTest {
     }
 
     @Test
+    fun `after applyPending, a fresh PlatformPaths reader sees the new data-dir`() {
+        // Regression for the stale-paths bug in LauncherBootstrap.preBoot:
+        // when a pending move applies, the rest of preBoot must re-resolve
+        // PlatformPaths so Files.createDirectories, NetworkState.initialize,
+        // SingleInstance.acquire, and Koin singletons all see the new dir
+        // instead of recreating + wiring against the now-empty old path.
+        // This test pins the underlying contract that the re-resolve relies
+        // on: applyPending commits the new dir into BootstrapConf, and a
+        // new PlatformPaths reader picks it up.
+        DataDirMover.schedule(source, target, confFile)
+        DataDirMover.applyPending(confFile)
+
+        val freshAfterApply = PlatformPaths(
+            osName = "Linux",
+            home = workDir,
+            env = { null },
+            bootstrapDataDir = { BootstrapConf.read(confFile)[BootstrapConf.KEY_DATA_DIR]?.let { java.nio.file.Paths.get(it) } },
+        )
+        assertEquals(
+            target.toAbsolutePath().normalize(),
+            freshAfterApply.dataDir.toAbsolutePath().normalize(),
+        )
+    }
+
+    @Test
     fun `NEXIRA_DATA_DIR env wins over bootstrap conf override`() {
         BootstrapConf.write(mapOf(BootstrapConf.KEY_DATA_DIR to "/tmp/conf-side"), confFile)
         val envOverride = workDir / "env-side"


### PR DESCRIPTION
## Summary

Fixes the "Move data directory" flow losing user state on the first restart after the move. Reported by the official tester on 2.3.3 Win11: after picking an empty target folder and restarting, files appeared in the new location but the launcher kept reading from a recreated-empty old location -- credentials gone, kicked from account, fresh login surfaced a downstream `trustAnchors / Network Error`.

## Root cause

`LauncherBootstrap.preBoot()` captured `PlatformPaths.system()` BEFORE calling `DataDirMover.applyPending()`. The mover did its job correctly -- copied the tree, committed the new dir into `BootstrapConf.data-dir`, deleted the source -- but the captured `paths` value still pointed at the old (now-deleted) location. The rest of `preBoot` then:

- `Files.createDirectories(paths.dataDir)` -- **recreated the old dir as empty**
- `NetworkState.initialize(paths.dataDir.resolve("ssl-bypasses.json"))` -- pointed at empty dir
- `SingleInstance.acquire(paths.dataDir)` -- locked empty dir
- `startKoin { ... }` -- wired every singleton against empty dir (data dir Koin reads via `single<Path> { get<PlatformPaths>().dataDir }`)

End result: user state effectively missing for that session. On the SECOND restart, BootstrapConf's committed `data-dir` got picked up by `PlatformPaths.system()` at the top of `preBoot` and everything worked.

## Fix

Resolve `PlatformPaths.system()` twice -- once before `applyPending` so logback's `${nexira.logs.dir}` substitution has a value for the first log line, once after so the rest of `preBoot` sees the post-move data-dir.

No-op for the steady-state case (no pending move).

## On the downstream trustAnchors error

The tester's `java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty` during fresh login from the broken-state was likely a side effect: empty data-dir → ssl-bypasses + creds gone → cold network handshake into an OkHttp/JBR path that doesn't normally execute on a warm install. No code in this repo touches the JVM trust store directly. Expect this to resolve once the data-dir fix lands and the launcher correctly stays under the new dir from the first post-move restart. If it persists in a separate scenario, that's a follow-up.

## Logback caveat

Unchanged from before: logback's rolling-file appender keeps writing to the old path's handle for the rest of this session, since logback doesn't auto-reload on system-property change. Next launch starts fresh under the new path. `applyPending` emits a handful of log lines and the user has been told a restart is needed, so the residual misdirect is acceptable. Cleaner solutions (`logbackContext.reset()` + reconfigure) are overkill for a one-time event.

## Test plan

- [x] New regression test: `after applyPending, a fresh PlatformPaths reader sees the new data-dir`
- [x] Existing `DataDirMoverTest` suite still green
- [x] Full `:client-launcher:test` suite green
- [ ] Manual: Win11 install, "Move data directory" -> pick empty `D:\NexiraData` -> restart -> launcher comes up under D:, credentials retained, account stays logged in, no trustAnchors error
- [ ] Manual: Linux, same flow -- move from `~/.local/share/nexira` to `~/Documents/NexiraData` -> restart -> works
- [ ] Manual: Cancel out of pending move (edit `~/.nexira.conf` to remove pending keys, leave data-dir absent) -> launcher boots normally from default path