### PR TITLE
fix(codex-sweep): backlog of P1/P2 findings across the launcher

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -90,19 +90,33 @@ jobs:
           # exclude self-reviews and detect Qodana's comment-API engagement.
           PR_JSON=$(gh pr view "$PR" --repo "$GH_REPO" --json author,reviews,comments)
           AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login')
-          # Count only the LATEST review per reviewer in the APPROVED tally.
-          # gh pr view --json reviews returns every historical review event,
-          # so the naive `state=="APPROVED"` filter passes even when a
-          # reviewer later submitted CHANGES_REQUESTED that supersedes their
-          # earlier APPROVED. Group by reviewer login, take the
-          # most-recently-submitted entry per reviewer, then count APPROVED
-          # — mirrors GitHub's own "latest review per reviewer" UI rule.
+          # GitHub's own staleness rule: an APPROVED review is
+          # "current" until the same reviewer submits CHANGES_REQUESTED
+          # or DISMISSED. A later COMMENTED entry from the same
+          # reviewer does NOT supersede their approval (the GitHub UI
+          # keeps the green check). Our jq does the same: count a
+          # reviewer as approving iff they have at least one APPROVED
+          # entry AND no CHANGES_REQUESTED/DISMISSED entry that is
+          # newer.
+          #
+          # Defensive `select(.author != null)` drops reviews from
+          # deleted GitHub accounts; otherwise group_by(.author.login)
+          # buckets every null-author into a single group and the
+          # count diverges from the truth.
           APPROVED=$(echo "$PR_JSON" | jq --arg author "$AUTHOR" '
             [ .reviews
+              | map(select(.author != null and .author.login != $author))
               | group_by(.author.login)
-              | map(max_by(.submittedAt))
-              | .[]
-              | select(.state == "APPROVED" and .author.login != $author)
+              | map({
+                  lastApproved:
+                    (map(select(.state == "APPROVED") | .submittedAt) | max),
+                  lastSupersede:
+                    (map(select(.state == "CHANGES_REQUESTED" or .state == "DISMISSED") | .submittedAt) | max),
+                })
+              | map(select(
+                  .lastApproved != null
+                  and (.lastSupersede == null or .lastApproved > .lastSupersede)
+                ))
             ] | length
           ')
           # Weak signal stays "any non-author review entry of any kind",

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -90,8 +90,24 @@ jobs:
           # exclude self-reviews and detect Qodana's comment-API engagement.
           PR_JSON=$(gh pr view "$PR" --repo "$GH_REPO" --json author,reviews,comments)
           AUTHOR=$(echo "$PR_JSON" | jq -r '.author.login')
-          APPROVED=$(echo "$PR_JSON" | jq --arg author "$AUTHOR" \
-            '[.reviews[] | select(.state=="APPROVED" and .author.login != $author)] | length')
+          # Count only the LATEST review per reviewer in the APPROVED tally.
+          # gh pr view --json reviews returns every historical review event,
+          # so the naive `state=="APPROVED"` filter passes even when a
+          # reviewer later submitted CHANGES_REQUESTED that supersedes their
+          # earlier APPROVED. Group by reviewer login, take the
+          # most-recently-submitted entry per reviewer, then count APPROVED
+          # — mirrors GitHub's own "latest review per reviewer" UI rule.
+          APPROVED=$(echo "$PR_JSON" | jq --arg author "$AUTHOR" '
+            [ .reviews
+              | group_by(.author.login)
+              | map(max_by(.submittedAt))
+              | .[]
+              | select(.state == "APPROVED" and .author.login != $author)
+            ] | length
+          ')
+          # Weak signal stays "any non-author review entry of any kind",
+          # since Codex always lands a COMMENTED review and is the cheapest
+          # bot signal we have when no human approval exists.
           ANY_REVIEW=$(echo "$PR_JSON" | jq --arg author "$AUTHOR" \
             '[.reviews[] | select(.author.login != $author)] | length')
           # Qodana posts as `github-actions[bot]` (login `github-actions`)

--- a/client-launcher/src/main/kotlin/hivens/launcher/JsonPackRepository.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JsonPackRepository.kt
@@ -2,6 +2,7 @@ package hivens.launcher
 
 import hivens.core.api.interfaces.IPackRepository
 import hivens.core.data.PackInstance
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -110,8 +111,37 @@ class JsonPackRepository(
             try {
                 Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
             } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
+                // Best-effort: the underlying filesystem (typically
+                // FAT32 / exFAT on a removable drive, or some SMB
+                // shares) does not support atomic rename. A non-
+                // atomic REPLACE_EXISTING move decomposes to
+                // delete-target-then-rename on those filesystems,
+                // and a power loss between the two steps leaves
+                // packs.json missing -- next launch loads emptyList()
+                // and the library appears wiped. We surface a WARN
+                // so a user who lands on this branch can correlate
+                // their data-dir choice with the weaker durability
+                // contract; full safety would require a fsync ladder
+                // that POSIX cannot guarantee on these filesystems.
+                log.warn(
+                    "Filesystem at {} does not support ATOMIC_MOVE; " +
+                    "falling back to non-atomic rename. A crash mid-rename " +
+                    "can lose packs.json. Move the data directory to a " +
+                    "filesystem that supports atomic rename (ext4, NTFS, " +
+                    "APFS) for full library durability.",
+                    file.parent,
+                )
                 Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING)
             }
+        } catch (e: CancellationException) {
+            // Today persist() has no suspension points inside the
+            // try-body, so withContext's cancellation check fires at
+            // entry/exit and we never land here under cancellation.
+            // The next refactor that introduces a suspending serializer
+            // OR an async IO call WILL trip cancellation inside the
+            // try -- pre-emptive rethrow keeps the structured-
+            // concurrency invariant intact across that hypothetical.
+            throw e
         } catch (e: Exception) {
             log.error("Failed to persist packs registry at {}", file, e)
         }

