### PR TITLE
fix(phase3-review): screen-change clamp + AprilFools progress reset + atomic move parity

### DIFF
--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
@@ -285,16 +285,8 @@ class SmrtSyncService(
                 }
             }
         }
-        // ATOMIC_MOVE so a crash between rename and fsync leaves either
-        // the old file or the new one, never a half-byte target. The
-        // resolveSafe contract draws an explicit "writes go inside the
-        // instance dir" boundary that a non-atomic rename would
-        // undermine -- on FAT32 / SMB shares (Steam Deck SD card, dual-
-        // boot partitions) Files.move(REPLACE_EXISTING) decomposes to
-        // delete-target-then-rename, and a power loss between the two
-        // can leave the dest as a 0-byte jar that Forge tries to
-        // classload and surfaces as an opaque ZipException. Mirrors
-        // the persist() fallback pattern in JsonPackRepository.
+        // Non-atomic REPLACE_EXISTING on FAT32/SMB can leave a 0-byte
+        // dest after power loss; Forge then classloads garbage.
         try {
             Files.move(
                 tmp,
@@ -304,9 +296,7 @@ class SmrtSyncService(
             )
         } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
             log.warn(
-                "Filesystem at {} does not support ATOMIC_MOVE; falling back to non-atomic rename. " +
-                    "A crash mid-rename can leave a 0-byte file at the dest. Move the data directory to a " +
-                    "filesystem that supports atomic rename (ext4, NTFS, APFS) for full sync durability.",
+                "Filesystem at {} does not support ATOMIC_MOVE; non-atomic fallback may leave a 0-byte file on crash",
                 dest.parent,
             )
             Files.move(tmp, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING)

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
@@ -300,6 +300,12 @@ class SmrtSyncService(
                 dest.parent,
             )
             Files.move(tmp, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        } catch (_: java.nio.file.FileAlreadyExistsException) {
+            // Java spec allows ATOMIC_MOVE to ignore REPLACE_EXISTING; some
+            // providers then refuse and raise FileAlreadyExistsException
+            // when dest already exists. Re-sync over an existing jar would
+            // hard-fail without this fallback.
+            Files.move(tmp, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
         }
     }
 

--- a/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
+++ b/client-launcher/src/main/kotlin/hivens/launcher/smrt/SmrtSyncService.kt
@@ -285,7 +285,32 @@ class SmrtSyncService(
                 }
             }
         }
