### PR TITLE
feat(launch): wire pack-centric Play button + LaunchTarget abstraction

### DIFF
--- a/client-core/src/main/kotlin/hivens/core/api/interfaces/ILauncherService.kt
+++ b/client-core/src/main/kotlin/hivens/core/api/interfaces/ILauncherService.kt
@@ -1,6 +1,8 @@
 package hivens.core.api.interfaces
 
 import hivens.core.api.model.ServerProfile
+import hivens.core.data.CachedManifestSnapshot
+import hivens.core.data.InstanceRuntime
 import hivens.core.data.LauncherLogType
 import hivens.core.data.SessionData
 import java.io.IOException
@@ -28,6 +30,52 @@ interface ILauncherService {
         clientRootPath: Path,
         javaExecutablePath: Path,
         allocatedMemoryMB: Int,
+        onLog: (String, LauncherLogType) -> Unit,
+    ): Process
+
+    /**
+     * Pack-centric launch path. Spawns the JVM against a Hivens
+     * mirror pack instance, using the [runtime] settings (heap, JVM
+     * args, java path) tied to the [PackInstance] and the static
+     * [manifest] snapshot recorded at install / sync time.
+     *
+     * The legacy [launchClient] / [launchClientWithLogs] path is SC
+     * server-centric and reaches for per-server [InstanceProfile]
+     * data via the legacy [hivens.launcher.ProfileManager]; this
+     * method is the equivalent for pack-centric instances and bypasses
+     * that whole branch.
+     *
+     * @param sessionData      Player session (player name, uuid,
+     *                         accessToken). Pack-centric mirror packs
+     *                         do not require a fresh auth call before
+     *                         launch; the in-game join is what
+     *                         actually exercises auth.
+     * @param manifest         Snapshot of mirror-manifest values the
+     *                         command builder needs. Persisted on the
+     *                         [PackInstance] at install time so a Play
+     *                         click never makes a network round trip.
+     * @param runtime          Per-instance JVM preferences (heap, args,
+     *                         java path).
+     * @param clientRootPath   Absolute path to the instance's directory
+     *                         (`<dataDir>/instances/<instanceDirName>`).
+     * @param javaExecutablePath Default Java executable. Used when the
+     *                         instance's [InstanceRuntime.javaPath] is
+     *                         null or empty.
+     * @param allocatedMemoryMB Fallback heap (MB) when the instance's
+     *                         own [InstanceRuntime.memoryMb] is 0 or
+     *                         below the launcher floor.
+     * @param displayName      Human label for log lines.
+     * @param onLog            Stdout / stderr line callback.
+     */
+    @Throws(IOException::class)
+    suspend fun launchPackClient(
+        sessionData: SessionData,
+        manifest: CachedManifestSnapshot,
+        runtime: InstanceRuntime,
+        clientRootPath: Path,
+        javaExecutablePath: Path,
+        allocatedMemoryMB: Int,
+        displayName: String,
         onLog: (String, LauncherLogType) -> Unit,
     ): Process
 }

--- a/client-core/src/main/kotlin/hivens/core/data/CachedManifestSnapshot.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/CachedManifestSnapshot.kt
@@ -1,0 +1,23 @@
+package hivens.core.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Subset of a Hivens mirror manifest the launcher needs to launch a
+ * pack instance: MC version, loader, and Java major. Cached on
+ * [PackInstance.cachedManifest] at install / sync time so a Play
+ * click does not require a manifest fetch -- the JSON repository on
+ * disk already has every value the launch command builder needs.
+ *
+ * Source of truth is the live mirror manifest at sync time; if the
+ * pack ever updates server-side, the next sync refreshes this
+ * snapshot. Offline Play uses whatever the last sync recorded --
+ * that is the whole point of caching here rather than re-fetching.
+ */
+@Serializable
+data class CachedManifestSnapshot(
+    val minecraftVersion: String,
+    val loaderName: String,
+    val loaderVersion: String,
+    val javaMajor: Int,
+)

--- a/client-core/src/main/kotlin/hivens/core/data/PackInstance.kt
+++ b/client-core/src/main/kotlin/hivens/core/data/PackInstance.kt
@@ -59,4 +59,13 @@ data class PackInstance(
     val forkedFrom: PackReference? = null,
     /** User-editable free text. Shown on the instance detail surface. */
     val notes: String = "",
+    /**
+     * Snapshot of the fields the launch command builder needs from the
+     * mirror manifest (MC version, loader, Java major). Filled in by
+     * the install / sync flow so Play does not require a fresh
+     * manifest fetch. Null on instances created before the field
+     * existed; the launch path falls back to a one-shot fetch in that
+     * case, then writes the snapshot back.
+     */
+    val cachedManifest: CachedManifestSnapshot? = null,
 )

--- a/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/LauncherService.kt
@@ -3,13 +3,16 @@ package hivens.launcher
 import hivens.core.api.interfaces.IJavaManager
 import hivens.core.api.interfaces.ILauncherService
 import hivens.core.api.model.ServerProfile
+import hivens.core.data.CachedManifestSnapshot
 import hivens.core.data.FileManifest
 import hivens.core.data.InstanceProfile
+import hivens.core.data.InstanceRuntime
 import hivens.core.data.LauncherLogType
 import hivens.core.data.SessionData
 import hivens.launcher.component.ClasspathProvider
 import hivens.launcher.component.EnvironmentPreparer
 import hivens.launcher.component.GameCommandBuilder
+import hivens.launcher.component.LaunchTarget
 import hivens.launcher.component.ProcessLogHandler
 import org.slf4j.LoggerFactory
 import java.io.IOException
@@ -104,6 +107,79 @@ internal class LauncherService(
         ) { _, _ -> /* Logs are ignored */ }
     }
 