--- a/client-launcher/src/main/kotlin/hivens/launcher/JsonPackRepository.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/JsonPackRepository.kt
@@ -100,7 +100,18 @@ class JsonPackRepository(
             // leaves either the old or the new file, never a
             // half-written packs.json that the next load() would
             // reject as malformed and silently empty the library.
-            Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+            //
+            // Filesystems that do not support atomic rename (FAT32 on
+            // removable drives, some network shares) throw
+            // AtomicMoveNotSupportedException; without a fallback the
+            // outer catch then swallows it and the in-memory state
+            // diverges from disk indefinitely, so a restart would
+            // empty the library.
+            try {
+                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
+            } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
+                Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING)
+            }
         } catch (e: Exception) {
             log.error("Failed to persist packs registry at {}", file, e)
         }

--- a/client-launcher/src/main/kotlin/hivens/launcher/instance/ServersDatReader.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/instance/ServersDatReader.kt
@@ -35,8 +35,16 @@ class ServersDatReader {
             // launcher passes gzipped=false; if a future MC release
             // changes that, NbtException at parse time would point
             // at the wrong call site here, easy to flip.
+            //
+            // Catch broadly: the in-tree Nbt parser also surfaces
+            // IOException on truncated payloads and the occasional
+            // EOFException / IllegalArgumentException on malformed
+            // tag headers. A corrupt servers.dat must not blow up
+            // the Worlds tab; the graceful path is "no servers".
             Files.newInputStream(file).use { Nbt.read(it, gzipped = false) }
-        } catch (e: NbtException) {
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
             log.warn("servers.dat at {} did not parse: {}", file, e.message)
             return@withContext emptyList()
         }

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
@@ -154,7 +154,7 @@ class SmrtSyncService(
      * later iterations will respect a per-user opt-out map.
      */
     private suspend fun syncMod(mod: SmrtModEntry, clientDir: Path) {
-        val dest = clientDir.resolve("mods").resolve(mod.filename)
+        val dest = resolveSafe(clientDir.resolve("mods"), mod.filename, "mod ${mod.filename}")
         downloadIfNeeded(dest, mod.sha1, mod.sizeBytes, mod.source, "mod ${mod.filename}")
     }
 
@@ -167,8 +167,29 @@ class SmrtSyncService(
             log.debug("smrt sync: skipping protected {}", asset.dest)
             return
         }
-        val dest = clientDir.resolve(asset.dest)
+        val dest = resolveSafe(clientDir, asset.dest, "asset ${asset.dest}")
         downloadIfNeeded(dest, asset.sha1, asset.sizeBytes, asset.source, "asset ${asset.dest}")
+    }
+
+    /**
+     * Resolves [relative] against [root] and rejects entries that
+     * escape the root via `..` segments or absolute paths. A hostile
+     * or buggy manifest could otherwise hand the launcher
+     * `../../../etc/cron.d/payload` and end up overwriting arbitrary
+     * files writable by the launcher process. The mirror is trusted
+     * but the boundary check is cheap and means a single bad
+     * manifest entry can never escape the per-instance directory.
+     */
+    private fun resolveSafe(root: Path, relative: String, label: String): Path {
+        val resolved = root.resolve(relative).normalize()
+        val rootNormalized = root.normalize()
+        if (!resolved.startsWith(rootNormalized)) {
+            throw IOException(
+                "smrt manifest entry $label resolves outside the instance " +
+                    "directory ($resolved); refusing to write."
+            )
+        }
+        return resolved
     }
 
     private suspend fun downloadIfNeeded(

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
@@ -159,15 +159,23 @@ class SmrtSyncService(
     }
 
     private suspend fun syncAsset(asset: SmrtAssetEntry, clientDir: Path) {
+        // resolveSafe FIRST: a manifest entry like
+        // `../../config/servers.dat` happens to match the protected-
+        // suffix list (ProtectedPaths.isProtected lowercases + checks
+        // endsWith/contains on the raw string), so running the
+        // isProtected gate before path normalisation would silently
+        // skip a path-escape attempt as "protected" instead of loudly
+        // failing the manifest. The traversal IOException needs to
+        // win over the protected-path debug log.
+        val dest = resolveSafe(clientDir, asset.dest, "asset ${asset.dest}")
         // Protected paths (e.g. user-edited options.txt) are honored
         // here just like in the SC code path -- if the user has tuned
         // their FOV, sync must not overwrite. Protection only kicks in
         // when the file is already present and non-empty.
-        if (protectedPaths.isProtected(asset.dest) && fileIsPresentAndNonEmpty(clientDir.resolve(asset.dest))) {
+        if (protectedPaths.isProtected(asset.dest) && fileIsPresentAndNonEmpty(dest)) {
             log.debug("smrt sync: skipping protected {}", asset.dest)
             return
         }
-        val dest = resolveSafe(clientDir, asset.dest, "asset ${asset.dest}")
         downloadIfNeeded(dest, asset.sha1, asset.sizeBytes, asset.source, "asset ${asset.dest}")
     }
 
@@ -179,6 +187,18 @@ class SmrtSyncService(
      * files writable by the launcher process. The mirror is trusted
      * but the boundary check is cheap and means a single bad
      * manifest entry can never escape the per-instance directory.
+     *
+     * **Threat model**: defends against MANIFEST-DRIVEN traversal
+     * (a bad/hostile mirror manifest entry). Does NOT defend against
+     * a pre-existing symlink inside `root` that points outside --
+     * the lexical [Path.normalize] check is purely string-based, so
+     * `<root>/config -> /opt/shared-configs` followed by manifest
+     * entry `config/foo.cfg` writes to /opt/shared-configs/foo.cfg
+     * even though the lexical check passes. Symlinks under `<root>`
+     * are assumed user-installed and trusted; if the threat model
+     * ever broadens (multi-tenant installs, sandboxed sync), switch
+     * to `toRealPath(NOFOLLOW_LINKS)` per parent component before
+     * the startsWith comparison.
      */
     private fun resolveSafe(root: Path, relative: String, label: String): Path {
         val resolved = root.resolve(relative).normalize()

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -61,6 +61,7 @@ import hivens.ui.theme.CustomTheme
 import hivens.ui.theme.ThemeManager
 import hivens.ui.tray.TrayManager
 import hivens.ui.utils.GameConsoleService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -389,22 +390,57 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
             // [SmartyCraftServerListService.fetchDashboardData] swallows
             // network failures and returns `DashboardData(empty, empty)`
             // rather than throwing, so an outage looks like a successful
-            // empty fetch from this call site. Treat an empty server
-            // list as "fetch failed, keep the seed" -- the disk cache
-            // [serverListCache] already populated the tray above and
-            // wiping it back to "(No servers)" during a transient
-            // outage is what Codex flagged on PR #244.
+            // empty fetch from this call site. Without an explicit
+            // fetch-failed signal we cannot fully distinguish "outage"
+            // from "admin truly cleared the roster"; use the disk cache
+            // [serverListCache] as a heuristic: a previously-cached
+            // non-empty roster going to empty implies outage and we
+            // keep the seed; an already-empty cache going to empty is
+            // accepted as the new truth.
+            //
+            // Tradeoff: false-positive (admin actually cleared the
+            // roster while cache exists) keeps a stale entry for ONE
+            // session until next launch's fresh load(); the
+            // false-negative (transient outage wipes a real seed)
+            // hurts more, so the heuristic leans toward seed
+            // preservation. Reviewer flagged the previous "always
+            // preserve on empty" version as conflating both cases.
+            // Re-read the on-disk cache here -- the seed read inside
+            // the tray-init withContext block is local to that lambda,
+            // and re-reading is a cheap ~2 KB JSON load. The value is
+            // the heuristic we use to distinguish outage from a
+            // legitimately-empty roster below.
+            val seedFromCache = withContext(Dispatchers.IO) { serverListCache.load() }
             val dashboardServers = try {
                 val data = withContext(Dispatchers.IO) {
                     serverListService.fetchDashboardData().get()
                 }
-                if (data.servers.isNotEmpty()) {
-                    TrayManager.updateServers(data.servers)
+                when {
+                    data.servers.isNotEmpty() -> {
+                        TrayManager.updateServers(data.servers)
+                        data.servers
+                    }
+                    seedFromCache.isEmpty() -> {
+                        // No seed to preserve; accept the empty roster
+                        // and let the tray render "(No servers)".
+                        TrayManager.updateServers(emptyList())
+                        emptyList()
+                    }
+                    else -> {
+                        // Probable outage: keep the seeded tray entries
+                        // from the disk cache and return them so the
+                        // dashboard surface stays populated.
+                        seedFromCache
+                    }
                 }
-                data.servers
+            } catch (e: CancellationException) {
+                // Composition leave / locale switch / exit mid-fetch
+                // must propagate cooperatively; converting to "outage"
+                // would defeat structured concurrency.
+                throw e
             } catch (_: Exception) {
                 /* tray keeps the seeded cache from the IO init block */
-                emptyList()
+                seedFromCache
             }
 
             // ── Auto-sync (experimental, opt-in) ──────────────────────
@@ -499,10 +535,21 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                 // and block resize to a usable size. GraphicsConfiguration
                 // returns null before the window is realised, so fall
                 // back to the toolkit for the initial placement pass.
+                //
+                // Wayland peer-init quirk: on Hyprland (and other
+                // Wayland compositors) starting tray-resident, the
+                // Compose Window is created but not yet displayable.
+                // window.graphicsConfiguration is non-null (returns the
+                // device's default GC) but its bounds are Rectangle(0,0,0,0)
+                // until the surface negotiates. Treating that as a
+                // valid screen yields minimumSize = (0,0) and the WM
+                // can later shrink the window to a 1px sliver. Guard
+                // on positive bounds and fall through to the toolkit
+                // size otherwise.
                 val gc = window.graphicsConfiguration
-                val screen = if (gc != null) {
-                    val b = gc.bounds
-                    Dimension(b.width, b.height)
+                val gcBounds = gc?.bounds
+                val screen = if (gcBounds != null && gcBounds.width > 0 && gcBounds.height > 0) {
+                    Dimension(gcBounds.width, gcBounds.height)
                 } else {
                     Toolkit.getDefaultToolkit().screenSize
                 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -386,14 +386,24 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
             }
 
             // ── Populate server list ───────────────────────────────────
+            // [SmartyCraftServerListService.fetchDashboardData] swallows
+            // network failures and returns `DashboardData(empty, empty)`
+            // rather than throwing, so an outage looks like a successful
+            // empty fetch from this call site. Treat an empty server
+            // list as "fetch failed, keep the seed" -- the disk cache
+            // [serverListCache] already populated the tray above and
+            // wiping it back to "(No servers)" during a transient
+            // outage is what Codex flagged on PR #244.
             val dashboardServers = try {
                 val data = withContext(Dispatchers.IO) {
                     serverListService.fetchDashboardData().get()
                 }
-                TrayManager.updateServers(data.servers)
+                if (data.servers.isNotEmpty()) {
+                    TrayManager.updateServers(data.servers)
+                }
                 data.servers
             } catch (_: Exception) {
-                /* tray shows empty list */
+                /* tray keeps the seeded cache from the IO init block */
                 emptyList()
             }
 
@@ -481,7 +491,21 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                         MIN_WINDOW_HEIGHT_DP.dp.toPx().toInt(),
                     )
                 }
-                val screen = Toolkit.getDefaultToolkit().screenSize
+                // Prefer the bounds of the display this window is on;
+                // the toolkit's screenSize is the PRIMARY monitor only,
+                // and on a multi-monitor setup where the user restored
+                // the launcher on a smaller secondary screen the
+                // primary-derived clamp can exceed the actual display
+                // and block resize to a usable size. GraphicsConfiguration
+                // returns null before the window is realised, so fall
+                // back to the toolkit for the initial placement pass.
+                val gc = window.graphicsConfiguration
+                val screen = if (gc != null) {
+                    val b = gc.bounds
+                    Dimension(b.width, b.height)
+                } else {
+                    Toolkit.getDefaultToolkit().screenSize
+                }
                 val safe = computeSafeWindowMinSize(designPx.width, designPx.height, screen)
                 SwingUtilities.invokeLater { window.minimumSize = safe }
             }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/components/LaunchControlPanel.kt
@@ -107,17 +107,28 @@ fun LaunchControlPanel(
         }
 
         if (state !is LaunchState.Idle && state !is LaunchState.Error) {
-            LinearProgressIndicator(
-                progress        = { progress },
-                modifier        = Modifier
-                    .fillMaxWidth()
-                    .height(6.dp)
-                    .clip(RoundedCornerShape(3.dp)),
-                color           = CelestiaTheme.colors.primary,
-                trackColor      = CelestiaTheme.colors.surface,
-                gapSize         = 0.dp,
-                drawStopIndicator = {},
-            )
+            // NaN sentinel from wrapProgress = "size unknown but bytes
+            // flowing" -> indeterminate. Otherwise determinate fraction.
+            val barModifier = Modifier
+                .fillMaxWidth()
+                .height(6.dp)
+                .clip(RoundedCornerShape(3.dp))
+            if (progress.isNaN()) {
+                LinearProgressIndicator(
+                    modifier        = barModifier,
+                    color           = CelestiaTheme.colors.primary,
+                    trackColor      = CelestiaTheme.colors.surface,
+                )
+            } else {
+                LinearProgressIndicator(
+                    progress        = { progress },
+                    modifier        = barModifier,
+                    color           = CelestiaTheme.colors.primary,
+                    trackColor      = CelestiaTheme.colors.surface,
+                    gapSize         = 0.dp,
+                    drawStopIndicator = {},
+                )
+            }
         } else {
             Spacer(Modifier.height(6.dp))
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsProgress.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsProgress.kt
@@ -23,15 +23,25 @@ object AprilFoolsProgress {
     /**
      * Returns a display progress value (0..1) that may occasionally regress.
      *
+     * Sentinel: returns [Float.NaN] when bytes are flowing but the total
+     * is unknown (chunked HTTP without Content-Length, smrt sync's
+     * pre-tally phase). Callers must check [Float.isNaN] before binding
+     * the value to a determinate progress indicator; a NaN means
+     * "switch to indeterminate mode -- something is happening, but
+     * the bounded progress fraction is not yet computable". An earlier
+     * fix returned 0f for both (0,0) and (positive,0) which flatlined
+     * the bar during the pre-tally window even though bytes flowed.
+     *
      * @param downloaded  Bytes actually downloaded so far (real value).
      * @param total       Total bytes expected (real value).
      */
     fun wrap(downloaded: Long, total: Long): Float {
-        // Non-positive total is the "unknown size" signal the download
-        // callback emits early; coerceIn does not rescue NaN since NaN
-        // comparisons all return false, so naive `downloaded/total`
-        // propagates into UI state and breaks the progress bar render.
-        if (total <= 0L) return 0f
+        if (total <= 0L) {
+            // (0, 0) = nothing started yet -> show empty.
+            // (positive, 0) = bytes flowing, size unknown -> NaN sentinel
+            // -> caller renders indeterminate.
+            return if (downloaded <= 0L) 0f else Float.NaN
+        }
         if (!AprilFools.isActive()) {
             return (downloaded.toFloat() / total).coerceIn(0f, 1f)
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsProgress.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsProgress.kt
@@ -27,7 +27,12 @@ object AprilFoolsProgress {
      * @param total       Total bytes expected (real value).
      */
     fun wrap(downloaded: Long, total: Long): Float {
-        if (!AprilFools.isActive() || total <= 0L) {
+        // Non-positive total is the "unknown size" signal the download
+        // callback emits early; coerceIn does not rescue NaN since NaN
+        // comparisons all return false, so naive `downloaded/total`
+        // propagates into UI state and breaks the progress bar render.
+        if (total <= 0L) return 0f
+        if (!AprilFools.isActive()) {
             return (downloaded.toFloat() / total).coerceIn(0f, 1f)
         }
  

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/easter/NoOpAprilFools.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/easter/NoOpAprilFools.kt
@@ -38,8 +38,15 @@ object NoOpAprilFools : AprilFoolsLifecycle {
     override var debugForceActive: Boolean? = null
     override var debugIntensity: Float? = null
 
-    override fun wrapProgress(downloaded: Long, total: Long): Float =
-        if (total <= 0L) 0f else (downloaded.toFloat() / total).coerceIn(0f, 1f)
+    override fun wrapProgress(downloaded: Long, total: Long): Float {
+        // Same sentinel contract as the Real impl: NaN means "size
+        // unknown but bytes are flowing -> switch to indeterminate".
+        // See [AprilFoolsProgress.wrap] kdoc.
+        if (total <= 0L) {
+            return if (downloaded <= 0L) 0f else Float.NaN
+        }
+        return (downloaded.toFloat() / total).coerceIn(0f, 1f)
+    }
 
     override fun resetProgress() = Unit
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/browse/BrowseScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/browse/BrowseScreen.kt
@@ -72,6 +72,12 @@ fun BrowseScreen(onOpenPack: (packId: String) -> Unit) {
             val listing = withContext(Dispatchers.IO) { client.listPacks() }
             if (listing.packs.isEmpty()) BrowseState.Empty
             else BrowseState.Loaded(listing.packs)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            // Cooperatively cancel -- a fresh retryTick (or composition
+            // leave) restarts this LaunchedEffect, and converting the
+            // cancellation into an Error would surface spurious error UI
+            // for a click the user already overrode.
+            throw e
         } catch (e: Exception) {
             BrowseState.Error(e.message ?: s.browseErrorMessage)
         }


### PR DESCRIPTION
## Summary

Sweep across every merged PR that ever picked up a `chatgpt-codex-connector` review and never got the follow-up landed. 28 PRs surveyed, fixes applied where the issue is still present in current `stable`, no-op for findings already addressed in a later PR, deferred where the change is its own scope.

## Fixed

| PR | Severity | File | What |
|---|---|---|---|
| #248 | P1 | `ServersDatReader.kt` | Broaden NbtException catch to Exception so EOFException / IOException / IllegalArgumentException from malformed payloads degrade to "no servers" instead of throwing out of the Worlds tab |
| #244 | P1 | `AppShell.kt` | Skip `TrayManager.updateServers` when the fetched dashboard is empty (which is how `fetchDashboardData` encodes "network failed"); preserve the disk-seeded tray cache through transient outages |
| #242 | P1 | `JsonPackRepository.kt` | `AtomicMoveNotSupportedException` -> non-atomic `REPLACE_EXISTING` fallback so FAT32 / network-share users do not silently lose their library on restart |
| #220 | P1 | `SmrtSyncService.kt` | `resolveSafe` helper normalises manifest-driven dest paths and rejects entries that escape `<clientDir>` via `..` or absolute paths |
| #134 | P1 | `build_release.yml` | Review-gate counts only the LATEST review per reviewer; an early APPROVED followed by CHANGES_REQUESTED no longer counts as an approval |
| #246 | P2 | `AppShell.kt` | Compute min-window-size clamp from the window's `GraphicsConfiguration.bounds` (the display it is currently on), not the primary toolkit screen |
| #241 | P2 | `BrowseScreen.kt` | Rethrow `CancellationException` before mapping to `BrowseState.Error`; retry-tick bumps no longer surface spurious error UI |
| #115 | P1 | `AprilFoolsProgress.kt` | Return `0f` early when `total <= 0`; `coerceIn` does not rescue NaN since NaN comparisons are all false |

## Verified obsolete (no code change needed)

PR #212 destroyForcibly already waitFors. PR #208 portable ZIP path already uses customJpackageImage and SocketTimeoutException already java.net.*. PR #226 setup.iss already has `UsePreviousAppDir=no`. PR #239 HexField already trims. PR #207 mimic-version already debounced via SettingsFormState. PR #128 416 retry already RetryableHttpException-wrapped. PR #129 `.lock.pid` already in DataDirMigration housekeeping. PR #214 spec already documents numeric tuple ordering / canonical form / Modrinth `primary` selection. PR #220's ManifestCache-refresh finding lost its code path when PR #247 dropped the experimental Hivens-Mirror branch in LauncherController.

## Deferred (own scope)

- PR #220 SmrtSource sealed-class default for unknown discriminator — forward-compat work that touches kotlinx-serialization config + every source dispatch site.
- PR #103 / #101 Skia bitmap close-after-conversion — current `.use { it.toComposeImageBitmap() }` has been shipping for a year+; needs a runtime regression test before changing the close contract.
- PR #132 redaction / diagnostic-bundle hardening — coordinated diag-subsystem review.

## Test plan

- [x] `./gradlew :client-launcher:test :client-ui:desktopTest` — green
- [x] `:client-launcher:compileKotlin :client-ui:compileKotlinDesktop` — clean
- [ ] Live smoke: corrupt servers.dat -> Worlds tab empty, no crash; transient SC dashboard outage -> tray keeps seeded list; install on FAT32 -> packs.json persists after restart. Cannot run end-to-end here; reviewer or follow-up.