-        Files.move(tmp, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        // ATOMIC_MOVE so a crash between rename and fsync leaves either
+        // the old file or the new one, never a half-byte target. The
+        // resolveSafe contract draws an explicit "writes go inside the
+        // instance dir" boundary that a non-atomic rename would
+        // undermine -- on FAT32 / SMB shares (Steam Deck SD card, dual-
+        // boot partitions) Files.move(REPLACE_EXISTING) decomposes to
+        // delete-target-then-rename, and a power loss between the two
+        // can leave the dest as a 0-byte jar that Forge tries to
+        // classload and surfaces as an opaque ZipException. Mirrors
+        // the persist() fallback pattern in JsonPackRepository.
+        try {
+            Files.move(
+                tmp,
+                dest,
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+            )
+        } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
+            log.warn(
+                "Filesystem at {} does not support ATOMIC_MOVE; falling back to non-atomic rename. " +
+                    "A crash mid-rename can leave a 0-byte file at the dest. Move the data directory to a " +
+                    "filesystem that supports atomic rename (ext4, NTFS, APFS) for full sync durability.",
+                dest.parent,
+            )
+            Files.move(tmp, dest, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        }
     }
 
     private fun sha1Of(p: Path): String {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -519,42 +519,73 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
             // Clamped against the user's native screen so a small laptop
             // can still drag the window edges. Floating WMs respect the
             // hint; tiling WMs ignore it, which is fine.
+            //
+            // Recompute on screen change. A LaunchedEffect(Unit) would
+            // only fire at composition entry, leaving the clamp stale
+            // when the user later drags the window to a smaller monitor
+            // (4K primary -> 1366x768 laptop panel via DisplayPort
+            // hot-plug). Listen for ComponentEvent.componentMoved and
+            // diff GraphicsConfiguration's device id so we recompute
+            // only on actual screen-change crossings, not on every
+            // pixel of a within-screen drag.
             val sizeDensity = LocalDensity.current
-            LaunchedEffect(Unit) {
-                val designPx = with(sizeDensity) {
-                    Dimension(
-                        MIN_WINDOW_WIDTH_DP.dp.toPx().toInt(),
-                        MIN_WINDOW_HEIGHT_DP.dp.toPx().toInt(),
-                    )
+            DisposableEffect(window, sizeDensity) {
+                val applyClamp: () -> Unit = {
+                    val designPx = with(sizeDensity) {
+                        Dimension(
+                            MIN_WINDOW_WIDTH_DP.dp.toPx().toInt(),
+                            MIN_WINDOW_HEIGHT_DP.dp.toPx().toInt(),
+                        )
+                    }
+                    // Prefer the bounds of the display this window is on;
+                    // the toolkit's screenSize is the PRIMARY monitor only,
+                    // and on a multi-monitor setup where the user restored
+                    // the launcher on a smaller secondary screen the
+                    // primary-derived clamp can exceed the actual display
+                    // and block resize to a usable size. GraphicsConfiguration
+                    // returns null before the window is realised, so fall
+                    // back to the toolkit for the initial placement pass.
+                    //
+                    // Wayland peer-init quirk: on Hyprland (and other
+                    // Wayland compositors) starting tray-resident, the
+                    // Compose Window is created but not yet displayable.
+                    // window.graphicsConfiguration is non-null (returns
+                    // the device's default GC) but its bounds are
+                    // Rectangle(0,0,0,0) until the surface negotiates.
+                    // Treating that as a valid screen yields minimumSize
+                    // = (0,0) and the WM can later shrink the window to
+                    // a 1px sliver. Guard on positive bounds and fall
+                    // through to the toolkit size otherwise.
+                    val gc = window.graphicsConfiguration
+                    val gcBounds = gc?.bounds
+                    val screen = if (gcBounds != null && gcBounds.width > 0 && gcBounds.height > 0) {
+                        Dimension(gcBounds.width, gcBounds.height)
+                    } else {
+                        Toolkit.getDefaultToolkit().screenSize
+                    }
+                    val safe = computeSafeWindowMinSize(designPx.width, designPx.height, screen)
+                    SwingUtilities.invokeLater { window.minimumSize = safe }
                 }
-                // Prefer the bounds of the display this window is on;
-                // the toolkit's screenSize is the PRIMARY monitor only,
-                // and on a multi-monitor setup where the user restored
-                // the launcher on a smaller secondary screen the
-                // primary-derived clamp can exceed the actual display
-                // and block resize to a usable size. GraphicsConfiguration
-                // returns null before the window is realised, so fall
-                // back to the toolkit for the initial placement pass.
-                //
-                // Wayland peer-init quirk: on Hyprland (and other
-                // Wayland compositors) starting tray-resident, the
-                // Compose Window is created but not yet displayable.
-                // window.graphicsConfiguration is non-null (returns the
-                // device's default GC) but its bounds are Rectangle(0,0,0,0)
-                // until the surface negotiates. Treating that as a
-                // valid screen yields minimumSize = (0,0) and the WM
-                // can later shrink the window to a 1px sliver. Guard
-                // on positive bounds and fall through to the toolkit
-                // size otherwise.
-                val gc = window.graphicsConfiguration
-                val gcBounds = gc?.bounds
-                val screen = if (gcBounds != null && gcBounds.width > 0 && gcBounds.height > 0) {
-                    Dimension(gcBounds.width, gcBounds.height)
-                } else {
-                    Toolkit.getDefaultToolkit().screenSize
+
+                // Track current display id; AWT fires componentMoved on
+                // every pixel of a drag, so diff first and only recompute
+                // when the window actually crossed onto a new GraphicsDevice.
+                var lastDeviceId: String? = window.graphicsConfiguration?.device?.iDstring
+                val moveListener = object : java.awt.event.ComponentAdapter() {
+                    override fun componentMoved(e: java.awt.event.ComponentEvent) {
+                        val current = window.graphicsConfiguration?.device?.iDstring
+                        if (current != lastDeviceId) {
+                            lastDeviceId = current
+                            applyClamp()
+                        }
+                    }
                 }
-                val safe = computeSafeWindowMinSize(designPx.width, designPx.height, screen)
-                SwingUtilities.invokeLater { window.minimumSize = safe }
+                window.addComponentListener(moveListener)
+                applyClamp()  // initial placement pass
+
+                onDispose {
+                    window.removeComponentListener(moveListener)
+                }
             }
 
             val baseDensity   = androidx.compose.ui.platform.LocalDensity.current

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -513,21 +513,10 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                 }
             }
 
-            // Prophylactic minimum window size. Design intent is
-            // [MIN_WINDOW_WIDTH_DP] x [MIN_WINDOW_HEIGHT_DP] -- below
-            // those values multi-column screens collapse awkwardly.
-            // Clamped against the user's native screen so a small laptop
-            // can still drag the window edges. Floating WMs respect the
-            // hint; tiling WMs ignore it, which is fine.
-            //
-            // Recompute on screen change. A LaunchedEffect(Unit) would
-            // only fire at composition entry, leaving the clamp stale
-            // when the user later drags the window to a smaller monitor
-            // (4K primary -> 1366x768 laptop panel via DisplayPort
-            // hot-plug). Listen for ComponentEvent.componentMoved and
-            // diff GraphicsConfiguration's device id so we recompute
-            // only on actual screen-change crossings, not on every
-            // pixel of a within-screen drag.
+            // Prophylactic min-size clamped against the current display.
+            // Recomputes on display crossing (not every pixel of a drag).
+            // Wayland peer-init can return non-null GC with zero bounds
+            // before the surface negotiates -- guard on positive size.
             val sizeDensity = LocalDensity.current
             DisposableEffect(window, sizeDensity) {
                 val applyClamp: () -> Unit = {
@@ -537,25 +526,6 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                             MIN_WINDOW_HEIGHT_DP.dp.toPx().toInt(),
                         )
                     }
-                    // Prefer the bounds of the display this window is on;
-                    // the toolkit's screenSize is the PRIMARY monitor only,
-                    // and on a multi-monitor setup where the user restored
-                    // the launcher on a smaller secondary screen the
-                    // primary-derived clamp can exceed the actual display
-                    // and block resize to a usable size. GraphicsConfiguration
-                    // returns null before the window is realised, so fall
-                    // back to the toolkit for the initial placement pass.
-                    //
-                    // Wayland peer-init quirk: on Hyprland (and other
-                    // Wayland compositors) starting tray-resident, the
-                    // Compose Window is created but not yet displayable.
-                    // window.graphicsConfiguration is non-null (returns
-                    // the device's default GC) but its bounds are
-                    // Rectangle(0,0,0,0) until the surface negotiates.
-                    // Treating that as a valid screen yields minimumSize
-                    // = (0,0) and the WM can later shrink the window to
-                    // a 1px sliver. Guard on positive bounds and fall
-                    // through to the toolkit size otherwise.
                     val gc = window.graphicsConfiguration
                     val gcBounds = gc?.bounds
                     val screen = if (gcBounds != null && gcBounds.width > 0 && gcBounds.height > 0) {
@@ -567,9 +537,6 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                     SwingUtilities.invokeLater { window.minimumSize = safe }
                 }
 
-                // Track current display id; AWT fires componentMoved on
-                // every pixel of a drag, so diff first and only recompute
-                // when the window actually crossed onto a new GraphicsDevice.
                 var lastDeviceId: String? = window.graphicsConfiguration?.device?.iDstring
                 val moveListener = object : java.awt.event.ComponentAdapter() {
                     override fun componentMoved(e: java.awt.event.ComponentEvent) {
@@ -581,7 +548,7 @@ fun ApplicationScope.AppShell(boot: LauncherBootstrap.Result) {
                     }
                 }
                 window.addComponentListener(moveListener)
-                applyClamp()  // initial placement pass
+                applyClamp()
 
                 onDispose {
                     window.removeComponentListener(moveListener)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsProgress.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsProgress.kt
@@ -20,36 +20,13 @@ object AprilFoolsProgress {
  
     fun reset() { displayProgress = 0f }
  
-    /**
-     * Returns a display progress value (0..1) that may occasionally regress.
-     *
-     * Sentinel: returns [Float.NaN] when bytes are flowing but the total
-     * is unknown (chunked HTTP without Content-Length, smrt sync's
-     * pre-tally phase). Callers must check [Float.isNaN] before binding
-     * the value to a determinate progress indicator; a NaN means
-     * "switch to indeterminate mode -- something is happening, but
-     * the bounded progress fraction is not yet computable". An earlier
-     * fix returned 0f for both (0,0) and (positive,0) which flatlined
-     * the bar during the pre-tally window even though bytes flowed.
-     *
-     * @param downloaded  Bytes actually downloaded so far (real value).
-     * @param total       Total bytes expected (real value).
-     */
+    // Returns 0..1 fraction, or Float.NaN when total is unknown but bytes
+    // flow (callers branch on isNaN to switch to indeterminate mode).
     fun wrap(downloaded: Long, total: Long): Float {
         if (total <= 0L) {
-            // (0, 0) = nothing started yet -> show empty.
-            // (positive, 0) = bytes flowing, size unknown -> NaN sentinel
-            // -> caller renders indeterminate.
-            //
-            // Also wipe displayProgress so the next determinate tick
-            // doesn't lerp from a stale carry-over. LaunchControlPanel
-            // calls resetProgress() only on Idle->Downloading edges,
-            // not on mid-session transitions through an unknown-total
-            // window (chunked HTTP without Content-Length, a
-            // pre-tally phase after a prior sync). Without this reset
-            // the bar visibly jerks from a near-1.0 carry-over down
-            // to a fresh small `real` value on the next tick with
-            // total > 0.
+            // Reset prevents lerp-from-stale jerk on next determinate tick;
+            // resetProgress() fires only on Idle->Downloading edges, missing
+            // this case.
             displayProgress = 0f
             return if (downloaded <= 0L) 0f else Float.NaN
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsProgress.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/easter/AprilFoolsProgress.kt
@@ -40,6 +40,17 @@ object AprilFoolsProgress {
             // (0, 0) = nothing started yet -> show empty.
             // (positive, 0) = bytes flowing, size unknown -> NaN sentinel
             // -> caller renders indeterminate.
+            //
+            // Also wipe displayProgress so the next determinate tick
+            // doesn't lerp from a stale carry-over. LaunchControlPanel
+            // calls resetProgress() only on Idle->Downloading edges,
+            // not on mid-session transitions through an unknown-total
+            // window (chunked HTTP without Content-Length, a
+            // pre-tally phase after a prior sync). Without this reset
+            // the bar visibly jerks from a near-1.0 carry-over down
+            // to a fresh small `real` value on the next tick with
+            // total > 0.
+            displayProgress = 0f
             return if (downloaded <= 0L) 0f else Float.NaN
         }
         if (!AprilFools.isActive()) {


### PR DESCRIPTION
## Summary

Phase-3 review of the codex-sweep PR surfaced three issues beyond the verified ten-finding list. Each is a "second-tier footgun" that the first pass missed.

## Fixes

| Sev | Site | Change |
|---|---|---|
| P2 | `AppShell.kt` window minimumSize | LaunchedEffect(Unit) -> DisposableEffect with ComponentAdapter; recompute clamp on screen-change crossings (diff GraphicsDevice id), no-op within-screen drags |
| P2 | `AprilFoolsProgress.kt` early-return | Reset displayProgress to 0f on total<=0 so the next determinate tick doesn't lerp from a stale ~0.95 carry-over |
| P2 | `SmrtSyncService.downloadToFile` | ATOMIC_MOVE + AtomicMoveNotSupportedException fallback (mirrors JsonPackRepository.persist hardening for FAT32 / SMB / Steam Deck SD card) |

## Findings sharpened (no code change)

- The merged PR's syncAsset reorder finding was P1 in the original write-up; closer reading drops severity to P2 -- silent-skip path only fires when traversal target both matches protected suffix AND happens to exist outside clientDir (e.g. real `options.txt` at `../../mc/`). Real-world surface narrower than the P1 framing.
- JsonPackRepository.persist outer catch CancellationException rethrow has no live cancellation path today (try body all blocking nio). Kept for parity with sibling sites against future async refactors; explicitly a future-trap guard, not a live bug.

## Test plan

- [x] `./gradlew :client-launcher:compileKotlin :client-ui:compileKotlinDesktop`
- [x] `./gradlew :client-launcher:test :client-ui:desktopTest` -- green
- [ ] Live smoke for screen-change: external monitor unplug while window on it, observe new clamp; chunked-HTTP-no-Content-Length sync back-to-back with prior sync, observe no progress-bar jerk.