+    @Throws(IOException::class)
+    override suspend fun launchPackClient(
+        sessionData: SessionData,
+        manifest: CachedManifestSnapshot,
+        runtime: InstanceRuntime,
+        clientRootPath: Path,
+        javaExecutablePath: Path,
+        allocatedMemoryMB: Int,
+        displayName: String,
+        onLog: (String, LauncherLogType) -> Unit
+    ): Process {
+        val mcVersion = manifest.minecraftVersion
+
+        // 1. Memory allocation strategy -- same floor logic as the
+        // SC path; the InstanceRuntime value wins when positive.
+        val memory = normalizeMemory(runtime.memoryMb, allocatedMemoryMB)
+
+        // 2. Java path. Pack-centric runtime carries an optional
+        // explicit override; without it the caller's resolved default
+        // wins (LauncherController already consulted JavaManager).
+        val javaExec: String = resolvePackJavaPath(runtime, javaExecutablePath)
+
+        log.info("Session initialization (pack): {}, Java: {}, Heap: {}MB", displayName, javaExec, memory)
+        onLog("Running $displayName...", LauncherLogType.INFO)
+
+        // 3. Natives + assets layout. Reuse the same VersionConfig-keyed
+        // directory layout as the SC path; both flows write into the
+        // same canonical `<clientRoot>/bin/natives-<mcVersion>` shape.
+        val nativesDir = commandBuilder.getNativesDir(mcVersion)
+        envPreparer.prepareNatives(clientRootPath, nativesDir, mcVersion)
+        envPreparer.prepareAssets(clientRootPath, "assets-$mcVersion.zip")
+
+        // 4. Classpath. Pack-centric sync writes the same on-disk
+        // layout the SC FileManifest classpath provider expects (mods/,
+        // libraries-{ver}/, bin/, core mods, etc), so the same provider
+        // walks the directory and assembles the classpath without
+        // needing a server-side FileManifest object.
+        val classpath = classpathProvider.buildClasspath(
+            clientRootPath,
+            FileManifest(),
+            excludedModules = emptyList(),
+        )
+
+        // 5. Build the JVM command via the domain-agnostic LaunchTarget
+        // overload. Pack-centric installs do not pre-fill neoForgeArgs /
+        // ignoreModulesList (those are SC-server-side overrides); the
+        // builder's auto-detector and baked defaults handle the rest.
+        val command = commandBuilder.build(
+            javaExec   = javaExec,
+            memoryMB   = memory,
+            clientRoot = clientRootPath,
+            target     = LaunchTarget(
+                mcVersion         = mcVersion,
+                neoForgeArgs      = null,
+                ignoreModulesList = null,
+                jvmArgsOverride   = runtime.jvmArgs,
+                displayName       = displayName,
+            ),
+            session    = sessionData,
+            classpath  = classpath,
+        )
+
+        val pb = ProcessBuilder(command)
+        pb.directory(clientRootPath.toFile())
+        pb.redirectErrorStream(false)
+
+        onLog("CMD: ${java.lang.String.join(" ", command)}", LauncherLogType.INFO)
+
+        val process = pb.start()
+        logHandler.attach(process, onLog)
+        return process
+    }
+
     internal companion object {
         /**
          * Memory allocation rule: profile's per-instance value wins when positive,
@@ -113,6 +189,24 @@ internal class LauncherService(
         internal fun normalizeMemory(profileMb: Int, allocatedMb: Int): Int {
             val raw = if (profileMb > 0) profileMb else allocatedMb
             return if (raw < 768) 1024 else raw
+        }
+
+        /**
+         * Pack-centric Java path resolution. Mirrors [resolveJavaPath]'s
+         * fallback ladder but pulls the override from [InstanceRuntime]
+         * instead of the legacy [InstanceProfile]. The runtime's
+         * `javaPath` lands here as the highest priority; without it the
+         * caller's pre-resolved [defaultPath] wins (LauncherController
+         * already consulted JavaManager for the pack's Java major).
+         */
+        internal fun resolvePackJavaPath(
+            runtime: InstanceRuntime,
+            defaultPath: Path,
+        ): String {
+            val explicit = runtime.javaPath
+            if (!explicit.isNullOrEmpty()) return explicit
+            if (Files.exists(defaultPath)) return defaultPath.toString()
+            return "java"
         }
 
         /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/PackInstaller.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/PackInstaller.kt
@@ -3,6 +3,7 @@ package hivens.launcher
 import hivens.core.api.dto.smrt.SmrtPackManifest
 import hivens.core.api.dto.smrt.SmrtPackSummary
 import hivens.core.api.interfaces.IPackRepository
+import hivens.core.data.CachedManifestSnapshot
 import hivens.core.data.ContentToggle
 import hivens.core.data.InstanceRuntime
 import hivens.core.data.PackInstance
@@ -77,6 +78,12 @@ class PackInstaller(
             optionalContent       = emptyList<ContentToggle>(),
             forkedFrom            = null,
             notes                 = "",
+            cachedManifest        = CachedManifestSnapshot(
+                minecraftVersion = manifest.minecraft.version,
+                loaderName       = manifest.loader.name,
+                loaderVersion    = manifest.loader.version,
+                javaMajor        = manifest.java.major,
+            ),
         )
         repository.put(instance)
         log.info("install: registered instance {} in repository", instanceId)

--- a/client-launcher/src/main/kotlin/hivens/launcher/component/GameCommandBuilder.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/component/GameCommandBuilder.kt
@@ -71,9 +71,9 @@ internal class GameCommandBuilder(
     }
 
     /**
-     * Collects a list of arguments for [ProcessBuilder].
-     *
-     * @return An ordered list of strings, ready to be passed to the OS process.
+     * Legacy SC server-centric entry point. Projects [serverProfile] +
+     * [userProfile] onto a [LaunchTarget] and delegates to the
+     * domain-agnostic [build] overload below.
      */
     fun build(
         javaExec: String,
@@ -83,8 +83,35 @@ internal class GameCommandBuilder(
         session: SessionData,
         userProfile: InstanceProfile,
         classpath: String
+    ): List<String> = build(
+        javaExec   = javaExec,
+        memoryMB   = memoryMB,
+        clientRoot = clientRoot,
+        target     = LaunchTarget(
+            mcVersion         = serverProfile.version,
+            neoForgeArgs      = serverProfile.neoForgeArgs,
+            ignoreModulesList = serverProfile.ignoreModulesList,
+            jvmArgsOverride   = userProfile.jvmArgs,
+            displayName       = serverProfile.name,
+        ),
+        session    = session,
+        classpath  = classpath,
+    )
+
+    /**
+     * Collects a list of arguments for [ProcessBuilder].
+     *
+     * @return An ordered list of strings, ready to be passed to the OS process.
+     */
+    fun build(
+        javaExec: String,
+        memoryMB: Int,
+        clientRoot: Path,
+        target: LaunchTarget,
+        session: SessionData,
+        classpath: String
     ): List<String> {
-        val version = serverProfile.version
+        val version = target.mcVersion
         val config = getConfig(version)
         val isModernEnvironment = config.mainClass.contains("BootstrapLauncher")
         val args = ArrayList<String>()
@@ -127,7 +154,7 @@ internal class GameCommandBuilder(
             args.add("-DlibraryDirectory=" + libDir.toAbsolutePath())
 
             val defaultIgnore = "client,securejarhandler,asm,bootstraplauncher,JarJarFileSystems,client-extra,neoforge-"
-            val ignoreList = serverProfile.ignoreModulesList?.takeIf { it.isNotBlank() } ?: defaultIgnore
+            val ignoreList = target.ignoreModulesList?.takeIf { it.isNotBlank() } ?: defaultIgnore
             args.add("-DignoreList=$ignoreList")
             args.add("-DmergeModules=jna-5.14.0.jar,jna-platform-5.14.0.jar")
         }
@@ -141,8 +168,8 @@ internal class GameCommandBuilder(
             args.add("--add-modules=jdk.incubator.vector")
         }
 
-        if (!userProfile.jvmArgs.isNullOrEmpty()) {
-            args.addAll(userProfile.jvmArgs!!.split(" "))
+        if (!target.jvmArgsOverride.isNullOrBlank()) {
+            args.addAll(target.jvmArgsOverride.trim().split(Regex("\\s+")))
         } else {
             args.addAll(gcArgs)
         }
@@ -205,7 +232,7 @@ internal class GameCommandBuilder(
         args.addAll(config.programArgs)
 
         // 9. Game Arguments
-        args.addAll(buildMinecraftArgs(session, serverProfile, clientRoot, config.assetIndex, isModernEnvironment))
+        args.addAll(buildMinecraftArgs(session, target, clientRoot, config.assetIndex, isModernEnvironment))
 
         if (config.tweakClass != null) {
             args.add("--tweakClass")
@@ -223,14 +250,14 @@ internal class GameCommandBuilder(
 
     private fun buildMinecraftArgs(
         session: SessionData,
-        profile: ServerProfile,
+        target: LaunchTarget,
         root: Path,
         assetIndex: String,
         isModernEnvironment: Boolean
     ): List<String> {
         val args = ArrayList<String>()
         args.add("--username"); args.add(session.playerName)
-        args.add("--version"); args.add("Forge ${profile.version}")
+        args.add("--version"); args.add("Forge ${target.mcVersion}")
         args.add("--gameDir"); args.add(root.toAbsolutePath().toString())
         args.add("--assetsDir"); args.add(root.resolve("assets").toAbsolutePath().toString())
         args.add("--assetIndex"); args.add(assetIndex)
@@ -259,7 +286,7 @@ internal class GameCommandBuilder(
             }
 
             // Backend arguments still win -- server can override what was detected.
-            val backendArgs = profile.neoForgeArgs ?: emptyMap()
+            val backendArgs = target.neoForgeArgs ?: emptyMap()
             val finalFmlArgs = defaultFmlArgs + backendArgs
 
             finalFmlArgs.forEach { (key, value) ->

--- a/client-launcher/src/main/kotlin/hivens/launcher/component/LaunchTarget.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/component/LaunchTarget.kt
@@ -1,0 +1,42 @@
+package hivens.launcher.component
+
+/**
+ * Pack/server-agnostic input for [GameCommandBuilder.build]. Both
+ * the legacy SC server-centric flow and the Hivens pack-centric
+ * flow project their domain object (ServerProfile vs PackInstance +
+ * mirror manifest) onto this shape before invoking the command
+ * builder.
+ *
+ * Keeps [GameCommandBuilder] from having to know about ServerProfile
+ * or PackInstance; only the values it actually uses to assemble
+ * argv survive into the launch path.
+ */
+internal data class LaunchTarget(
+    /**
+     * Minecraft version, e.g. `"1.12.2"`. Drives VersionConfig lookup,
+     * the `--version` arg, `--fml.mcVersion`, and asset/natives layout.
+     */
+    val mcVersion: String,
+    /**
+     * NeoForge-only argument overrides (`fml.neoForgeVersion`,
+     * `fml.fmlVersion`, etc). Null / empty defers to the in-bundle
+     * auto-detector + baked defaults. SC server-list profiles pre-fill
+     * these from the dashboard; pack-centric installs leave them null
+     * and let the detector run.
+     */
+    val neoForgeArgs: Map<String, String>? = null,
+    /**
+     * Optional override of NeoForge's `-DignoreList=...` system property.
+     * Null defers to the version-keyed default in GameCommandBuilder.
+     */
+    val ignoreModulesList: String? = null,
+    /**
+     * Free-text JVM args; whitespace-split into argv. Null / blank
+     * keeps the VersionConfig's baked-in `-XX:` GC args. Wins over
+     * the bundled GC args when non-blank (the partition-and-append
+     * dance from the legacy code stays as-is).
+     */
+    val jvmArgsOverride: String? = null,
+    /** Human label used in log lines ("Running <name>..."). */
+    val displayName: String,
+)

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -444,14 +444,29 @@ class LauncherController(
      * absent. The returned [PackInstance] is the (possibly updated)
      * instance the caller should use for the rest of the launch flow
      * -- never falls back to the input value silently.
+     *
+     * For instances without a cached manifest the fetch targets the
+     * pinned version (`pinnedPackVersion` or `packRef.version`),
+     * NOT the mirror's latest. A floating instance (both pins null)
+     * picks up whatever the mirror currently serves -- but those are
+     * always created post-this-PR, so they already have a cached
+     * manifest and never reach this fallback.
      */
     private suspend fun resolveOrFetchManifest(
         instance: PackInstance,
     ): Pair<CachedManifestSnapshot, PackInstance> {
         instance.cachedManifest?.let { return it to instance }
 
-        logger.info("Pack {} has no cached manifest; fetching from mirror once.", instance.id)
-        val manifest = smrtPackClient.fetchManifest(instance.packRef.id)
+        val pin = instance.pinnedPackVersion ?: instance.packRef.version
+        logger.info(
+            "Pack {} has no cached manifest; fetching {} (pin={}) from mirror once.",
+            instance.id, instance.packRef.id, pin ?: "latest",
+        )
+        val manifest = if (pin != null) {
+            smrtPackClient.fetchManifestVersion(instance.packRef.id, pin)
+        } else {
+            smrtPackClient.fetchManifest(instance.packRef.id)
+        }
         val snapshot = CachedManifestSnapshot(
             minecraftVersion = manifest.minecraft.version,
             loaderName       = manifest.loader.name,

--- a/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/launch/LauncherController.kt
@@ -3,6 +3,8 @@ package hivens.launcher.launch
 import hivens.core.api.TwoFactorRequiredException
 import hivens.core.api.interfaces.*
 import hivens.core.api.model.ServerProfile
+import hivens.core.data.CachedManifestSnapshot
+import hivens.core.data.PackInstance
 import hivens.core.data.SessionData
 import hivens.core.data.SettingsData
 import hivens.core.diag.ActionRing
@@ -10,6 +12,7 @@ import hivens.launcher.CredentialsManager
 import hivens.launcher.ManifestCache
 import hivens.launcher.ProfileManager
 import hivens.launcher.di.AppCoroutineScopeHook
+import hivens.launcher.smrt.SmrtPackClient
 import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -21,6 +24,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import org.slf4j.LoggerFactory
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 import java.util.UUID
 import kotlinx.coroutines.slf4j.MDCContext
 
@@ -47,6 +51,8 @@ class LauncherController(
     private val manifestProcessor: IManifestProcessorService,
     private val manifestCache: ManifestCache,
     private val profileManager: ProfileManager,
+    private val packRepository: IPackRepository,
+    private val smrtPackClient: SmrtPackClient,
     private val dataDirectory: Path,
     private val appScope: CoroutineScope,
 ) {
@@ -299,6 +305,163 @@ class LauncherController(
                 }
             }
         }
+    }
+
+    /**
+     * Pack-centric launch path. Equivalent to [launch] for the
+     * Hivens mirror world: takes a [PackInstance] from the local
+     * Library, skips SC auth + per-launch asset re-sync (mirror
+     * packs are static + already on disk after install), resolves
+     * Java from the manifest's declared MC version, and spawns via
+     * [ILauncherService.launchPackClient].
+     *
+     * Re-entry guard, MDC tagging and abort semantics mirror [launch]
+     * exactly so the existing UI surfaces ([LaunchControlPanel],
+     * `GameConsoleService`) plug in unchanged.
+     *
+     * Behaviour notes:
+     * - No SC auth and no SmrtSyncService call: the install flow is
+     *   responsible for materialising the instance, and an explicit
+     *   "Update pack" Library action will run sync separately later.
+     * - When [PackInstance.cachedManifest] is null (instance created
+     *   before the field existed), a one-time mirror fetch fills it
+     *   in and the result is written back via [IPackRepository.put].
+     *   Subsequent Play clicks read from cache.
+     * - [PackInstance.lastPlayedEpochOrZero] is bumped on successful
+     *   spawn so the Library sort-by-recently-played stays accurate.
+     */
+    fun launchPackInstance(
+        currentSession: SessionData,
+        packInstance: PackInstance,
+    ) {
+        synchronized(launchLock) {
+            if (_state.value !is LaunchState.Idle &&
+                _state.value !is LaunchState.Error) return
+            _state.value = LaunchState.Prepare(PrepareStage.INIT, 0.0f)
+        }
+
+        val launchId = UUID.randomUUID().toString().take(8)
+
+        launchJob = appScope.launch(MDCContext(mapOf("launchId" to launchId))) {
+            val settings = settingsService.getSettings()
+
+            try {
+                _state.value = LaunchState.Prepare(PrepareStage.INIT, 0.0f)
+
+                emit(LaunchLogEvent.SessionStarted)
+                emit(LaunchLogEvent.AppBanner)
+                // Mirror packs are public read; surfacing the offline
+                // flag here would be misleading -- pack-centric Play
+                // does not need network at all when cachedManifest is
+                // populated.
+                emit(LaunchLogEvent.TargetServer(packInstance.displayName, offline = false))
+
+                ActionRing.record("Launching pack: ${packInstance.displayName} (launchId=$launchId)")
+
+                // 1. Resolve the manifest snapshot. Stored on the
+                // instance after install; one-shot fetch + write-back
+                // covers instances that predate the field.
+                setStage(PrepareStage.SYNC, 0.3f)
+                val (manifestSnapshot, refreshedInstance) =
+                    resolveOrFetchManifest(packInstance)
+
+                // 2. Java. Same JavaManager path as the SC flow --
+                // pack manifest's declared MC version drives the
+                // managed Liberica selection.
+                setStage(PrepareStage.JVM, 0.7f)
+                val javaPath = if (!settings.javaPath.isNullOrEmpty()) {
+                    Path.of(settings.javaPath!!)
+                } else {
+                    javaManagerService.getJavaPath(manifestSnapshot.minecraftVersion)
+                }
+
+                // 3. Spawn. Pack-centric clientRoot lives under
+                // `<dataDir>/instances/<instanceDirName>`, not under
+                // `<dataDir>/clients/<serverId>` like the SC flow.
+                setStage(PrepareStage.LAUNCH, 0.95f)
+                ActionRing.record("Game running: ${packInstance.displayName}")
+                emit(LaunchLogEvent.Launching)
+
+                val clientDir = dataDirectory
+                    .resolve("instances")
+                    .resolve(refreshedInstance.instanceDirName)
+                if (!Files.exists(clientDir)) {
+                    fail(LaunchError.OfflineNoClient)
+                    return@launch
+                }
+
+                val process = launcherService.launchPackClient(
+                    sessionData          = currentSession,
+                    manifest             = manifestSnapshot,
+                    runtime              = refreshedInstance.runtime,
+                    clientRootPath       = clientDir,
+                    javaExecutablePath   = javaPath,
+                    allocatedMemoryMB    = settings.memoryMB,
+                    displayName          = refreshedInstance.displayName,
+                ) { text, type ->
+                    emit(LaunchLogEvent.ProcessOutput(text, type))
+                }
+
+                runningProcess = process
+                _state.value = LaunchState.GameRunning(process)
+
+                // Bump lastPlayed *after* the process has actually
+                // spawned, not before -- a failed spawn should not
+                // pollute the recent-played sort.
+                runCatching {
+                    packRepository.put(
+                        refreshedInstance.copy(
+                            lastPlayedEpochOrZero = Instant.now().epochSecond,
+                        ),
+                    )
+                }.onFailure { logger.warn("Failed to bump lastPlayed for ${refreshedInstance.id}", it) }
+
+                val exitCode = process.waitFor()
+                runningProcess = null
+                ActionRing.record("Game exited: ${refreshedInstance.displayName} (code $exitCode)")
+
+                if (exitCode != 0) {
+                    fail(LaunchError.ExitCode(exitCode))
+                } else {
+                    _state.value = LaunchState.Idle
+                }
+
+            } catch (e: Exception) {
+                runningProcess = null
+                if (e !is CancellationException) {
+                    logger.error("Pack launch flow failed for {}", packInstance.displayName, e)
+                    fail(LaunchError.Internal(e.message ?: ""), e)
+                } else {
+                    _state.value = LaunchState.Idle
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns the [CachedManifestSnapshot] for [instance], fetching
+     * from the mirror and persisting back when the on-disk value is
+     * absent. The returned [PackInstance] is the (possibly updated)
+     * instance the caller should use for the rest of the launch flow
+     * -- never falls back to the input value silently.
+     */
+    private suspend fun resolveOrFetchManifest(
+        instance: PackInstance,
+    ): Pair<CachedManifestSnapshot, PackInstance> {
+        instance.cachedManifest?.let { return it to instance }
+
+        logger.info("Pack {} has no cached manifest; fetching from mirror once.", instance.id)
+        val manifest = smrtPackClient.fetchManifest(instance.packRef.id)
+        val snapshot = CachedManifestSnapshot(
+            minecraftVersion = manifest.minecraft.version,
+            loaderName       = manifest.loader.name,
+            loaderVersion    = manifest.loader.version,
+            javaMajor        = manifest.java.major,
+        )
+        val refreshed = instance.copy(cachedManifest = snapshot)
+        runCatching { packRepository.put(refreshed) }
+            .onFailure { logger.warn("Failed to persist cachedManifest for ${instance.id}", it) }
+        return snapshot to refreshed
     }
 
     /**

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtPackClient.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtPackClient.kt
@@ -48,6 +48,18 @@ class SmrtPackClient(
     suspend fun fetchManifest(packId: String): SmrtPackManifest =
         getJson("$mirrorBase/v1/packs/$packId/manifest")
 
+    /**
+     * Fetch a specific historical manifest version. Pinned-version
+     * instances (the install-time `pack_version` is recorded on
+     * [hivens.core.data.PackInstance.pinnedPackVersion]) must call
+     * this rather than the latest endpoint, since the mirror may
+     * have bumped the pack since install and a divergent latest
+     * manifest's MC version / loader / Java major would not match
+     * the files that were synced to disk.
+     */
+    suspend fun fetchManifestVersion(packId: String, version: String): SmrtPackManifest =
+        getJson("$mirrorBase/v1/packs/$packId/manifest/$version")
+
     suspend fun fetchSummary(packId: String): SmrtPackSummary =
         getJson("$mirrorBase/v1/packs/$packId")
 

--- a/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
+++ b/client-launcher/src/test/kotlin/hivens/launcher/launch/LauncherControllerTest.kt
@@ -6,6 +6,7 @@ import hivens.core.api.interfaces.IFileDownloadService
 import hivens.core.api.interfaces.IJavaManager
 import hivens.core.api.interfaces.ILauncherService
 import hivens.core.api.interfaces.IManifestProcessorService
+import hivens.core.api.interfaces.IPackRepository
 import hivens.core.api.interfaces.ISettingsService
 import hivens.core.api.model.ServerProfile
 import hivens.core.data.FileManifest
@@ -15,6 +16,7 @@ import hivens.core.security.IKeyringStorage
 import hivens.launcher.CredentialsManager
 import hivens.launcher.ManifestCache
 import hivens.launcher.ProfileManager
+import hivens.launcher.smrt.SmrtPackClient
 import io.mockk.coEvery
 import io.mockk.coJustRun
 import io.mockk.coVerify
@@ -22,6 +24,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -74,6 +77,8 @@ class LauncherControllerTest {
     private lateinit var credentialsManager: CredentialsManager
     private lateinit var manifestCache: ManifestCache
     private lateinit var profileManager: ProfileManager
+    private lateinit var packRepository: IPackRepository
+    private lateinit var smrtPackClient: SmrtPackClient
 
     private val server = ServerProfile(
         name     = "TestSrv",
@@ -103,6 +108,12 @@ class LauncherControllerTest {
         profileManager     = ProfileManager(sandbox, json)
         manifestCache      = ManifestCache(sandbox.resolve("manifest-cache"), json)
         credentialsManager = CredentialsManager(sandbox, json, mockk<IKeyringStorage>(relaxed = true))
+        // PackRepository + SmrtPackClient: pack-centric controller
+        // dependencies. SC-only tests do not call `launchPackInstance`,
+        // so a relaxed mockk on both is enough to satisfy the
+        // constructor without any stubbing.
+        packRepository     = mockk(relaxed = true)
+        smrtPackClient     = mockk(relaxed = true)
 
         every { manifestProcessor.calculateIgnoredFiles(any(), any()) } returns emptySet()
         coEvery { javaManagerService.getJavaPath(any()) } returns Path.of("/usr/bin/java")
@@ -124,6 +135,8 @@ class LauncherControllerTest {
         manifestProcessor  = manifestProcessor,
         manifestCache      = manifestCache,
         profileManager     = profileManager,
+        packRepository     = packRepository,
+        smrtPackClient     = smrtPackClient,
         dataDirectory      = sandbox,
         appScope           = scope,
     )
@@ -240,6 +253,72 @@ class LauncherControllerTest {
         )
 
         collectorJob.cancel()
+    }
+
+    @Test
+    fun `pack-centric launch with cached manifest spawns and bumps lastPlayed`() = runTest {
+        every { settingsService.getSettings() } returns SettingsData()
+        coEvery { javaManagerService.getJavaPath("1.12.2") } returns Path.of("/opt/jdk8/bin/java")
+
+        val process = mockk<Process>()
+        every { process.waitFor() } returns 0
+        coEvery {
+            launcherService.launchPackClient(
+                sessionData        = any(),
+                manifest           = any(),
+                runtime            = any(),
+                clientRootPath     = any(),
+                javaExecutablePath = any(),
+                allocatedMemoryMB  = any(),
+                displayName        = any(),
+                onLog              = any(),
+            )
+        } returns process
+
+        // PackInstance with cachedManifest already filled. Controller
+        // must skip the SmrtPackClient fetch entirely.
+        val instance = hivens.core.data.PackInstance(
+            id                    = "i-1",
+            packRef               = hivens.core.data.PackReference(
+                origin  = hivens.core.data.PackOrigin.Mirror,
+                id      = "Industrial",
+                version = "2026.05.26.1",
+            ),
+            displayName           = "Industrial",
+            instanceDirName       = "Industrial-i-1",
+            createdAtEpoch        = 0L,
+            lastPlayedEpochOrZero = 0L,
+            pinnedPackVersion     = "2026.05.26.1",
+            cachedManifest        = hivens.core.data.CachedManifestSnapshot(
+                minecraftVersion = "1.12.2",
+                loaderName       = "forge",
+                loaderVersion    = "14.23.5.2922",
+                javaMajor        = 8,
+            ),
+        )
+        // The clientDir is materialised by the install flow; the
+        // controller refuses to launch when it is missing, so the test
+        // pre-creates it.
+        Files.createDirectories(sandbox.resolve("instances").resolve(instance.instanceDirName))
+
+        val captured = slot<hivens.core.data.PackInstance>()
+        coJustRun { packRepository.put(capture(captured)) }
+
+        val controller = newController(this)
+        controller.launchPackInstance(
+            currentSession = SessionData(playerName = "tester", uuid = "u", accessToken = "tok"),
+            packInstance   = instance,
+        )
+        advanceUntilIdle()
+
+        assertEquals(LaunchState.Idle, controller.state.value)
+        // packRepository.put fires exactly once -- the lastPlayed bump.
+        // No cached-manifest write happens because the instance arrived
+        // pre-populated; if the fetch path had fired, mockk would not
+        // be able to stub SmrtPackClient under JDK 25 (per the file
+        // header) and the launch coroutine would have thrown.
+        coVerify(exactly = 1) { packRepository.put(any()) }
+        assertTrue(captured.captured.lastPlayedEpochOrZero > 0)
     }
 
     @Test

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppLayout.kt
@@ -226,6 +226,7 @@ fun AppLayout(
                     is Screen.PackDetail ->
                         PackDetailScreen(
                             instanceId = screen.instanceId,
+                            appState   = appState,
                             onBack     = { onScreenChange(Screen.Library) },
                         )
                 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsText.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsText.kt
@@ -29,7 +29,7 @@ object AprilFoolsText {
         "at sun.reflect.NativeMethodAccessorImpl.invoke0",
         "FATAL: connection to server lost",
         "Warning: undefined behavior detected",
-        "TODO: fix this before release",
+        "TODO: Fix stability",
         "// this code was written at 3am",
         "Stack overflow in stack overflow handler",
         "OutOfMemoryError: Java heap space",

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -667,6 +667,8 @@ interface AppStrings {
     /** Receives the instance dir name (a sanitized folder under `instances/`). */
     fun packDetailInstanceDirHint(dirName: String): String
     val packDetailPlay: String
+    /** Shown above the Play button when the user is not authenticated. */
+    val packDetailPlayLoginRequired: String
     val packDetailNotFoundTitle: String
     val packDetailNotFoundHint: String
     val packDetailNotFoundBack: String

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -628,6 +628,7 @@ object EnglishStrings : AppStrings {
     override val packDetailReadyTitle           = "Ready to play"
     override fun packDetailInstanceDirHint(dirName: String) = "Instance folder: instances/$dirName"
     override val packDetailPlay                 = "Play"
+    override val packDetailPlayLoginRequired    = "Sign in to play"
     override val packDetailNotFoundTitle        = "Instance not found"
     override val packDetailNotFoundHint         = "It may have been removed from another window."
     override val packDetailNotFoundBack         = "Back to Library"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -628,6 +628,7 @@ object GermanStrings : AppStrings {
     override val packDetailReadyTitle           = "Bereit zum Spielen"
     override fun packDetailInstanceDirHint(dirName: String) = "Instanz-Ordner: instances/$dirName"
     override val packDetailPlay                 = "Spielen"
+    override val packDetailPlayLoginRequired    = "Anmelden zum Spielen"
     override val packDetailNotFoundTitle        = "Instanz nicht gefunden"
     override val packDetailNotFoundHint         = "Möglicherweise in einem anderen Fenster entfernt."
     override val packDetailNotFoundBack         = "Zurück zur Library"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -629,6 +629,7 @@ object RussianStrings : AppStrings {
     override val packDetailReadyTitle           = "Готов к запуску"
     override fun packDetailInstanceDirHint(dirName: String) = "Папка экземпляра: instances/$dirName"
     override val packDetailPlay                 = "Играть"
+    override val packDetailPlayLoginRequired    = "Войдите, чтобы играть"
     override val packDetailNotFoundTitle        = "Экземпляр не найден"
     override val packDetailNotFoundHint         = "Возможно, удалён в другом окне."
     override val packDetailNotFoundBack         = "Назад в Library"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
@@ -41,7 +41,9 @@ import androidx.compose.ui.unit.dp
 import hivens.core.api.interfaces.IPackRepository
 import hivens.core.data.PackInstance
 import hivens.core.data.PackOrigin
+import hivens.launcher.launch.LauncherController
 import hivens.launcher.platform.PlatformPaths
+import hivens.ui.AppState
 import hivens.ui.customization.glassSurfaceAlpha
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetClick
@@ -68,6 +70,7 @@ import org.koin.compose.koinInject
 @Composable
 fun PackDetailScreen(
     instanceId: String,
+    appState: AppState,
     onBack: () -> Unit,
 ) {
     PuppetScreen("PackDetail.$instanceId")
@@ -75,6 +78,7 @@ fun PackDetailScreen(
 
     val repo: IPackRepository = koinInject()
     val paths: PlatformPaths = koinInject()
+    val controller: LauncherController = koinInject()
     var instance by remember { mutableStateOf<PackInstance?>(null) }
     var resolved by remember { mutableStateOf(false) }
     LaunchedEffect(instanceId) {
@@ -108,7 +112,15 @@ fun PackDetailScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             MetaRow(pack)
-            PlayBar(pack = pack, onPlay = { /* pack-centric launch flow lands in a follow-up PR */ })
+            val authedSession = (appState as? AppState.Authenticated)?.session
+            PlayBar(
+                pack    = pack,
+                enabled = authedSession != null,
+                onPlay  = {
+                    val session = authedSession ?: return@PlayBar
+                    controller.launchPackInstance(session, pack)
+                },
+            )
         }
 
         TabRow(
@@ -196,7 +208,11 @@ private fun MetaRow(pack: PackInstance) {
 }
 
 @Composable
-private fun PlayBar(pack: PackInstance, onPlay: () -> Unit) {
+private fun PlayBar(
+    pack: PackInstance,
+    enabled: Boolean,
+    onPlay: () -> Unit,
+) {
     val s = LocalStrings.current
     Box(
         modifier = Modifier
@@ -212,7 +228,7 @@ private fun PlayBar(pack: PackInstance, onPlay: () -> Unit) {
         ) {
             Column {
                 Text(
-                    text       = s.packDetailReadyTitle,
+                    text       = if (enabled) s.packDetailReadyTitle else s.packDetailPlayLoginRequired,
                     style      = MaterialTheme.typography.titleMedium,
                     color      = CelestiaTheme.colors.textPrimary,
                     fontWeight = FontWeight.SemiBold,
@@ -225,6 +241,7 @@ private fun PlayBar(pack: PackInstance, onPlay: () -> Unit) {
             }
             Button(
                 onClick        = onPlay,
+                enabled        = enabled,
                 shape          = RoundedCornerShape(12.dp),
                 contentPadding = PaddingValues(horizontal = 24.dp, vertical = 12.dp),
                 colors         = ButtonDefaults.buttonColors(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import hivens.core.api.interfaces.IPackRepository
 import hivens.core.data.PackInstance
+import hivens.launcher.launch.LauncherController
 import hivens.ui.AppState
 import hivens.ui.Screen
 import hivens.ui.puppet.PuppetScreen
@@ -39,28 +40,26 @@ import org.koin.compose.koinInject
  * Library = user's collection of installed [PackInstance]s.
  * Renders [PackCard] rows for each instance the [IPackRepository]
  * is aware of. Card click navigates to [hivens.ui.Screen.PackDetail];
- * quick-actions (Play / Settings / More) bypass the detail hop.
+ * per-card Play launches via [LauncherController.launchPackInstance]
+ * without the detail-screen hop; Settings / More still route to the
+ * detail surface (the per-pack settings window lands in a follow-up
+ * PR, [[project_pack_centric_direction]]).
  *
  * Empty state when the repository has nothing to show -- by design
  * this is the cold-start view for a fresh install (no packs yet);
  * the Browse screen is the entry point for installing.
- *
- * Currently the per-card Play / Settings / More actions only
- * navigate; the actual launch wiring goes through the existing
- * server-bound launch flow which the pack-centric installer hasn't
- * replaced yet. Wiring those to the real launch happens in the next
- * subtask of [project_pack_centric_direction]; for now they route
- * to PackDetail like the whole-card click.
  */
 @Composable
 fun LibraryScreen(
-    @Suppress("UNUSED_PARAMETER") appState: AppState,
+    appState: AppState,
     onScreenChange: (Screen) -> Unit,
 ) {
     PuppetScreen("Library")
 
     val repo: IPackRepository = koinInject()
+    val controller: LauncherController = koinInject()
     val instances by remember { repo.observe() }.collectAsState(initial = emptyList())
+    val authedSession = (appState as? AppState.Authenticated)?.session
 
     Column(Modifier.fillMaxSize().padding(horizontal = 24.dp, vertical = 20.dp)) {
         Text(
@@ -83,7 +82,17 @@ fun LibraryScreen(
             LibraryList(
                 instances = instances,
                 onOpenDetail = { onScreenChange(Screen.PackDetail(it.id)) },
-                onPlay = { /* TODO: pack-centric launch flow not wired yet */ onScreenChange(Screen.PackDetail(it.id)) },
+                onPlay = { instance ->
+                    // Unauthenticated state: defer to the detail screen
+                    // which renders an explicit "Sign in to play" prompt
+                    // instead of swallowing the click silently.
+                    val session = authedSession
+                    if (session == null) {
+                        onScreenChange(Screen.PackDetail(instance.id))
+                    } else {
+                        controller.launchPackInstance(session, instance)
+                    }
+                },
                 onSettings = { onScreenChange(Screen.PackDetail(it.id)) },
                 onMore = { onScreenChange(Screen.PackDetail(it.id)) },
             )


### PR DESCRIPTION
## Summary

- Library / PackDetail Play buttons now actually launch the game. The data model has been ready (`PackInstance.runtime: InstanceRuntime`), but the glue from `controller.launchPackInstance(...)` down to `ProcessBuilder.start()` did not exist; both surfaces were no-ops with TODO comments.
- New `LaunchTarget` abstraction inside `GameCommandBuilder` decouples the JVM command assembly from `ServerProfile`/`InstanceProfile` (SC-only shapes). Legacy SC entry point delegates; behaviour is bit-identical.
- `CachedManifestSnapshot` on `PackInstance` lets Play skip a network manifest fetch on each click.

## Architecture note

This sits on the Hivens-protocol side of the SC-vs-Hivens split: static sha1-keyed manifest, public read, no per-launch auth. The legacy `launch(server)` flow keeps doing its SC-protocol thing (auth-on-every-asset-read, ProfileManager lookup, processSession sync); `launchPackInstance(pack)` is the parallel road for mirror packs.

## What lands

| File | Why |
|---|---|
| `client-core/.../data/CachedManifestSnapshot.kt` | New: snapshot of manifest fields the command builder needs |
| `client-core/.../data/PackInstance.kt` | Adds `cachedManifest` field (nullable, backward-compat) |
| `client-core/.../api/interfaces/ILauncherService.kt` | Adds `launchPackClient(...)` method |
| `client-launcher/.../component/LaunchTarget.kt` | New: domain-agnostic command-builder input |
| `client-launcher/.../component/GameCommandBuilder.kt` | Refactor + legacy delegate |
| `client-launcher/.../LauncherService.kt` | Implements `launchPackClient` |
| `client-launcher/.../launch/LauncherController.kt` | Adds `launchPackInstance` orchestrator + manifest resolve-or-fetch |
| `client-launcher/.../PackInstaller.kt` | Fills `cachedManifest` at install time |
| `client-ui/.../screens/library/LibraryScreen.kt` | Wires per-card Play |
| `client-ui/.../screens/detail/PackDetailScreen.kt` | Wires PlayBar, signs-in prompt when unauthenticated |
| i18n triple (`En/Ru/De`) + `AppStrings.kt` | New `packDetailPlayLoginRequired` string |
| `client-launcher/.../launch/LauncherControllerTest.kt` | New test + setup updates for the two new constructor params |

## Intentionally out of scope (follow-up PRs)

- Per-pack settings UI (heap slider, JVM args builder, java path, window geometry) — the InstanceRuntime fields persist but no editor surface exists. The floating per-pack settings window is the next PR.
- Manifest-driven version dispatch — pack on 1.20.4 still hits `GameCommandBuilder.configs` and falls through. Lifting the 1.7.10 / 1.12.2 / 1.21.1 floor is its own scope.
- Auto-connect via `InstanceRuntime.autoConnectServerId` — read by data layer but not yet emitted as `--server` / `--port`. Matches the SC flow's "join from in-game multiplayer" baseline.

## Test plan

- [x] `./gradlew :client-core:test :client-launcher:test :client-ui:desktopTest` — green
- [x] New `LauncherControllerTest.pack-centric launch with cached manifest spawns and bumps lastPlayed` — passes
- [x] Existing `LauncherControllerTest` and `LauncherServiceTest` suites — unaffected by the `LaunchTarget` refactor (legacy entry point delegates verbatim)
- [ ] **Live smoke**: Library → click Play on an installed mirror pack → game spawns; lastPlayed bumps; Quit returns to Idle. Cannot run end-to-end here (haven't tested the launcher UI yet in this session); reviewer or follow-up to confirm
- [ ] **Unauthenticated path**: open PackDetail while logged out → "Sign in to play" string shown, Play button disabled