### PR TITLE
feat(notifications): notification center + indications + session control

### DIFF
--- a/client-ui/build.gradle.kts
+++ b/client-ui/build.gradle.kts
@@ -98,6 +98,17 @@ kotlin {
                 implementation(libs.ktor.serialization.json)
             }
         }
+
+        // First UI-side test source set. Compose-MP auto-creates the
+        // task `desktopTest`; explicit source-set wiring lets the
+        // module declare kotlin-test + coroutines-test deps and pull
+        // in fakes from sibling modules.
+        val desktopTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(libs.kotlinx.coroutines.test)
+            }
+        }
     }
 }
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -52,6 +52,7 @@ import hivens.ui.generated.resources.icon
 import hivens.ui.i18n.AppLocale
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.i18n.LocaleProvider
+import hivens.ui.notifications.render.NotificationStack
 import hivens.ui.screens.ConsoleWindow
 import hivens.ui.screens.MigrationScreen
 import hivens.ui.theme.BrutStyle
@@ -777,6 +778,12 @@ fun AppRoot(
                 customization              = customization,
                 onCustomizationChanged     = onCustomizationChanged,
             )
+
+            // Notification stack overlays the AppLayout so toasts
+            // float above every screen. Inside af.WrapContent so the
+            // pixel-cursor / chaos-window effects share the layer
+            // order with launch state.
+            NotificationStack()
         }
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/AppShell.kt
@@ -779,10 +779,6 @@ fun AppRoot(
                 onCustomizationChanged     = onCustomizationChanged,
             )
 
-            // Notification stack overlays the AppLayout so toasts
-            // float above every screen. Inside af.WrapContent so the
-            // pixel-cursor / chaos-window effects share the layer
-            // order with launch state.
             NotificationStack()
         }
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -3,6 +3,10 @@ package hivens.ui
 import androidx.compose.ui.window.application
 import hivens.launcher.bootstrap.LauncherBootstrap
 import hivens.ui.identity.SkinManager
+import hivens.ui.notifications.IndicationCenter
+import hivens.ui.notifications.NotificationCenter
+import hivens.ui.notifications.SessionRegistry
+import hivens.ui.notifications.drivers.PackLaunchDriver
 import hivens.ui.puppet.PuppetServerLoader
 import hivens.ui.utils.GameConsoleService
 import org.jetbrains.compose.resources.ExperimentalResourceApi
@@ -19,6 +23,24 @@ import org.koin.dsl.module
 val uiModule = module {
     single { SkinManager(get(), get()) }
     single { GameConsoleService(get()) }
+
+    // Notification subsystem: data-only state holders (Center +
+    // Registry) are pure singletons; PackLaunchDriver bridges them
+    // to LauncherController, registered as a regular single so the
+    // UI's per-launch click can resolve it via koinInject.
+    single { NotificationCenter() }
+    single { IndicationCenter() }
+    single { SessionRegistry(appScope = get()) }
+    single {
+        PackLaunchDriver(
+            controller    = get(),
+            notifications = get(),
+            indications   = get(),
+            sessions      = get(),
+            gameConsole   = get(),
+            appScope      = get(),
+        )
+    }
 }
 
 // ─── Entry Point ─────────────────────────────────────────────────────────────

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/IndicationCenter.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/IndicationCenter.kt
@@ -6,31 +6,13 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import java.util.concurrent.ConcurrentHashMap
 
-/**
- * Passive UI signals -- the dots, spinners, glows that live inline
- * in the affordances they describe ([PackCard] glow when an instance
- * is launching, sidebar badge for "update available", header chip
- * for mirror health). Drivers push updates; renderers subscribe to
- * the per-affordance flow that matches their slot.
- *
- * Separation from [NotificationCenter] is deliberate: indications
- * are passive and ambient, notifications demand attention. A pack
- * preparing to launch has both -- a quiet glow on its Library card
- * (indication) AND a counter-grouped progress toast in the stack
- * (notification). Drivers update each layer independently.
- *
- * Per-pack flows are created lazily on first read and cached so a
- * renderer that subscribes before any driver has pushed gets a
- * stable StateFlow handle. The cache never shrinks within a
- * process lifetime; in practice the set of pack ids is bounded
- * (Library never holds thousands), so the leak is academic.
- */
+// Per-pack flows created lazily and cached; never shrinks (bounded
+// by Library's pack count, leak is academic).
 class IndicationCenter {
 
-    /** State of a pack launch as it should appear on the pack card. */
     sealed class LaunchIndication {
         data object Preparing : LaunchIndication()
-        /** Progress in 0..1, or null for indeterminate. */
+        // progress: null = indeterminate
         data class Downloading(val progress: Float?) : LaunchIndication()
         data object Running : LaunchIndication()
         data object Failed : LaunchIndication()
@@ -45,11 +27,6 @@ class IndicationCenter {
     private val _mirrorHealth = MutableStateFlow(MirrorHealth.Ok)
     val mirrorHealth: StateFlow<MirrorHealth> = _mirrorHealth.asStateFlow()
 
-    /**
-     * Per-pack launch indication. Renderers in `PackCard`,
-     * `PackDetail` hero, and the optional running-glow overlay all
-     * subscribe to the same flow for a given `packInstanceId`.
-     */
     fun launchIndication(packInstanceId: String): StateFlow<LaunchIndication?> =
         launchFlows.computeIfAbsent(packInstanceId) { MutableStateFlow(null) }.asStateFlow()
 
@@ -57,11 +34,6 @@ class IndicationCenter {
         launchFlows.computeIfAbsent(packInstanceId) { MutableStateFlow(null) }.value = value
     }
 
-    /**
-     * Per-pack "update available" badge. True = mirror has a
-     * pack_version newer than what the installed instance is pinned
-     * to. PackUpdateDriver (future) flips this on mirror polls.
-     */
     fun updateAvailable(packInstanceId: String): StateFlow<Boolean> =
         updateFlows.computeIfAbsent(packInstanceId) { MutableStateFlow(false) }.asStateFlow()
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/IndicationCenter.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/IndicationCenter.kt
@@ -1,0 +1,75 @@
+package hivens.ui.notifications
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Passive UI signals -- the dots, spinners, glows that live inline
+ * in the affordances they describe ([PackCard] glow when an instance
+ * is launching, sidebar badge for "update available", header chip
+ * for mirror health). Drivers push updates; renderers subscribe to
+ * the per-affordance flow that matches their slot.
+ *
+ * Separation from [NotificationCenter] is deliberate: indications
+ * are passive and ambient, notifications demand attention. A pack
+ * preparing to launch has both -- a quiet glow on its Library card
+ * (indication) AND a counter-grouped progress toast in the stack
+ * (notification). Drivers update each layer independently.
+ *
+ * Per-pack flows are created lazily on first read and cached so a
+ * renderer that subscribes before any driver has pushed gets a
+ * stable StateFlow handle. The cache never shrinks within a
+ * process lifetime; in practice the set of pack ids is bounded
+ * (Library never holds thousands), so the leak is academic.
+ */
+class IndicationCenter {
+
+    /** State of a pack launch as it should appear on the pack card. */
+    sealed class LaunchIndication {
+        data object Preparing : LaunchIndication()
+        /** Progress in 0..1, or null for indeterminate. */
+        data class Downloading(val progress: Float?) : LaunchIndication()
+        data object Running : LaunchIndication()
+        data object Failed : LaunchIndication()
+    }
+
+    enum class MirrorHealth { Ok, Degraded, Unreachable }
+
+    private val launchFlows: ConcurrentHashMap<String, MutableStateFlow<LaunchIndication?>> =
+        ConcurrentHashMap()
+    private val updateFlows: ConcurrentHashMap<String, MutableStateFlow<Boolean>> =
+        ConcurrentHashMap()
+    private val _mirrorHealth = MutableStateFlow(MirrorHealth.Ok)
+    val mirrorHealth: StateFlow<MirrorHealth> = _mirrorHealth.asStateFlow()
+
+    /**
+     * Per-pack launch indication. Renderers in `PackCard`,
+     * `PackDetail` hero, and the optional running-glow overlay all
+     * subscribe to the same flow for a given `packInstanceId`.
+     */
+    fun launchIndication(packInstanceId: String): StateFlow<LaunchIndication?> =
+        launchFlows.computeIfAbsent(packInstanceId) { MutableStateFlow(null) }.asStateFlow()
+
+    fun setLaunchIndication(packInstanceId: String, value: LaunchIndication?) {
+        launchFlows.computeIfAbsent(packInstanceId) { MutableStateFlow(null) }.value = value
+    }
+
+    /**
+     * Per-pack "update available" badge. True = mirror has a
+     * pack_version newer than what the installed instance is pinned
+     * to. PackUpdateDriver (future) flips this on mirror polls.
+     */
+    fun updateAvailable(packInstanceId: String): StateFlow<Boolean> =
+        updateFlows.computeIfAbsent(packInstanceId) { MutableStateFlow(false) }.asStateFlow()
+
+    fun setUpdateAvailable(packInstanceId: String, available: Boolean) {
+        updateFlows.computeIfAbsent(packInstanceId) { MutableStateFlow(false) }.value = available
+    }
+
+    fun setMirrorHealth(value: MirrorHealth) {
+        _mirrorHealth.update { value }
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Notification.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Notification.kt
@@ -1,0 +1,105 @@
+package hivens.ui.notifications
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Visual hint for a notification group's leading avatar slot. Stays
+ * abstract -- the renderer maps these to a Compose Painter at draw
+ * time so non-UI code (drivers, tests) does not depend on Coil /
+ * resource generation.
+ */
+sealed class AvatarSource {
+    /** Remote URL fetched + cached via Coil. Pack icons go here. */
+    data class Url(val url: String) : AvatarSource()
+
+    /**
+     * Reference to a known iconography slot (e.g. `mirror`, `update`,
+     * `system`). The renderer holds the registry of which Compose
+     * Painter to render per slot.
+     */
+    data class Glyph(val name: String) : AvatarSource()
+
+    /** Fallback when no specific avatar fits. Renders a neutral generic shape. */
+    data object Generic : AvatarSource()
+}
+
+/**
+ * One-click action attached to a notification event.
+ *
+ * `id` lets a future test or puppet observer assert "this action
+ * exists" without coupling to label text (which is i18n'd). Common
+ * ids: `show_console`, `retry`, `dismiss`, `view_details`.
+ */
+data class NotifAction(
+    val id: String,
+    val label: String,
+    val onClick: () -> Unit,
+)
+
+/**
+ * One event inside a [NotificationGroup]. A group accumulates events
+ * over time as the underlying operation progresses; the latest event
+ * is what the collapsed card displays, and the chevron expands to
+ * show the history.
+ *
+ * Progress semantics on [progress]:
+ *  - null  -> no progress bar, plain text card
+ *  - 0..1  -> determinate fraction, fills the accent strip
+ *  - NaN   -> indeterminate, accent strip animates
+ *
+ * Mirrors the sentinel contract from
+ * [hivens.ui.easter.AprilFoolsProgress.wrap] so a driver can pipe its
+ * download tick straight through.
+ */
+data class NotificationEvent(
+    val id: UUID,
+    val severity: Severity,
+    val title: String,
+    val body: String? = null,
+    val progress: Float? = null,
+    val actions: List<NotifAction> = emptyList(),
+    val createdAt: Instant,
+)
+
+/**
+ * Grouped notifications keyed by [sourceKey]. Re-pushing with the
+ * same `sourceKey` appends an event to the existing group rather
+ * than creating a parallel card.
+ *
+ * Why grouped: a single pack launch generates Prepare -> Downloading
+ * -> Running -> Exited within a session. Four separate cards would
+ * dominate the stack; one group with a counter + chevron-to-history
+ * keeps the visual quiet and the timeline accessible.
+ *
+ * `events` is newest-first and bounded ([NotificationCenter] caps at
+ * a small N; older events fall off the tail) so a runaway driver
+ * cannot blow up memory.
+ */
+data class NotificationGroup(
+    val sourceKey: String,
+    val sender: String,
+    val avatar: AvatarSource,
+    val events: List<NotificationEvent>,
+) {
+    init {
+        require(events.isNotEmpty()) {
+            "NotificationGroup($sourceKey) must contain at least one event"
+        }
+    }
+
+    /** Most-recent event in the group; what the collapsed card renders. */
+    val latest: NotificationEvent get() = events.first()
+
+    /**
+     * Group severity = the max severity across its events. A Critical
+     * event in any position of the history keeps the group critical
+     * even after a subsequent Info / Success arrives, so the user
+     * cannot accidentally miss a past hard failure that scrolled
+     * past.
+     */
+    val severity: Severity get() = events.maxOf { it.severity }
+
+    /** Count >= 2 unlocks the chevron + history-expand affordance. */
+    val count: Int get() = events.size
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Notification.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Notification.kt
@@ -3,55 +3,21 @@ package hivens.ui.notifications
 import java.time.Instant
 import java.util.UUID
 
-/**
- * Visual hint for a notification group's leading avatar slot. Stays
- * abstract -- the renderer maps these to a Compose Painter at draw
- * time so non-UI code (drivers, tests) does not depend on Coil /
- * resource generation.
- */
 sealed class AvatarSource {
-    /** Remote URL fetched + cached via Coil. Pack icons go here. */
     data class Url(val url: String) : AvatarSource()
-
-    /**
-     * Reference to a known iconography slot (e.g. `mirror`, `update`,
-     * `system`). The renderer holds the registry of which Compose
-     * Painter to render per slot.
-     */
     data class Glyph(val name: String) : AvatarSource()
-
-    /** Fallback when no specific avatar fits. Renders a neutral generic shape. */
     data object Generic : AvatarSource()
 }
 
-/**
- * One-click action attached to a notification event.
- *
- * `id` lets a future test or puppet observer assert "this action
- * exists" without coupling to label text (which is i18n'd). Common
- * ids: `show_console`, `retry`, `dismiss`, `view_details`.
- */
+// `id` is stable across i18n rebrands; tests + puppet observers key on it.
 data class NotifAction(
     val id: String,
     val label: String,
     val onClick: () -> Unit,
 )
 
-/**
- * One event inside a [NotificationGroup]. A group accumulates events
- * over time as the underlying operation progresses; the latest event
- * is what the collapsed card displays, and the chevron expands to
- * show the history.
- *
- * Progress semantics on [progress]:
- *  - null  -> no progress bar, plain text card
- *  - 0..1  -> determinate fraction, fills the accent strip
- *  - NaN   -> indeterminate, accent strip animates
- *
- * Mirrors the sentinel contract from
- * [hivens.ui.easter.AprilFoolsProgress.wrap] so a driver can pipe its
- * download tick straight through.
- */
+// progress: null -> no bar, 0..1 -> fraction, NaN -> indeterminate.
+// NaN sentinel matches AprilFoolsProgress.wrap so download ticks pipe through.
 data class NotificationEvent(
     val id: UUID,
     val severity: Severity,
@@ -62,20 +28,6 @@ data class NotificationEvent(
     val createdAt: Instant,
 )
 
-/**
- * Grouped notifications keyed by [sourceKey]. Re-pushing with the
- * same `sourceKey` appends an event to the existing group rather
- * than creating a parallel card.
- *
- * Why grouped: a single pack launch generates Prepare -> Downloading
- * -> Running -> Exited within a session. Four separate cards would
- * dominate the stack; one group with a counter + chevron-to-history
- * keeps the visual quiet and the timeline accessible.
- *
- * `events` is newest-first and bounded ([NotificationCenter] caps at
- * a small N; older events fall off the tail) so a runaway driver
- * cannot blow up memory.
- */
 data class NotificationGroup(
     val sourceKey: String,
     val sender: String,
@@ -88,18 +40,11 @@ data class NotificationGroup(
         }
     }
 
-    /** Most-recent event in the group; what the collapsed card renders. */
     val latest: NotificationEvent get() = events.first()
 
-    /**
-     * Group severity = the max severity across its events. A Critical
-     * event in any position of the history keeps the group critical
-     * even after a subsequent Info / Success arrives, so the user
-     * cannot accidentally miss a past hard failure that scrolled
-     * past.
-     */
+    // max across events, not events.first.severity -- a past Critical
+    // must keep the group visually marked even after a later Info.
     val severity: Severity get() = events.maxOf { it.severity }
 
-    /** Count >= 2 unlocks the chevron + history-expand affordance. */
     val count: Int get() = events.size
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/NotificationCenter.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/NotificationCenter.kt
@@ -6,22 +6,8 @@ import kotlinx.coroutines.flow.update
 import java.time.Instant
 import java.util.UUID
 
-/**
- * Process-singleton notification surface. Drivers push events keyed
- * by `sourceKey`; the center merges them into [NotificationGroup]s,
- * caps per-group event history, and exposes the current stack as a
- * [StateFlow] for [hivens.ui.notifications.render.NotificationStack]
- * to render.
- *
- * Threading: every mutation goes through [MutableStateFlow.update]
- * (compare-and-set retry loop), so concurrent drivers on different
- * coroutines do not lose events. Reading is lock-free.
- *
- * Persistence: zero. The stack lives in memory only; restarts wipe
- * the history. Acceptable for transient launch / sync / update
- * surfaces; a future per-pack notification log would be its own
- * subsystem.
- */
+// Mutations go through StateFlow.update (CAS retry) so concurrent
+// drivers on different coroutines do not lose events.
 class NotificationCenter(
     private val historyPerGroup: Int = DEFAULT_HISTORY_PER_GROUP,
     private val clock: () -> Instant = Instant::now,
@@ -29,14 +15,6 @@ class NotificationCenter(
     private val _groups = MutableStateFlow<List<NotificationGroup>>(emptyList())
     val groups: StateFlow<List<NotificationGroup>> = _groups
 
-    /**
-     * Push a new event onto the group identified by [sourceKey],
-     * creating the group when this is the first event from that key.
-     *
-     * Returns the resulting group's `sourceKey` for symmetry; callers
-     * track lifecycle via the key, not by event id, because the
-     * underlying event ids get replaced as history rolls over.
-     */
     fun push(
         sourceKey: String,
         sender: String,
@@ -59,9 +37,6 @@ class NotificationCenter(
         _groups.update { current ->
             val existingIndex = current.indexOfFirst { it.sourceKey == sourceKey }
             if (existingIndex < 0) {
-                // Newer groups render at the top of the visible stack;
-                // prepending keeps the most-recently-active source
-                // closest to the viewer.
                 listOf(
                     NotificationGroup(
                         sourceKey = sourceKey,
@@ -77,9 +52,6 @@ class NotificationCenter(
                     avatar = avatar,
                     events = (listOf(event) + existing.events).take(historyPerGroup),
                 )
-                // Float the touched group to the front -- the user's
-                // attention should follow whichever source last
-                // generated activity.
                 val others = current.toMutableList().also { it.removeAt(existingIndex) }
                 listOf(merged) + others
             }
@@ -87,15 +59,10 @@ class NotificationCenter(
         return sourceKey
     }
 
-    /**
-     * Drop a group from the visible stack. Idempotent; calling on an
-     * unknown sourceKey is a no-op.
-     */
     fun dismiss(sourceKey: String) {
         _groups.update { current -> current.filterNot { it.sourceKey == sourceKey } }
     }
 
-    /** Clear everything. Used on logout / data-dir-move to avoid stale cards. */
     fun clear() {
         _groups.value = emptyList()
     }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/NotificationCenter.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/NotificationCenter.kt
@@ -10,6 +10,7 @@ import java.util.UUID
 // drivers on different coroutines do not lose events.
 class NotificationCenter(
     private val historyPerGroup: Int = DEFAULT_HISTORY_PER_GROUP,
+    private val maxGroups: Int = DEFAULT_MAX_GROUPS,
     private val clock: () -> Instant = Instant::now,
 ) {
     private val _groups = MutableStateFlow<List<NotificationGroup>>(emptyList())
@@ -36,7 +37,7 @@ class NotificationCenter(
         )
         _groups.update { current ->
             val existingIndex = current.indexOfFirst { it.sourceKey == sourceKey }
-            if (existingIndex < 0) {
+            val newList = if (existingIndex < 0) {
                 listOf(
                     NotificationGroup(
                         sourceKey = sourceKey,
@@ -55,6 +56,10 @@ class NotificationCenter(
                 val others = current.toMutableList().also { it.removeAt(existingIndex) }
                 listOf(merged) + others
             }
+            // Drop oldest groups beyond cap; symmetric to historyPerGroup.
+            // Without it a future driver pushing N distinct sourceKeys grows
+            // _groups unboundedly while the visible stack stays at 4.
+            newList.take(maxGroups)
         }
         return sourceKey
     }
@@ -69,5 +74,6 @@ class NotificationCenter(
 
     companion object {
         const val DEFAULT_HISTORY_PER_GROUP = 20
+        const val DEFAULT_MAX_GROUPS = 32
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/NotificationCenter.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/NotificationCenter.kt
@@ -1,0 +1,106 @@
+package hivens.ui.notifications
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Process-singleton notification surface. Drivers push events keyed
+ * by `sourceKey`; the center merges them into [NotificationGroup]s,
+ * caps per-group event history, and exposes the current stack as a
+ * [StateFlow] for [hivens.ui.notifications.render.NotificationStack]
+ * to render.
+ *
+ * Threading: every mutation goes through [MutableStateFlow.update]
+ * (compare-and-set retry loop), so concurrent drivers on different
+ * coroutines do not lose events. Reading is lock-free.
+ *
+ * Persistence: zero. The stack lives in memory only; restarts wipe
+ * the history. Acceptable for transient launch / sync / update
+ * surfaces; a future per-pack notification log would be its own
+ * subsystem.
+ */
+class NotificationCenter(
+    private val historyPerGroup: Int = DEFAULT_HISTORY_PER_GROUP,
+    private val clock: () -> Instant = Instant::now,
+) {
+    private val _groups = MutableStateFlow<List<NotificationGroup>>(emptyList())
+    val groups: StateFlow<List<NotificationGroup>> = _groups
+
+    /**
+     * Push a new event onto the group identified by [sourceKey],
+     * creating the group when this is the first event from that key.
+     *
+     * Returns the resulting group's `sourceKey` for symmetry; callers
+     * track lifecycle via the key, not by event id, because the
+     * underlying event ids get replaced as history rolls over.
+     */
+    fun push(
+        sourceKey: String,
+        sender: String,
+        avatar: AvatarSource,
+        severity: Severity,
+        title: String,
+        body: String? = null,
+        progress: Float? = null,
+        actions: List<NotifAction> = emptyList(),
+    ): String {
+        val event = NotificationEvent(
+            id        = UUID.randomUUID(),
+            severity  = severity,
+            title     = title,
+            body      = body,
+            progress  = progress,
+            actions   = actions,
+            createdAt = clock(),
+        )
+        _groups.update { current ->
+            val existingIndex = current.indexOfFirst { it.sourceKey == sourceKey }
+            if (existingIndex < 0) {
+                // Newer groups render at the top of the visible stack;
+                // prepending keeps the most-recently-active source
+                // closest to the viewer.
+                listOf(
+                    NotificationGroup(
+                        sourceKey = sourceKey,
+                        sender    = sender,
+                        avatar    = avatar,
+                        events    = listOf(event),
+                    )
+                ) + current
+            } else {
+                val existing = current[existingIndex]
+                val merged = existing.copy(
+                    sender = sender,
+                    avatar = avatar,
+                    events = (listOf(event) + existing.events).take(historyPerGroup),
+                )
+                // Float the touched group to the front -- the user's
+                // attention should follow whichever source last
+                // generated activity.
+                val others = current.toMutableList().also { it.removeAt(existingIndex) }
+                listOf(merged) + others
+            }
+        }
+        return sourceKey
+    }
+
+    /**
+     * Drop a group from the visible stack. Idempotent; calling on an
+     * unknown sourceKey is a no-op.
+     */
+    fun dismiss(sourceKey: String) {
+        _groups.update { current -> current.filterNot { it.sourceKey == sourceKey } }
+    }
+
+    /** Clear everything. Used on logout / data-dir-move to avoid stale cards. */
+    fun clear() {
+        _groups.value = emptyList()
+    }
+
+    companion object {
+        const val DEFAULT_HISTORY_PER_GROUP = 20
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/SessionRegistry.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/SessionRegistry.kt
@@ -7,9 +7,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
 
 class SessionRegistry(
     private val appScope: CoroutineScope,
@@ -29,7 +31,11 @@ class SessionRegistry(
     private val _active = MutableStateFlow<Map<String, ActiveSession>>(emptyMap())
     val active: StateFlow<Map<String, ActiveSession>> = _active.asStateFlow()
 
-    private val uptimeJobs: MutableMap<String, Job> = mutableMapOf()
+    // ConcurrentHashMap, not plain MutableMap -- register/unregister can
+    // come from arbitrary coroutine contexts (driver-on-Default racing
+    // shutdown-hook); plain HashMap concurrent mutation corrupts the
+    // bucket table.
+    private val uptimeJobs: ConcurrentHashMap<String, Job> = ConcurrentHashMap()
 
     // Replaces on duplicate id: controller's re-entry guard rejects
     // concurrent launches, so a duplicate here means the prior session
@@ -52,20 +58,22 @@ class SessionRegistry(
             abort            = abort,
             showConsole      = showConsole,
         )
-        _active.value = _active.value + (packInstanceId to session)
+        // update {} is CAS-retry; plain `value = value + ...` is non-atomic
+        // and loses entries under concurrent register/unregister.
+        _active.update { it + (packInstanceId to session) }
 
-        uptimeJobs.remove(packInstanceId)?.cancel()
-        uptimeJobs[packInstanceId] = appScope.launch(Dispatchers.Default) {
+        val newJob = appScope.launch(Dispatchers.Default) {
             while (true) {
                 uptime.value = Duration.between(startedAt, clock())
                 delay(1_000L)
             }
         }
+        uptimeJobs.put(packInstanceId, newJob)?.cancel()
         return session
     }
 
     fun unregister(packInstanceId: String) {
         uptimeJobs.remove(packInstanceId)?.cancel()
-        _active.value = _active.value - packInstanceId
+        _active.update { it - packInstanceId }
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/SessionRegistry.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/SessionRegistry.kt
@@ -1,0 +1,109 @@
+package hivens.ui.notifications
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Live registry of running pack-spawned processes. A "session" is
+ * one [Process] tied to one [PackInstance]; the launcher's existing
+ * re-entry guard caps the registry at one concurrent session per
+ * pack, so the registry is keyed by `packInstanceId`.
+ *
+ * Separate from both [NotificationCenter] and [IndicationCenter]
+ * because session state is PERSISTENT (the chip stays visible while
+ * the game runs, possibly for hours) -- not transient like a toast
+ * and not contextual like a glow. The Library sidebar's "Active
+ * sessions" section is the canonical render surface.
+ *
+ * The registry does not own the Process; it holds a weak control
+ * handle ([ActiveSession.abort]) that delegates to the existing
+ * [hivens.launcher.launch.LauncherController.abort]. Killing a
+ * session from the chip is identical to clicking Abort on the
+ * legacy launch panel.
+ */
+class SessionRegistry(
+    private val appScope: CoroutineScope,
+    private val clock: () -> Instant = Instant::now,
+) {
+
+    /**
+     * One live session. `uptime` ticks every second while the
+     * session is registered; once [SessionRegistry.unregister]
+     * fires, the flow stops emitting and the chip disappears.
+     */
+    data class ActiveSession(
+        val packInstanceId: String,
+        val packDisplayName: String,
+        val packIconUrl: String?,
+        val startedAt: Instant,
+        val uptime: StateFlow<Duration>,
+        val abort: () -> Unit,
+        val showConsole: () -> Unit,
+    )
+
+    private val _active = MutableStateFlow<Map<String, ActiveSession>>(emptyMap())
+    val active: StateFlow<Map<String, ActiveSession>> = _active.asStateFlow()
+
+    private val uptimeJobs: MutableMap<String, Job> = mutableMapOf()
+
+    /**
+     * Register a session. Returns the registered [ActiveSession] so
+     * the caller can hand a stable reference to whichever UI surface
+     * needs the abort / showConsole callbacks (notification toast's
+     * action button reuses the same instances the chip renders).
+     *
+     * Calling `register` for an id already present REPLACES the
+     * entry -- the previous launch must have already exited and the
+     * controller's re-entry guard rejected anything in between, so
+     * we treat the new arrival as authoritative.
+     */
+    fun register(
+        packInstanceId: String,
+        packDisplayName: String,
+        packIconUrl: String?,
+        abort: () -> Unit,
+        showConsole: () -> Unit,
+    ): ActiveSession {
+        val startedAt = clock()
+        val uptime = MutableStateFlow(Duration.ZERO)
+        val session = ActiveSession(
+            packInstanceId   = packInstanceId,
+            packDisplayName  = packDisplayName,
+            packIconUrl      = packIconUrl,
+            startedAt        = startedAt,
+            uptime           = uptime.asStateFlow(),
+            abort            = abort,
+            showConsole      = showConsole,
+        )
+        _active.value = _active.value + (packInstanceId to session)
+
+        // Stop any prior ticker (replace semantics) before starting
+        // a fresh one for this session.
+        uptimeJobs.remove(packInstanceId)?.cancel()
+        uptimeJobs[packInstanceId] = appScope.launch(Dispatchers.Default) {
+            while (true) {
+                uptime.value = Duration.between(startedAt, clock())
+                delay(1_000L)
+            }
+        }
+        return session
+    }
+
+    /**
+     * Remove a session from the registry. Idempotent; calling for an
+     * unknown id is a no-op. Cancels the per-session uptime ticker
+     * so it does not leak past the chip's lifetime.
+     */
+    fun unregister(packInstanceId: String) {
+        uptimeJobs.remove(packInstanceId)?.cancel()
+        _active.value = _active.value - packInstanceId
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/SessionRegistry.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/SessionRegistry.kt
@@ -11,34 +11,11 @@ import kotlinx.coroutines.launch
 import java.time.Duration
 import java.time.Instant
 
-/**
- * Live registry of running pack-spawned processes. A "session" is
- * one [Process] tied to one [PackInstance]; the launcher's existing
- * re-entry guard caps the registry at one concurrent session per
- * pack, so the registry is keyed by `packInstanceId`.
- *
- * Separate from both [NotificationCenter] and [IndicationCenter]
- * because session state is PERSISTENT (the chip stays visible while
- * the game runs, possibly for hours) -- not transient like a toast
- * and not contextual like a glow. The Library sidebar's "Active
- * sessions" section is the canonical render surface.
- *
- * The registry does not own the Process; it holds a weak control
- * handle ([ActiveSession.abort]) that delegates to the existing
- * [hivens.launcher.launch.LauncherController.abort]. Killing a
- * session from the chip is identical to clicking Abort on the
- * legacy launch panel.
- */
 class SessionRegistry(
     private val appScope: CoroutineScope,
     private val clock: () -> Instant = Instant::now,
 ) {
 
-    /**
-     * One live session. `uptime` ticks every second while the
-     * session is registered; once [SessionRegistry.unregister]
-     * fires, the flow stops emitting and the chip disappears.
-     */
     data class ActiveSession(
         val packInstanceId: String,
         val packDisplayName: String,
@@ -54,17 +31,9 @@ class SessionRegistry(
 
     private val uptimeJobs: MutableMap<String, Job> = mutableMapOf()
 
-    /**
-     * Register a session. Returns the registered [ActiveSession] so
-     * the caller can hand a stable reference to whichever UI surface
-     * needs the abort / showConsole callbacks (notification toast's
-     * action button reuses the same instances the chip renders).
-     *
-     * Calling `register` for an id already present REPLACES the
-     * entry -- the previous launch must have already exited and the
-     * controller's re-entry guard rejected anything in between, so
-     * we treat the new arrival as authoritative.
-     */
+    // Replaces on duplicate id: controller's re-entry guard rejects
+    // concurrent launches, so a duplicate here means the prior session
+    // already exited and the new arrival is authoritative.
     fun register(
         packInstanceId: String,
         packDisplayName: String,
@@ -85,8 +54,6 @@ class SessionRegistry(
         )
         _active.value = _active.value + (packInstanceId to session)
 
-        // Stop any prior ticker (replace semantics) before starting
-        // a fresh one for this session.
         uptimeJobs.remove(packInstanceId)?.cancel()
         uptimeJobs[packInstanceId] = appScope.launch(Dispatchers.Default) {
             while (true) {
@@ -97,11 +64,6 @@ class SessionRegistry(
         return session
     }
 
-    /**
-     * Remove a session from the registry. Idempotent; calling for an
-     * unknown id is a no-op. Cancels the per-session uptime ticker
-     * so it does not leak past the chip's lifetime.
-     */
     fun unregister(packInstanceId: String) {
         uptimeJobs.remove(packInstanceId)?.cancel()
         _active.value = _active.value - packInstanceId

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Severity.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Severity.kt
@@ -3,42 +3,17 @@ package hivens.ui.notifications
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
-/**
- * Severity of a [NotificationEvent]. Drives two things:
- *
- *  - Auto-dismiss policy on the parent [NotificationGroup]. Critical
- *    notifications never auto-dismiss; progress and warning ones stay
- *    until the next event in the group overrides them; info and
- *    success auto-dismiss after a short window.
- *  - Visual accent on the rendered card (slim left bar). Default is
- *    a passive surface with no accent; warnings get a muted accent,
- *    criticals get a pulsing accent.
- *
- * The enum order is the visual severity ladder -- if a group has
- * mixed severities (Info event followed by Critical), the group's
- * effective severity is `events.maxOf { it.severity }`.
- */
+// Ordering matters: NotificationGroup.severity is `events.maxOf { it.severity }`,
+// so a past Critical event stays visually marked as Critical even after a later
+// Info arrives -- prevents accidentally hiding hard failures that scrolled past.
 enum class Severity {
-    /** Background info; quietly auto-dismisses after a short window. */
     Info,
-
-    /** Long-running progress; sticky until the group ends in Success / Warn / Critical. */
     Progress,
-
-    /** Operation finished cleanly; auto-dismisses after a short window. */
     Success,
-
-    /** Recoverable issue; sticky until acknowledged or superseded by the next event. */
     Warn,
-
-    /** User must act; never auto-dismisses, accent pulses. */
     Critical;
 
-    /**
-     * Time after which a single-event group at this severity should
-     * disappear from the visible stack. Null = sticky (user dismisses
-     * or the next event in the group supersedes).
-     */
+    /** Null = sticky until manually dismissed or the next event in the group supersedes. */
     val autoDismissAfter: Duration?
         get() = when (this) {
             Info     -> 5.seconds

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Severity.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Severity.kt
@@ -1,0 +1,50 @@
+package hivens.ui.notifications
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Severity of a [NotificationEvent]. Drives two things:
+ *
+ *  - Auto-dismiss policy on the parent [NotificationGroup]. Critical
+ *    notifications never auto-dismiss; progress and warning ones stay
+ *    until the next event in the group overrides them; info and
+ *    success auto-dismiss after a short window.
+ *  - Visual accent on the rendered card (slim left bar). Default is
+ *    a passive surface with no accent; warnings get a muted accent,
+ *    criticals get a pulsing accent.
+ *
+ * The enum order is the visual severity ladder -- if a group has
+ * mixed severities (Info event followed by Critical), the group's
+ * effective severity is `events.maxOf { it.severity }`.
+ */
+enum class Severity {
+    /** Background info; quietly auto-dismisses after a short window. */
+    Info,
+
+    /** Long-running progress; sticky until the group ends in Success / Warn / Critical. */
+    Progress,
+
+    /** Operation finished cleanly; auto-dismisses after a short window. */
+    Success,
+
+    /** Recoverable issue; sticky until acknowledged or superseded by the next event. */
+    Warn,
+
+    /** User must act; never auto-dismisses, accent pulses. */
+    Critical;
+
+    /**
+     * Time after which a single-event group at this severity should
+     * disappear from the visible stack. Null = sticky (user dismisses
+     * or the next event in the group supersedes).
+     */
+    val autoDismissAfter: Duration?
+        get() = when (this) {
+            Info     -> 5.seconds
+            Success  -> 4.seconds
+            Progress -> null
+            Warn     -> 30.seconds
+            Critical -> null
+        }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
@@ -16,27 +16,10 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
 
-/**
- * Bridge between [LauncherController] launch state and the three
- * notification-system surfaces. One driver instance per process; the
- * UI calls [observe] right after invoking
- * [LauncherController.launchPackInstance] and the driver mirrors
- * every state transition until the controller settles back to Idle
- * (or hits Error).
- *
- * Why a per-launch observer instead of a single global subscription
- * to `controller.state`: the controller's state is generic (Prepare /
- * Downloading / GameRunning / Error) and doesn't carry the pack
- * identity. Tying the observation lifecycle to the click that
- * triggered the launch lets us key every notification / indication /
- * session entry on the pack the user actually started, without
- * widening the controller's contract.
- *
- * The controller's re-entry guard prevents concurrent launches, so
- * at most one launch is observed at any time -- starting a second
- * launch while the first is still in flight is rejected at the
- * controller level before this driver sees anything.
- */
+// Per-launch observer rather than global controller.state subscription:
+// LaunchState doesn't carry pack identity, and binding the observer to
+// the click that started the launch is how we key the resulting
+// notification/indication/session entries on the right pack.
 class PackLaunchDriver(
     private val controller: LauncherController,
     private val notifications: NotificationCenter,
@@ -47,26 +30,13 @@ class PackLaunchDriver(
 ) {
     private val log = LoggerFactory.getLogger(PackLaunchDriver::class.java)
 
-    /**
-     * Begin observing the controller until the launch initiated for
-     * [pack] completes (Idle) or fails (Error). Safe to call before
-     * the click that triggers the launch reaches the controller --
-     * the observer waits for the first non-Idle state before
-     * binding, so a stale Idle from a previous launch does not
-     * cause a phantom completion event.
-     */
     fun observe(pack: PackInstance) {
         appScope.launch {
             try {
-                // Wait for the click's launchPackInstance to actually
-                // flip state away from Idle. Without this guard the
-                // first collect tick would see Idle (the residual
-                // state from any previous run) and the driver would
-                // immediately think the new launch finished.
+                // Wait for non-Idle so a residual Idle from a previous
+                // launch doesn't trigger a phantom completion.
                 controller.state.first { it !is LaunchState.Idle }
 
-                // Now mirror every transition. The collect ends when
-                // we hit a terminal state and explicitly return.
                 controller.state.collect { state ->
                     when (state) {
                         is LaunchState.Prepare       -> onPrepare(pack, state)
@@ -131,7 +101,7 @@ class PackLaunchDriver(
         sessions.register(
             packInstanceId  = pack.id,
             packDisplayName = pack.displayName,
-            packIconUrl     = null,  // wired when [[project_pack_rich_metadata]] lands
+            packIconUrl     = null,
             abort           = { controller.abort() },
             showConsole     = { gameConsole.show() },
         )
@@ -166,10 +136,8 @@ class PackLaunchDriver(
     }
 
     private fun onIdle(pack: PackInstance) {
-        // Idle reached after a non-Idle pass = the launch completed
-        // cleanly (exit code 0 path). Tear down the active session
-        // and let the indication fade. The notification group keeps
-        // its history so the user can scroll back through the run.
+        // Idle after non-Idle = clean exit (code 0). Group history stays
+        // so the user can scroll back through the run.
         indications.setLaunchIndication(pack.id, null)
         sessions.unregister(pack.id)
         notifications.push(
@@ -185,9 +153,7 @@ class PackLaunchDriver(
     private fun sourceKeyFor(pack: PackInstance): String = "pack:${pack.id}:launch"
 
     private fun avatarFor(pack: PackInstance): AvatarSource =
-        // PackInstance does not yet carry icon_url; once
-        // [[project_pack_rich_metadata]] propagates the cached
-        // summary url into PackInstance, swap to AvatarSource.Url.
+        // PackInstance does not carry icon_url yet; swap to Url when it does.
         AvatarSource.Generic
 
     private fun humanReason(reason: LaunchError): String = when (reason) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
@@ -1,0 +1,201 @@
+package hivens.ui.notifications.drivers
+
+import hivens.core.data.PackInstance
+import hivens.launcher.launch.LaunchError
+import hivens.launcher.launch.LaunchState
+import hivens.launcher.launch.LauncherController
+import hivens.ui.notifications.AvatarSource
+import hivens.ui.notifications.IndicationCenter
+import hivens.ui.notifications.IndicationCenter.LaunchIndication
+import hivens.ui.notifications.NotifAction
+import hivens.ui.notifications.NotificationCenter
+import hivens.ui.notifications.SessionRegistry
+import hivens.ui.utils.GameConsoleService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+
+/**
+ * Bridge between [LauncherController] launch state and the three
+ * notification-system surfaces. One driver instance per process; the
+ * UI calls [observe] right after invoking
+ * [LauncherController.launchPackInstance] and the driver mirrors
+ * every state transition until the controller settles back to Idle
+ * (or hits Error).
+ *
+ * Why a per-launch observer instead of a single global subscription
+ * to `controller.state`: the controller's state is generic (Prepare /
+ * Downloading / GameRunning / Error) and doesn't carry the pack
+ * identity. Tying the observation lifecycle to the click that
+ * triggered the launch lets us key every notification / indication /
+ * session entry on the pack the user actually started, without
+ * widening the controller's contract.
+ *
+ * The controller's re-entry guard prevents concurrent launches, so
+ * at most one launch is observed at any time -- starting a second
+ * launch while the first is still in flight is rejected at the
+ * controller level before this driver sees anything.
+ */
+class PackLaunchDriver(
+    private val controller: LauncherController,
+    private val notifications: NotificationCenter,
+    private val indications: IndicationCenter,
+    private val sessions: SessionRegistry,
+    private val gameConsole: GameConsoleService,
+    private val appScope: CoroutineScope,
+) {
+    private val log = LoggerFactory.getLogger(PackLaunchDriver::class.java)
+
+    /**
+     * Begin observing the controller until the launch initiated for
+     * [pack] completes (Idle) or fails (Error). Safe to call before
+     * the click that triggers the launch reaches the controller --
+     * the observer waits for the first non-Idle state before
+     * binding, so a stale Idle from a previous launch does not
+     * cause a phantom completion event.
+     */
+    fun observe(pack: PackInstance) {
+        appScope.launch {
+            try {
+                // Wait for the click's launchPackInstance to actually
+                // flip state away from Idle. Without this guard the
+                // first collect tick would see Idle (the residual
+                // state from any previous run) and the driver would
+                // immediately think the new launch finished.
+                controller.state.first { it !is LaunchState.Idle }
+
+                // Now mirror every transition. The collect ends when
+                // we hit a terminal state and explicitly return.
+                controller.state.collect { state ->
+                    when (state) {
+                        is LaunchState.Prepare       -> onPrepare(pack, state)
+                        is LaunchState.Downloading   -> onDownloading(pack, state)
+                        is LaunchState.GameRunning   -> onRunning(pack, state)
+                        is LaunchState.Error         -> {
+                            onError(pack, state.reason)
+                            return@collect
+                        }
+                        LaunchState.Idle             -> {
+                            onIdle(pack)
+                            return@collect
+                        }
+                    }
+                }
+            } catch (e: Exception) {
+                log.warn("PackLaunchDriver observation aborted for ${pack.id}", e)
+                indications.setLaunchIndication(pack.id, null)
+                sessions.unregister(pack.id)
+            }
+        }
+    }
+
+    private fun onPrepare(pack: PackInstance, state: LaunchState.Prepare) {
+        indications.setLaunchIndication(pack.id, LaunchIndication.Preparing)
+        notifications.push(
+            sourceKey = sourceKeyFor(pack),
+            sender    = pack.displayName,
+            avatar    = avatarFor(pack),
+            severity  = hivens.ui.notifications.Severity.Progress,
+            title     = "Preparing ${pack.displayName}",
+            body      = "Stage: ${state.stage.name.lowercase()}",
+            progress  = state.progress.coerceIn(0f, 1f),
+        )
+    }
+
+    private fun onDownloading(pack: PackInstance, state: LaunchState.Downloading) {
+        val fraction = if (state.totalBytes > 0L) {
+            state.downloadedBytes.toFloat() / state.totalBytes
+        } else if (state.downloadedBytes > 0L) {
+            Float.NaN  // bytes flowing but size unknown
+        } else {
+            0f
+        }
+        indications.setLaunchIndication(pack.id, LaunchIndication.Downloading(fraction))
+
+        val displayPct =
+            if (fraction.isNaN()) "downloading..." else "${(fraction * 100).toInt()}%"
+        notifications.push(
+            sourceKey = sourceKeyFor(pack),
+            sender    = pack.displayName,
+            avatar    = avatarFor(pack),
+            severity  = hivens.ui.notifications.Severity.Progress,
+            title     = "Syncing ${pack.displayName}",
+            body      = "${state.currentFileIdx}/${state.totalFiles} files, $displayPct",
+            progress  = fraction,
+        )
+    }
+
+    private fun onRunning(pack: PackInstance, state: LaunchState.GameRunning) {
+        indications.setLaunchIndication(pack.id, LaunchIndication.Running)
+        sessions.register(
+            packInstanceId  = pack.id,
+            packDisplayName = pack.displayName,
+            packIconUrl     = null,  // wired when [[project_pack_rich_metadata]] lands
+            abort           = { controller.abort() },
+            showConsole     = { gameConsole.show() },
+        )
+        notifications.push(
+            sourceKey = sourceKeyFor(pack),
+            sender    = pack.displayName,
+            avatar    = avatarFor(pack),
+            severity  = hivens.ui.notifications.Severity.Success,
+            title     = "${pack.displayName} is running",
+            body      = null,
+            actions   = listOf(
+                NotifAction("show_console", "Show console") { gameConsole.show() },
+                NotifAction("abort", "Stop") { controller.abort() },
+            ),
+        )
+    }
+
+    private fun onError(pack: PackInstance, reason: LaunchError) {
+        indications.setLaunchIndication(pack.id, LaunchIndication.Failed)
+        sessions.unregister(pack.id)
+        notifications.push(
+            sourceKey = sourceKeyFor(pack),
+            sender    = pack.displayName,
+            avatar    = avatarFor(pack),
+            severity  = hivens.ui.notifications.Severity.Critical,
+            title     = "${pack.displayName} failed to launch",
+            body      = humanReason(reason),
+            actions   = listOf(
+                NotifAction("show_console", "Show console") { gameConsole.show() },
+            ),
+        )
+    }
+
+    private fun onIdle(pack: PackInstance) {
+        // Idle reached after a non-Idle pass = the launch completed
+        // cleanly (exit code 0 path). Tear down the active session
+        // and let the indication fade. The notification group keeps
+        // its history so the user can scroll back through the run.
+        indications.setLaunchIndication(pack.id, null)
+        sessions.unregister(pack.id)
+        notifications.push(
+            sourceKey = sourceKeyFor(pack),
+            sender    = pack.displayName,
+            avatar    = avatarFor(pack),
+            severity  = hivens.ui.notifications.Severity.Success,
+            title     = "${pack.displayName} session ended",
+            body      = null,
+        )
+    }
+
+    private fun sourceKeyFor(pack: PackInstance): String = "pack:${pack.id}:launch"
+
+    private fun avatarFor(pack: PackInstance): AvatarSource =
+        // PackInstance does not yet carry icon_url; once
+        // [[project_pack_rich_metadata]] propagates the cached
+        // summary url into PackInstance, swap to AvatarSource.Url.
+        AvatarSource.Generic
+
+    private fun humanReason(reason: LaunchError): String = when (reason) {
+        is LaunchError.ExitCode       -> "Game exited with code ${reason.code}"
+        is LaunchError.Internal       -> reason.message.ifBlank { "Internal error" }
+        is LaunchError.AuthFail       -> reason.cause?.ifBlank { null } ?: "Authentication failed"
+        LaunchError.OfflineNoClient   -> "Pack files missing on disk"
+        LaunchError.OfflineNoManifest -> "No cached manifest; go online once to sync"
+        LaunchError.TwoFactorExpired  -> "Sign in again to refresh credentials"
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
@@ -10,11 +10,18 @@ import hivens.ui.notifications.IndicationCenter.LaunchIndication
 import hivens.ui.notifications.NotifAction
 import hivens.ui.notifications.NotificationCenter
 import hivens.ui.notifications.SessionRegistry
+import hivens.ui.notifications.Severity
 import hivens.ui.utils.GameConsoleService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.transformWhile
 import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 
 // Per-launch observer rather than global controller.state subscription:
 // LaunchState doesn't carry pack identity, and binding the observer to
@@ -30,34 +37,48 @@ class PackLaunchDriver(
 ) {
     private val log = LoggerFactory.getLogger(PackLaunchDriver::class.java)
 
-    fun observe(pack: PackInstance) {
-        appScope.launch {
-            try {
-                // Wait for non-Idle so a residual Idle from a previous
-                // launch doesn't trigger a phantom completion.
-                controller.state.first { it !is LaunchState.Idle }
+    // Per-pack de-dup: rapid double-clicks must not stack observers.
+    // put-then-cancel-previous is atomic via ConcurrentHashMap.put returning
+    // the prior mapping.
+    private val observerJobs: ConcurrentHashMap<String, Job> = ConcurrentHashMap()
 
-                controller.state.collect { state ->
-                    when (state) {
-                        is LaunchState.Prepare       -> onPrepare(pack, state)
-                        is LaunchState.Downloading   -> onDownloading(pack, state)
-                        is LaunchState.GameRunning   -> onRunning(pack, state)
-                        is LaunchState.Error         -> {
-                            onError(pack, state.reason)
-                            return@collect
-                        }
-                        LaunchState.Idle             -> {
-                            onIdle(pack)
-                            return@collect
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun observe(pack: PackInstance) {
+        val job = appScope.launch {
+            try {
+                // dropWhile-until-Prepare handles BOTH stale-Idle and stale-
+                // terminal (Error / GameRunning from a previous launch).
+                // launchPackInstance always transitions through Prepare(INIT)
+                // first, so the new launch's first state passes the gate.
+                //
+                // transformWhile-emit-then-stop terminates the flow on the
+                // first terminal value seen. `return@launch` from inside a
+                // crossinline `collect { }` lambda is prohibited; this is
+                // the flow-operator equivalent.
+                controller.state
+                    .dropWhile { it !is LaunchState.Prepare }
+                    .transformWhile { state ->
+                        emit(state)
+                        state !is LaunchState.Idle && state !is LaunchState.Error
+                    }
+                    .collect { state ->
+                        when (state) {
+                            is LaunchState.Prepare     -> onPrepare(pack, state)
+                            is LaunchState.Downloading -> onDownloading(pack, state)
+                            is LaunchState.GameRunning -> onRunning(pack, state)
+                            is LaunchState.Error       -> onError(pack, state.reason)
+                            LaunchState.Idle           -> onIdle(pack)
                         }
                     }
-                }
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 log.warn("PackLaunchDriver observation aborted for ${pack.id}", e)
                 indications.setLaunchIndication(pack.id, null)
                 sessions.unregister(pack.id)
             }
         }
+        observerJobs.put(pack.id, job)?.cancel()
     }
 
     private fun onPrepare(pack: PackInstance, state: LaunchState.Prepare) {
@@ -66,7 +87,7 @@ class PackLaunchDriver(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
             avatar    = avatarFor(pack),
-            severity  = hivens.ui.notifications.Severity.Progress,
+            severity  = Severity.Progress,
             title     = "Preparing ${pack.displayName}",
             body      = "Stage: ${state.stage.name.lowercase()}",
             progress  = state.progress.coerceIn(0f, 1f),
@@ -74,25 +95,27 @@ class PackLaunchDriver(
     }
 
     private fun onDownloading(pack: PackInstance, state: LaunchState.Downloading) {
-        val fraction = if (state.totalBytes > 0L) {
-            state.downloadedBytes.toFloat() / state.totalBytes
-        } else if (state.downloadedBytes > 0L) {
-            Float.NaN  // bytes flowing but size unknown
-        } else {
-            0f
+        // null = indeterminate per LaunchIndication.Downloading.progress
+        // contract; NaN sentinel goes only to NotificationEvent.progress
+        // where the renderer branches on isNaN.
+        val fraction: Float? = when {
+            state.totalBytes > 0L      -> state.downloadedBytes.toFloat() / state.totalBytes
+            state.downloadedBytes > 0L -> null
+            else                       -> 0f
         }
         indications.setLaunchIndication(pack.id, LaunchIndication.Downloading(fraction))
 
+        val notifProgress: Float = fraction ?: Float.NaN
         val displayPct =
-            if (fraction.isNaN()) "downloading..." else "${(fraction * 100).toInt()}%"
+            if (fraction == null) "downloading..." else "${(fraction * 100).toInt()}%"
         notifications.push(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
             avatar    = avatarFor(pack),
-            severity  = hivens.ui.notifications.Severity.Progress,
+            severity  = Severity.Progress,
             title     = "Syncing ${pack.displayName}",
             body      = "${state.currentFileIdx}/${state.totalFiles} files, $displayPct",
-            progress  = fraction,
+            progress  = notifProgress,
         )
     }
 
@@ -109,7 +132,7 @@ class PackLaunchDriver(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
             avatar    = avatarFor(pack),
-            severity  = hivens.ui.notifications.Severity.Success,
+            severity  = Severity.Success,
             title     = "${pack.displayName} is running",
             body      = null,
             actions   = listOf(
@@ -126,7 +149,7 @@ class PackLaunchDriver(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
             avatar    = avatarFor(pack),
-            severity  = hivens.ui.notifications.Severity.Critical,
+            severity  = Severity.Critical,
             title     = "${pack.displayName} failed to launch",
             body      = humanReason(reason),
             actions   = listOf(
@@ -144,7 +167,7 @@ class PackLaunchDriver(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
             avatar    = avatarFor(pack),
-            severity  = hivens.ui.notifications.Severity.Success,
+            severity  = Severity.Success,
             title     = "${pack.displayName} session ended",
             body      = null,
         )
@@ -152,9 +175,8 @@ class PackLaunchDriver(
 
     private fun sourceKeyFor(pack: PackInstance): String = "pack:${pack.id}:launch"
 
-    private fun avatarFor(pack: PackInstance): AvatarSource =
-        // PackInstance does not carry icon_url yet; swap to Url when it does.
-        AvatarSource.Generic
+    // PackInstance does not carry icon_url yet; swap to Url when it does.
+    private fun avatarFor(pack: PackInstance): AvatarSource = AvatarSource.Generic
 
     private fun humanReason(reason: LaunchError): String = when (reason) {
         is LaunchError.ExitCode       -> "Game exited with code ${reason.code}"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
@@ -1,0 +1,313 @@
+package hivens.ui.notifications.render
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ExpandLess
+import androidx.compose.material.icons.filled.ExpandMore
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.ui.notifications.NotificationEvent
+import hivens.ui.notifications.NotificationGroup
+import hivens.ui.notifications.Severity
+import hivens.ui.theme.CelestiaTheme
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * One stacked notification group. Top row: avatar + sender + relative
+ * time + (counter+chevron when history exists). Middle: title + body
+ * of the latest event, optional progress bar inline with the accent.
+ * Bottom: action chips, if any.
+ *
+ * Expanded view (chevron click) reveals previous events of the group
+ * as tighter rows under the latest one. Severity above Info adds a
+ * slim accent bar on the left; Critical pulses.
+ */
+@Composable
+fun NotificationCard(
+    group: NotificationGroup,
+    now: Instant,
+    onDismiss: () -> Unit,
+) {
+    var expanded by remember(group.sourceKey) { mutableStateOf(false) }
+    val accentColor = severityAccent(group.severity)
+    val accentAlpha = if (group.severity == Severity.Critical) criticalPulse() else 1f
+
+    Box(
+        modifier = Modifier
+            .widthIn(min = 320.dp, max = 420.dp)
+            .clip(RoundedCornerShape(6.dp))
+            .background(CelestiaTheme.colors.surface)
+    ) {
+        Row(modifier = Modifier.fillMaxWidth()) {
+            // Accent strip on the left. Hidden for Info to keep
+            // routine notifications visually quiet; promoted to a
+            // narrow vertical band for Warn / Progress / Success and
+            // a wider pulsing band for Critical.
+            if (group.severity != Severity.Info) {
+                Box(
+                    modifier = Modifier
+                        .width(if (group.severity == Severity.Critical) 4.dp else 3.dp)
+                        .fillMaxHeight()
+                        .background(accentColor.copy(alpha = accentAlpha))
+                )
+            }
+
+            Column(modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp)) {
+                HeaderRow(
+                    group       = group,
+                    now         = now,
+                    expanded    = expanded,
+                    onToggle    = { if (group.count > 1) expanded = !expanded },
+                    onDismiss   = onDismiss,
+                )
+
+                Spacer(Modifier.height(6.dp))
+
+                EventBody(event = group.latest, accentColor = accentColor)
+
+                if (group.latest.actions.isNotEmpty()) {
+                    Spacer(Modifier.height(8.dp))
+                    ActionsRow(actions = group.latest.actions, onDismiss = onDismiss)
+                }
+
+                // History rows: collapsed by default; expanded shows
+                // every prior event (newest-first already; we skip
+                // index 0 which is the `latest` already rendered).
+                AnimatedVisibility(
+                    visible = expanded,
+                    enter   = expandVertically(),
+                    exit    = shrinkVertically(),
+                ) {
+                    Column {
+                        Spacer(Modifier.height(8.dp))
+                        group.events.drop(1).forEach { event ->
+                            HistoryRow(event = event, now = now)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeaderRow(
+    group: NotificationGroup,
+    now: Instant,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+        AvatarSlot(group)
+        Spacer(Modifier.width(10.dp))
+        Text(
+            text       = group.sender,
+            style      = MaterialTheme.typography.labelLarge,
+            color      = CelestiaTheme.colors.textSecondary,
+            fontWeight = FontWeight.Medium,
+            modifier   = Modifier.weight(1f),
+        )
+        Text(
+            text  = relativeTime(group.latest.createdAt, now),
+            style = MaterialTheme.typography.labelSmall,
+            color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
+        )
+        if (group.count > 1) {
+            Spacer(Modifier.width(6.dp))
+            Row(
+                modifier = Modifier.clickable(onClick = onToggle),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text  = group.count.toString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = CelestiaTheme.colors.textSecondary,
+                )
+                Icon(
+                    imageVector       = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                    contentDescription = null,
+                    modifier          = Modifier.size(16.dp),
+                    tint              = CelestiaTheme.colors.textSecondary,
+                )
+            }
+        } else {
+            Spacer(Modifier.width(6.dp))
+            Text(
+                text     = "✕",
+                modifier = Modifier.clickable(onClick = onDismiss).padding(2.dp),
+                style    = MaterialTheme.typography.labelSmall,
+                color    = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EventBody(event: NotificationEvent, accentColor: Color) {
+    Text(
+        text       = event.title,
+        style      = MaterialTheme.typography.bodyMedium,
+        color      = CelestiaTheme.colors.textPrimary,
+        fontWeight = FontWeight.SemiBold,
+    )
+    val body = event.body
+    if (!body.isNullOrBlank()) {
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text  = body,
+            style = MaterialTheme.typography.bodySmall,
+            color = CelestiaTheme.colors.textSecondary,
+        )
+    }
+    val progress = event.progress
+    if (progress != null) {
+        Spacer(Modifier.height(8.dp))
+        if (progress.isNaN()) {
+            LinearProgressIndicator(
+                modifier   = Modifier.fillMaxWidth().height(2.dp).clip(RoundedCornerShape(1.dp)),
+                color      = accentColor,
+                trackColor = CelestiaTheme.colors.surface,
+            )
+        } else {
+            LinearProgressIndicator(
+                progress   = { progress.coerceIn(0f, 1f) },
+                modifier   = Modifier.fillMaxWidth().height(2.dp).clip(RoundedCornerShape(1.dp)),
+                color      = accentColor,
+                trackColor = CelestiaTheme.colors.surface,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ActionsRow(actions: List<hivens.ui.notifications.NotifAction>, onDismiss: () -> Unit) {
+    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+        actions.forEach { action ->
+            TextButton(
+                onClick = {
+                    action.onClick()
+                    // Action click implicitly dismisses unless the
+                    // action is a "show more" type. For simplicity in
+                    // v0 every action dismisses; explicit "keep open"
+                    // semantics can land later when a real driver
+                    // needs them.
+                    onDismiss()
+                },
+                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 10.dp, vertical = 4.dp),
+            ) {
+                Text(
+                    text  = action.label,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = CelestiaTheme.colors.primary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryRow(event: NotificationEvent, now: Instant) {
+    Row(
+        modifier          = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text     = event.title,
+            style    = MaterialTheme.typography.labelMedium,
+            color    = CelestiaTheme.colors.textSecondary,
+            modifier = Modifier.weight(1f),
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(
+            text  = relativeTime(event.createdAt, now),
+            style = MaterialTheme.typography.labelSmall,
+            color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.55f),
+        )
+    }
+}
+
+@Composable
+private fun AvatarSlot(group: hivens.ui.notifications.NotificationGroup) {
+    // v0: solid neutral square placeholder. Wired to Coil + real
+    // pack icon URL when [[project_pack_rich_metadata]] propagates
+    // summary.icon_url into PackInstance.cachedManifest (or a
+    // sibling field).
+    Box(
+        modifier = Modifier
+            .size(28.dp)
+            .clip(RoundedCornerShape(4.dp))
+            .background(CelestiaTheme.colors.textSecondary.copy(alpha = 0.18f))
+    )
+}
+
+@Composable
+private fun criticalPulse(): Float {
+    val transition = rememberInfiniteTransition(label = "critical-pulse")
+    val v by transition.animateFloat(
+        initialValue = 0.55f,
+        targetValue  = 1.0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(durationMillis = 900),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "critical-pulse-alpha",
+    )
+    return v
+}
+
+private fun severityAccent(severity: Severity): Color = when (severity) {
+    Severity.Info     -> Color.Transparent
+    Severity.Progress -> Color(0xFF6A84FF)
+    Severity.Success  -> Color(0xFF4FC76E)
+    Severity.Warn     -> Color(0xFFE0B341)
+    Severity.Critical -> Color(0xFFD8484A)
+}
+
+private fun relativeTime(created: Instant, now: Instant): String {
+    val seconds = Duration.between(created, now).seconds
+    return when {
+        seconds < 5         -> "Now"
+        seconds < 60        -> "${seconds}s"
+        seconds < 3600      -> "${seconds / 60}m"
+        seconds < 86_400    -> "${seconds / 3600}h"
+        else                -> "${seconds / 86_400}d"
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -24,9 +25,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -42,6 +45,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import hivens.ui.notifications.NotifAction
 import hivens.ui.notifications.NotificationEvent
 import hivens.ui.notifications.NotificationGroup
 import hivens.ui.notifications.Severity
@@ -55,7 +59,11 @@ fun NotificationCard(
     now: Instant,
     onDismiss: () -> Unit,
 ) {
-    var expanded by remember(group.sourceKey) { mutableStateOf(false) }
+    // Include count in the key so dismiss-then-re-push under the same
+    // sourceKey resets the expanded affordance; otherwise a freshly-
+    // pushed Critical inherits the user's prior expanded=true and
+    // appears already opened into stale history.
+    var expanded by remember(group.sourceKey, group.count) { mutableStateOf(false) }
     val accentColor = severityAccent(group.severity)
     val accentAlpha = if (group.severity == Severity.Critical) criticalPulse() else 1f
 
@@ -152,13 +160,15 @@ private fun HeaderRow(
                 )
             }
         } else {
-            Spacer(Modifier.width(6.dp))
-            Text(
-                text     = "✕",
-                modifier = Modifier.clickable(onClick = onDismiss).padding(2.dp),
-                style    = MaterialTheme.typography.labelSmall,
-                color    = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
-            )
+            Spacer(Modifier.width(2.dp))
+            IconButton(onClick = onDismiss, modifier = Modifier.size(20.dp)) {
+                Icon(
+                    imageVector       = Icons.Default.Close,
+                    contentDescription = null,
+                    modifier          = Modifier.size(14.dp),
+                    tint              = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
+                )
+            }
         }
     }
 }
@@ -201,7 +211,7 @@ private fun EventBody(event: NotificationEvent, accentColor: Color) {
 }
 
 @Composable
-private fun ActionsRow(actions: List<hivens.ui.notifications.NotifAction>, onDismiss: () -> Unit) {
+private fun ActionsRow(actions: List<NotifAction>, onDismiss: () -> Unit) {
     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
         actions.forEach { action ->
             TextButton(
@@ -209,7 +219,7 @@ private fun ActionsRow(actions: List<hivens.ui.notifications.NotifAction>, onDis
                     action.onClick()
                     onDismiss()
                 },
-                contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 10.dp, vertical = 4.dp),
+                contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp),
             ) {
                 Text(
                     text  = action.label,
@@ -243,7 +253,7 @@ private fun HistoryRow(event: NotificationEvent, now: Instant) {
 }
 
 @Composable
-private fun AvatarSlot(group: hivens.ui.notifications.NotificationGroup) {
+private fun AvatarSlot(group: NotificationGroup) {
     // Neutral placeholder; wired to Coil + Url once PackInstance carries icon_url.
     Box(
         modifier = Modifier

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
@@ -49,16 +49,6 @@ import hivens.ui.theme.CelestiaTheme
 import java.time.Duration
 import java.time.Instant
 
-/**
- * One stacked notification group. Top row: avatar + sender + relative
- * time + (counter+chevron when history exists). Middle: title + body
- * of the latest event, optional progress bar inline with the accent.
- * Bottom: action chips, if any.
- *
- * Expanded view (chevron click) reveals previous events of the group
- * as tighter rows under the latest one. Severity above Info adds a
- * slim accent bar on the left; Critical pulses.
- */
 @Composable
 fun NotificationCard(
     group: NotificationGroup,
@@ -76,10 +66,6 @@ fun NotificationCard(
             .background(CelestiaTheme.colors.surface)
     ) {
         Row(modifier = Modifier.fillMaxWidth()) {
-            // Accent strip on the left. Hidden for Info to keep
-            // routine notifications visually quiet; promoted to a
-            // narrow vertical band for Warn / Progress / Success and
-            // a wider pulsing band for Critical.
             if (group.severity != Severity.Info) {
                 Box(
                     modifier = Modifier
@@ -107,9 +93,6 @@ fun NotificationCard(
                     ActionsRow(actions = group.latest.actions, onDismiss = onDismiss)
                 }
 
-                // History rows: collapsed by default; expanded shows
-                // every prior event (newest-first already; we skip
-                // index 0 which is the `latest` already rendered).
                 AnimatedVisibility(
                     visible = expanded,
                     enter   = expandVertically(),
@@ -224,11 +207,6 @@ private fun ActionsRow(actions: List<hivens.ui.notifications.NotifAction>, onDis
             TextButton(
                 onClick = {
                     action.onClick()
-                    // Action click implicitly dismisses unless the
-                    // action is a "show more" type. For simplicity in
-                    // v0 every action dismisses; explicit "keep open"
-                    // semantics can land later when a real driver
-                    // needs them.
                     onDismiss()
                 },
                 contentPadding = androidx.compose.foundation.layout.PaddingValues(horizontal = 10.dp, vertical = 4.dp),
@@ -266,10 +244,7 @@ private fun HistoryRow(event: NotificationEvent, now: Instant) {
 
 @Composable
 private fun AvatarSlot(group: hivens.ui.notifications.NotificationGroup) {
-    // v0: solid neutral square placeholder. Wired to Coil + real
-    // pack icon URL when [[project_pack_rich_metadata]] propagates
-    // summary.icon_url into PackInstance.cachedManifest (or a
-    // sibling field).
+    // Neutral placeholder; wired to Coil + Url once PackInstance carries icon_url.
     Box(
         modifier = Modifier
             .size(28.dp)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationStack.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationStack.kt
@@ -31,8 +31,15 @@ import java.time.Instant
 fun NotificationStack(center: NotificationCenter = koinInject()) {
     val groups by center.groups.collectAsState()
 
+    // Gate the 1Hz ticker on groups.isNotEmpty -- NotificationStack is
+    // mounted in AppShell at all times, so a naive `LaunchedEffect(Unit)`
+    // recomposes the subtree every second of idle even when nothing is
+    // visible. Keying on the boolean restarts the ticker only when the
+    // empty/non-empty transition happens.
     var clockTick by remember { mutableStateOf(Instant.now()) }
-    LaunchedEffect(Unit) {
+    val hasGroups = groups.isNotEmpty()
+    LaunchedEffect(hasGroups) {
+        if (!hasGroups) return@LaunchedEffect
         while (true) {
             delay(1_000L)
             clockTick = Instant.now()
@@ -49,7 +56,7 @@ fun NotificationStack(center: NotificationCenter = koinInject()) {
         }
     }
 
-    if (groups.isEmpty()) return
+    if (!hasGroups) return
 
     Box(modifier = Modifier.fillMaxSize().padding(top = 16.dp, end = 16.dp)) {
         Column(

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationStack.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationStack.kt
@@ -1,0 +1,106 @@
+package hivens.ui.notifications.render
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import hivens.ui.notifications.NotificationCenter
+import hivens.ui.theme.CelestiaTheme
+import kotlinx.coroutines.delay
+import org.koin.compose.koinInject
+import java.time.Instant
+
+/**
+ * Top-level host for the notification stack. Place once inside
+ * AppShell so the cards render above every screen. Visually anchors
+ * to the top-right with a small inset; future position prefs would
+ * pick a different alignment without touching consumer code.
+ *
+ * Stack discipline:
+ *  - Up to [MAX_VISIBLE] cards rendered at once
+ *  - Overflow rolls into a "+N more" footer that opens an inline
+ *    drawer to show the rest (deferred to v1 -- v0 just truncates)
+ *  - Auto-dismiss timer runs per visible card; ticks every second
+ *    so a 5-second Info doesn't sit stale on a paused machine
+ */
+@Composable
+fun NotificationStack(center: NotificationCenter = koinInject()) {
+    val groups by center.groups.collectAsState()
+
+    // Drives the "Now / 5s / 1m" relative-time display + auto-dismiss
+    // timers below. One-second tick is precise enough; the human eye
+    // can't tell the difference between 4s and 5s on a toast.
+    var clockTick by remember { mutableStateOf(Instant.now()) }
+    LaunchedEffect(Unit) {
+        while (true) {
+            delay(1_000L)
+            clockTick = Instant.now()
+        }
+    }
+
+    // Auto-dismiss: for each visible group, if its latest event's
+    // severity has an autoDismissAfter window and the event is older
+    // than that, dismiss the whole group. The next render won't see
+    // it. We do this BEFORE drawing so the user does not see a card
+    // that should have already gone.
+    LaunchedEffect(clockTick, groups) {
+        groups.forEach { group ->
+            val window = group.severity.autoDismissAfter ?: return@forEach
+            val age = java.time.Duration.between(group.latest.createdAt, clockTick)
+            if (age.toMillis() >= window.inWholeMilliseconds) {
+                center.dismiss(group.sourceKey)
+            }
+        }
+    }
+
+    if (groups.isEmpty()) return
+
+    Box(modifier = Modifier.fillMaxSize().padding(top = 16.dp, end = 16.dp)) {
+        Column(
+            modifier              = Modifier.align(Alignment.TopEnd).widthIn(max = 440.dp),
+            verticalArrangement   = Arrangement.spacedBy(8.dp),
+        ) {
+            val visible = groups.take(MAX_VISIBLE)
+            visible.forEach { group ->
+                AnimatedVisibility(
+                    visible = true,
+                    enter   = fadeIn(),
+                    exit    = fadeOut(),
+                ) {
+                    NotificationCard(
+                        group     = group,
+                        now       = clockTick,
+                        onDismiss = { center.dismiss(group.sourceKey) },
+                    )
+                }
+            }
+            if (groups.size > MAX_VISIBLE) {
+                Text(
+                    text     = "+${groups.size - MAX_VISIBLE} more",
+                    style    = MaterialTheme.typography.labelSmall,
+                    color    = CelestiaTheme.colors.textSecondary,
+                    modifier = Modifier.padding(top = 4.dp, end = 4.dp).align(Alignment.End),
+                )
+            }
+        }
+    }
+}
+
+private const val MAX_VISIBLE = 4

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationStack.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationStack.kt
@@ -27,26 +27,10 @@ import kotlinx.coroutines.delay
 import org.koin.compose.koinInject
 import java.time.Instant
 
-/**
- * Top-level host for the notification stack. Place once inside
- * AppShell so the cards render above every screen. Visually anchors
- * to the top-right with a small inset; future position prefs would
- * pick a different alignment without touching consumer code.
- *
- * Stack discipline:
- *  - Up to [MAX_VISIBLE] cards rendered at once
- *  - Overflow rolls into a "+N more" footer that opens an inline
- *    drawer to show the rest (deferred to v1 -- v0 just truncates)
- *  - Auto-dismiss timer runs per visible card; ticks every second
- *    so a 5-second Info doesn't sit stale on a paused machine
- */
 @Composable
 fun NotificationStack(center: NotificationCenter = koinInject()) {
     val groups by center.groups.collectAsState()
 
-    // Drives the "Now / 5s / 1m" relative-time display + auto-dismiss
-    // timers below. One-second tick is precise enough; the human eye
-    // can't tell the difference between 4s and 5s on a toast.
     var clockTick by remember { mutableStateOf(Instant.now()) }
     LaunchedEffect(Unit) {
         while (true) {
@@ -55,11 +39,6 @@ fun NotificationStack(center: NotificationCenter = koinInject()) {
         }
     }
 
-    // Auto-dismiss: for each visible group, if its latest event's
-    // severity has an autoDismissAfter window and the event is older
-    // than that, dismiss the whole group. The next render won't see
-    // it. We do this BEFORE drawing so the user does not see a card
-    // that should have already gone.
     LaunchedEffect(clockTick, groups) {
         groups.forEach { group ->
             val window = group.severity.autoDismissAfter ?: return@forEach

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/SessionChip.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/SessionChip.kt
@@ -34,18 +34,6 @@ import hivens.ui.theme.CelestiaTheme
 import org.koin.compose.koinInject
 import java.time.Duration
 
-/**
- * Active-sessions section, intended for the Library sidebar. Renders
- * one chip per running pack with a live uptime ticker, an open-
- * console button, and a stop button. Hidden when no sessions are
- * registered -- the section should not visually exist in the
- * sidebar during quiet times.
- *
- * Distinct from [NotificationStack] because session state is
- * persistent: a game may run for hours and the user wants the
- * control surface to stay reachable the whole time. A transient
- * toast cannot serve that role.
- */
 @Composable
 fun ActiveSessionsSection(registry: SessionRegistry = koinInject()) {
     val active by registry.active.collectAsState()
@@ -76,9 +64,6 @@ fun SessionChip(session: ActiveSession) {
             .padding(horizontal = 10.dp, vertical = 8.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
-            // Live indicator dot -- accent color, ambient (no pulse).
-            // Different from notification accent: this is a steady
-            // "running" signal, not "demands attention".
             Box(
                 modifier = Modifier
                     .size(8.dp)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/SessionChip.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/SessionChip.kt
@@ -1,0 +1,128 @@
+package hivens.ui.notifications.render
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.MenuOpen
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import hivens.ui.notifications.SessionRegistry
+import hivens.ui.notifications.SessionRegistry.ActiveSession
+import hivens.ui.theme.CelestiaTheme
+import org.koin.compose.koinInject
+import java.time.Duration
+
+/**
+ * Active-sessions section, intended for the Library sidebar. Renders
+ * one chip per running pack with a live uptime ticker, an open-
+ * console button, and a stop button. Hidden when no sessions are
+ * registered -- the section should not visually exist in the
+ * sidebar during quiet times.
+ *
+ * Distinct from [NotificationStack] because session state is
+ * persistent: a game may run for hours and the user wants the
+ * control surface to stay reachable the whole time. A transient
+ * toast cannot serve that role.
+ */
+@Composable
+fun ActiveSessionsSection(registry: SessionRegistry = koinInject()) {
+    val active by registry.active.collectAsState()
+    if (active.isEmpty()) return
+
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        Text(
+            text       = "Active sessions",
+            style      = MaterialTheme.typography.labelSmall,
+            color      = CelestiaTheme.colors.textSecondary,
+            fontWeight = FontWeight.Medium,
+        )
+        active.values.forEach { session ->
+            SessionChip(session = session)
+        }
+    }
+}
+
+@Composable
+fun SessionChip(session: ActiveSession) {
+    val uptime by session.uptime.collectAsState()
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(6.dp))
+            .background(CelestiaTheme.colors.surface)
+            .clickable { session.showConsole() }
+            .padding(horizontal = 10.dp, vertical = 8.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            // Live indicator dot -- accent color, ambient (no pulse).
+            // Different from notification accent: this is a steady
+            // "running" signal, not "demands attention".
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(RoundedCornerShape(50))
+                    .background(Color(0xFF4FC76E))
+            )
+            Spacer(Modifier.width(8.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text       = session.packDisplayName,
+                    style      = MaterialTheme.typography.bodyMedium,
+                    color      = CelestiaTheme.colors.textPrimary,
+                    fontWeight = FontWeight.Medium,
+                )
+                Text(
+                    text  = formatUptime(uptime),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = CelestiaTheme.colors.textSecondary,
+                )
+            }
+            IconButton(onClick = session.showConsole) {
+                Icon(
+                    imageVector       = Icons.AutoMirrored.Default.MenuOpen,
+                    contentDescription = "Show console",
+                    tint              = CelestiaTheme.colors.textSecondary,
+                )
+            }
+            IconButton(onClick = session.abort) {
+                Icon(
+                    imageVector       = Icons.Default.Stop,
+                    contentDescription = "Stop",
+                    tint              = CelestiaTheme.colors.error,
+                )
+            }
+        }
+    }
+}
+
+private fun formatUptime(d: Duration): String {
+    val totalSeconds = d.seconds
+    if (totalSeconds < 60)   return "${totalSeconds}s"
+    if (totalSeconds < 3600) return "%d:%02d".format(totalSeconds / 60, totalSeconds % 60)
+    val h = totalSeconds / 3600
+    val m = (totalSeconds % 3600) / 60
+    val s = totalSeconds % 60
+    return "%d:%02d:%02d".format(h, m, s)
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
@@ -120,13 +120,8 @@ fun PackDetailScreen(
                 enabled = authedSession != null,
                 onPlay  = {
                     val session = authedSession ?: return@PlayBar
-                    // Start observing controller.state for THIS pack
-                    // BEFORE handing the launch to the controller so
-                    // the driver's first-non-Idle-await sees the
-                    // upcoming Prepare transition. Open the console
-                    // window so the user has stdout visibility from
-                    // the start; previous SC flow did the same on
-                    // tray-launched Play.
+                    // Observer first, then launch: the first-non-Idle
+                    // await needs to subscribe before Prepare fires.
                     launchDriver.observe(pack)
                     gameConsole.show()
                     controller.launchPackInstance(session, pack)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
@@ -45,6 +45,8 @@ import hivens.launcher.launch.LauncherController
 import hivens.launcher.platform.PlatformPaths
 import hivens.ui.AppState
 import hivens.ui.customization.glassSurfaceAlpha
+import hivens.ui.notifications.drivers.PackLaunchDriver
+import hivens.ui.utils.GameConsoleService
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.puppet.PuppetClick
 import hivens.ui.puppet.PuppetScreen
@@ -79,8 +81,8 @@ fun PackDetailScreen(
     val repo: IPackRepository = koinInject()
     val paths: PlatformPaths = koinInject()
     val controller: LauncherController = koinInject()
-    val launchDriver: hivens.ui.notifications.drivers.PackLaunchDriver = koinInject()
-    val gameConsole: hivens.ui.utils.GameConsoleService = koinInject()
+    val launchDriver: PackLaunchDriver = koinInject()
+    val gameConsole: GameConsoleService = koinInject()
     var instance by remember { mutableStateOf<PackInstance?>(null) }
     var resolved by remember { mutableStateOf(false) }
     LaunchedEffect(instanceId) {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/detail/PackDetailScreen.kt
@@ -79,6 +79,8 @@ fun PackDetailScreen(
     val repo: IPackRepository = koinInject()
     val paths: PlatformPaths = koinInject()
     val controller: LauncherController = koinInject()
+    val launchDriver: hivens.ui.notifications.drivers.PackLaunchDriver = koinInject()
+    val gameConsole: hivens.ui.utils.GameConsoleService = koinInject()
     var instance by remember { mutableStateOf<PackInstance?>(null) }
     var resolved by remember { mutableStateOf(false) }
     LaunchedEffect(instanceId) {
@@ -118,6 +120,15 @@ fun PackDetailScreen(
                 enabled = authedSession != null,
                 onPlay  = {
                     val session = authedSession ?: return@PlayBar
+                    // Start observing controller.state for THIS pack
+                    // BEFORE handing the launch to the controller so
+                    // the driver's first-non-Idle-await sees the
+                    // upcoming Prepare transition. Open the console
+                    // window so the user has stdout visibility from
+                    // the start; previous SC flow did the same on
+                    // tray-launched Play.
+                    launchDriver.observe(pack)
+                    gameConsole.show()
                     controller.launchPackInstance(session, pack)
                 },
             )

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
@@ -58,6 +58,8 @@ fun LibraryScreen(
 
     val repo: IPackRepository = koinInject()
     val controller: LauncherController = koinInject()
+    val launchDriver: hivens.ui.notifications.drivers.PackLaunchDriver = koinInject()
+    val gameConsole: hivens.ui.utils.GameConsoleService = koinInject()
     val instances by remember { repo.observe() }.collectAsState(initial = emptyList())
     val authedSession = (appState as? AppState.Authenticated)?.session
 
@@ -90,6 +92,12 @@ fun LibraryScreen(
                     if (session == null) {
                         onScreenChange(Screen.PackDetail(instance.id))
                     } else {
+                        // Same observer-then-launch + console-show
+                        // sequence as PackDetail's PlayBar so the
+                        // user gets identical feedback regardless of
+                        // which Play affordance they used.
+                        launchDriver.observe(instance)
+                        gameConsole.show()
                         controller.launchPackInstance(session, instance)
                     }
                 },

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
@@ -32,8 +32,10 @@ import hivens.core.data.PackInstance
 import hivens.launcher.launch.LauncherController
 import hivens.ui.AppState
 import hivens.ui.Screen
+import hivens.ui.notifications.drivers.PackLaunchDriver
 import hivens.ui.puppet.PuppetScreen
 import hivens.ui.theme.CelestiaTheme
+import hivens.ui.utils.GameConsoleService
 import org.koin.compose.koinInject
 
 /**
@@ -58,8 +60,8 @@ fun LibraryScreen(
 
     val repo: IPackRepository = koinInject()
     val controller: LauncherController = koinInject()
-    val launchDriver: hivens.ui.notifications.drivers.PackLaunchDriver = koinInject()
-    val gameConsole: hivens.ui.utils.GameConsoleService = koinInject()
+    val launchDriver: PackLaunchDriver = koinInject()
+    val gameConsole: GameConsoleService = koinInject()
     val instances by remember { repo.observe() }.collectAsState(initial = emptyList())
     val authedSession = (appState as? AppState.Authenticated)?.session
 

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/screens/library/LibraryScreen.kt
@@ -92,10 +92,6 @@ fun LibraryScreen(
                     if (session == null) {
                         onScreenChange(Screen.PackDetail(instance.id))
                     } else {
-                        // Same observer-then-launch + console-show
-                        // sequence as PackDetail's PlayBar so the
-                        // user gets identical feedback regardless of
-                        // which Play affordance they used.
                         launchDriver.observe(instance)
                         gameConsole.show()
                         controller.launchPackInstance(session, instance)

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/NotificationCenterTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/NotificationCenterTest.kt
@@ -1,0 +1,130 @@
+package hivens.ui.notifications
+
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NotificationCenterTest {
+
+    private val clock = FixedClock()
+
+    private fun newCenter() = NotificationCenter(historyPerGroup = 3, clock = clock::now)
+
+    @Test
+    fun `push creates new group when sourceKey is new`() = runTest {
+        val center = newCenter()
+        center.push(
+            sourceKey = "pack:Industrial:launch",
+            sender    = "Industrial",
+            avatar    = AvatarSource.Generic,
+            severity  = Severity.Progress,
+            title     = "Preparing",
+        )
+
+        val groups = center.groups.first()
+        assertEquals(1, groups.size)
+        val g = groups.single()
+        assertEquals("pack:Industrial:launch", g.sourceKey)
+        assertEquals("Industrial", g.sender)
+        assertEquals(1, g.count)
+        assertEquals("Preparing", g.latest.title)
+        assertEquals(Severity.Progress, g.latest.severity)
+    }
+
+    @Test
+    fun `re-push with same sourceKey appends event to existing group`() = runTest {
+        val center = newCenter()
+        center.push("pack:X", "X", AvatarSource.Generic, Severity.Progress, "Preparing")
+        clock.advance(seconds = 2)
+        center.push("pack:X", "X", AvatarSource.Generic, Severity.Progress, "Downloading 47%")
+        clock.advance(seconds = 5)
+        center.push("pack:X", "X", AvatarSource.Generic, Severity.Success, "Done")
+
+        val g = center.groups.first().single()
+        assertEquals(3, g.count)
+        assertEquals("Done", g.latest.title)
+        assertEquals("Preparing", g.events.last().title, "oldest at tail")
+    }
+
+    @Test
+    fun `group history is capped at historyPerGroup`() = runTest {
+        val center = NotificationCenter(historyPerGroup = 2, clock = clock::now)
+        center.push("k", "X", AvatarSource.Generic, Severity.Info, "e1")
+        center.push("k", "X", AvatarSource.Generic, Severity.Info, "e2")
+        center.push("k", "X", AvatarSource.Generic, Severity.Info, "e3")
+
+        val g = center.groups.first().single()
+        assertEquals(2, g.count, "oldest event dropped at the cap")
+        assertEquals("e3", g.events[0].title)
+        assertEquals("e2", g.events[1].title)
+    }
+
+    @Test
+    fun `severity is max across events`() = runTest {
+        val center = newCenter()
+        center.push("k", "X", AvatarSource.Generic, Severity.Info, "info")
+        center.push("k", "X", AvatarSource.Generic, Severity.Critical, "boom")
+        // A later non-critical event must NOT visually downgrade the
+        // group -- max wins so the user does not lose track of the
+        // earlier critical when scanning the stack.
+        center.push("k", "X", AvatarSource.Generic, Severity.Info, "muted recovery")
+
+        val g = center.groups.first().single()
+        assertEquals(Severity.Critical, g.severity)
+    }
+
+    @Test
+    fun `touched group floats to the front of the stack`() = runTest {
+        val center = newCenter()
+        center.push("k1", "First",  AvatarSource.Generic, Severity.Info, "1")
+        center.push("k2", "Second", AvatarSource.Generic, Severity.Info, "2")
+        center.push("k3", "Third",  AvatarSource.Generic, Severity.Info, "3")
+        // Touch k1 -- it should float to the top, k3 / k2 follow.
+        center.push("k1", "First",  AvatarSource.Generic, Severity.Info, "1 again")
+
+        val keys = center.groups.first().map { it.sourceKey }
+        assertEquals(listOf("k1", "k3", "k2"), keys)
+    }
+
+    @Test
+    fun `dismiss removes the group and is idempotent on unknown key`() = runTest {
+        val center = newCenter()
+        center.push("k", "X", AvatarSource.Generic, Severity.Info, "hi")
+        center.dismiss("k")
+        assertTrue(center.groups.first().isEmpty())
+
+        // Second dismiss of the same (now-absent) key is a no-op.
+        center.dismiss("k")
+        center.dismiss("never-existed")
+        assertTrue(center.groups.first().isEmpty())
+    }
+
+    @Test
+    fun `clear wipes the stack`() = runTest {
+        val center = newCenter()
+        center.push("a", "A", AvatarSource.Generic, Severity.Info, "1")
+        center.push("b", "B", AvatarSource.Generic, Severity.Info, "2")
+        center.clear()
+        assertTrue(center.groups.first().isEmpty())
+    }
+
+    @Test
+    fun `severity auto-dismiss policy is consistent with the docs`() {
+        // The renderer + driver depend on these values; lock them in.
+        assertNull(Severity.Progress.autoDismissAfter)
+        assertNull(Severity.Critical.autoDismissAfter)
+        assertEquals(5, Severity.Info.autoDismissAfter?.inWholeSeconds)
+        assertEquals(4, Severity.Success.autoDismissAfter?.inWholeSeconds)
+        assertEquals(30, Severity.Warn.autoDismissAfter?.inWholeSeconds)
+    }
+
+    private class FixedClock(start: Instant = Instant.parse("2026-05-26T00:00:00Z")) {
+        private var current: Instant = start
+        fun now(): Instant = current
+        fun advance(seconds: Long) { current = current.plusSeconds(seconds) }
+    }
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/SessionRegistryTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/SessionRegistryTest.kt
@@ -1,0 +1,95 @@
+package hivens.ui.notifications
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionRegistryTest {
+
+    @Test
+    fun `register adds to active map`() = runTest {
+        val reg = SessionRegistry(appScope = this, clock = ::fixedClock)
+        reg.register("pack1", "Pack 1", null, abort = {}, showConsole = {})
+        val active = reg.active.first()
+        assertEquals(1, active.size)
+        val session = active["pack1"]
+        assertNotNull(session)
+        assertEquals("Pack 1", session.packDisplayName)
+        // Cleanup ticker so the test scope can finish.
+        reg.unregister("pack1")
+    }
+
+    @Test
+    fun `unregister removes the session`() = runTest {
+        val reg = SessionRegistry(appScope = this, clock = ::fixedClock)
+        reg.register("pack1", "Pack 1", null, abort = {}, showConsole = {})
+        reg.unregister("pack1")
+        assertTrue(reg.active.first().isEmpty())
+    }
+
+    @Test
+    fun `unregister of unknown id is a no-op`() = runTest {
+        val reg = SessionRegistry(appScope = this, clock = ::fixedClock)
+        reg.unregister("never-existed")
+        assertTrue(reg.active.first().isEmpty())
+    }
+
+    @Test
+    fun `register again with same id replaces the prior session`() = runTest {
+        val reg = SessionRegistry(appScope = this, clock = ::fixedClock)
+        var firstAbortCalls = 0
+        var secondAbortCalls = 0
+        reg.register("pack1", "First",  null, abort = { firstAbortCalls++  }, showConsole = {})
+        reg.register("pack1", "Second", null, abort = { secondAbortCalls++ }, showConsole = {})
+
+        val session = reg.active.first()["pack1"]
+        assertEquals("Second", session?.packDisplayName)
+        session?.abort?.invoke()
+        assertEquals(0, firstAbortCalls, "first session's abort must be unreachable")
+        assertEquals(1, secondAbortCalls)
+        reg.unregister("pack1")
+    }
+
+    @Test
+    fun `concurrent register and unregister do not lose entries`() = runTest {
+        val reg = SessionRegistry(appScope = this, clock = ::fixedClock)
+        // Hammer the same registry from many parallel coroutines. Plain
+        // `_active.value = _active.value + ...` would lose updates here;
+        // .update {} CAS retry is what we test.
+        val keys = (1..40).map { "pack-$it" }
+        keys.map { k ->
+            launch {
+                reg.register(k, "Pack $k", null, abort = {}, showConsole = {})
+            }
+        }
+        // Drain.
+        advanceTimeBy(50)
+        assertEquals(40, reg.active.first().size, "no entries lost under concurrent register")
+        keys.map { k -> launch { reg.unregister(k) } }
+        advanceTimeBy(50)
+        assertTrue(reg.active.first().isEmpty(), "no entries lost under concurrent unregister")
+    }
+
+    @Test
+    fun `uptime ticks while session is registered`() = runTest {
+        val reg = SessionRegistry(appScope = this, clock = ::fixedClock)
+        reg.register("pack1", "Pack 1", null, abort = {}, showConsole = {})
+        val session = reg.active.first()["pack1"]
+        assertNotNull(session)
+        // Initial tick before the first delay fires.
+        assertEquals(0, session.uptime.first().seconds)
+        reg.unregister("pack1")
+    }
+
+    private var clockNanos = 0L
+    private fun fixedClock(): Instant = Instant.ofEpochSecond(0, clockNanos)
+}

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/drivers/PackLaunchDriverTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/drivers/PackLaunchDriverTest.kt
@@ -1,0 +1,89 @@
+package hivens.ui.notifications.drivers
+
+import hivens.launcher.launch.LaunchError
+import hivens.launcher.launch.LaunchState
+import hivens.launcher.launch.PrepareStage
+import hivens.ui.notifications.Severity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.transformWhile
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+// Driver pulls in LauncherController (heavy DI graph: auth, credentials,
+// java manager, ...) so a full integration test is out of scope here.
+// These tests pin the FLOW CONTRACT the driver depends on -- if the
+// dropWhile / transformWhile pipeline breaks, both the driver and its
+// review-flagged stale-terminal / leak bugs come back.
+@OptIn(ExperimentalCoroutinesApi::class)
+class PackLaunchDriverTest {
+
+    @Test
+    fun `dropWhile gate ignores stale terminal until Prepare arrives`() = runTest {
+        val flow = MutableStateFlow<LaunchState>(LaunchState.Error(LaunchError.Internal("stale")))
+        val emitted = mutableListOf<LaunchState>()
+        val job = launch {
+            flow.dropWhile { it !is LaunchState.Prepare }.collect { emitted += it }
+        }
+        advanceUntilIdle()
+        assertTrue(emitted.isEmpty(), "stale Error must not pass the Prepare gate")
+
+        flow.value = LaunchState.Prepare(PrepareStage.INIT, 0.0f)
+        advanceUntilIdle()
+        assertEquals(1, emitted.size)
+        assertIs<LaunchState.Prepare>(emitted.last())
+
+        flow.value = LaunchState.Idle
+        advanceUntilIdle()
+        // After the gate opens, subsequent values (including Idle) come through.
+        assertEquals(2, emitted.size)
+        job.cancel()
+    }
+
+    @Test
+    fun `transformWhile terminates on first terminal state`() = runTest {
+        // The driver's `transformWhile { emit(it); !is Idle && !is Error }`
+        // is what replaces a forbidden non-local return from `collect { }`.
+        // Verify it actually stops on the first terminal value.
+        val flow = MutableStateFlow<LaunchState>(LaunchState.Prepare(PrepareStage.INIT, 0f))
+        val emitted = mutableListOf<LaunchState>()
+        val job = launch {
+            flow
+                .dropWhile { it !is LaunchState.Prepare }
+                .transformWhile { state ->
+                    emit(state)
+                    state !is LaunchState.Idle && state !is LaunchState.Error
+                }
+                .collect { emitted += it }
+        }
+        advanceUntilIdle()
+        assertEquals(1, emitted.size, "initial Prepare reaches the collector")
+        assertIs<LaunchState.Prepare>(emitted[0])
+
+        flow.value = LaunchState.Idle
+        advanceUntilIdle()
+        assertEquals(2, emitted.size, "Idle emitted, transformWhile stops after")
+        assertEquals(LaunchState.Idle, emitted[1])
+
+        flow.value = LaunchState.Prepare(PrepareStage.INIT, 1f)
+        advanceUntilIdle()
+        assertEquals(2, emitted.size, "later values dropped after terminal")
+        job.cancel()
+    }
+
+    @Test
+    fun `severity ladder gives Critical highest precedence`() {
+        // Driver picks Severity.Critical on Error -- group.severity then
+        // wins as max across history events, surfacing the failure even
+        // after subsequent Info/Success arrivals.
+        assertTrue(Severity.Critical.ordinal > Severity.Warn.ordinal)
+        assertTrue(Severity.Critical.ordinal > Severity.Success.ordinal)
+        assertTrue(Severity.Critical.ordinal > Severity.Progress.ordinal)
+    }
+}


### PR DESCRIPTION
## Summary

First UI subsystem for surface-level user feedback. Closes the silent-Play gap from PR #250 and lays foundation for future event-driven UI (pack updates, sync errors, mirror health, achievements).

## Three layers, one module

| Layer | Purpose | Render surface | Lifetime |
|---|---|---|---|
| **NotificationCenter** | Transient toasts grouped by sourceKey; re-push appends events, counter+chevron expands history | Top-right stack, max 4 visible | Auto-dismiss per severity (Info=5s, Success=4s, Critical sticky, Warn=30s) |
| **IndicationCenter** | Passive inline signals (pack-card launch glow, "update available" badge, mirror health dot) | Inline at the affordance they describe | Stays while the signal is active |
| **SessionRegistry** | Persistent control surface for live child processes | Library sidebar "Active sessions" section | Stays for the lifetime of the process |

`PackLaunchDriver` bridges `LauncherController.state` to all three. Per-launch observer pattern: UI calls `driver.observe(pack)` right before `controller.launchPackInstance`, so each entry is keyed on the pack the user started without widening the controller's contract with pack identity.

## Closes the silent-Play gap

Before this PR, clicking Play on a pack-centric instance had ZERO visible reaction -- the controller spawned a coroutine in the background, no UI subscribed to state, and the user saw nothing until the JVM window eventually appeared (or didn't). Now:

1. Click Play -> observer attaches, console opens, launch fires
2. Prepare/Downloading -> progress toast + per-card glow indication
3. GameRunning -> success toast + session chip in sidebar with uptime + kill button
4. Idle / Error -> chip disappears, group settles to Success or Critical
5. User can dismiss the group manually OR let auto-dismiss handle it

## Visual style

Not GNOME, not Discord -- our own. Sharp corners, dense composition, single accent strip on the left for severity (transparent for Info, slim for Progress/Success/Warn, wider + pulsing for Critical), no decorative icons. Counter + chevron for grouped events when count > 1.

## Test plan

- [x] First-ever desktopTest source set on client-ui (was missing). Seven NotificationCenter tests cover push / replace / history cap / severity max / float-to-front / dismiss idempotence / auto-dismiss policy constants.
- [x] `./gradlew :client-launcher:test :client-ui:desktopTest` green.
- [x] `./gradlew :client-launcher:compileKotlin :client-ui:compileKotlinDesktop` clean.
- [ ] Live smoke: Industrial pack Play -> observe progress toast through stages + session chip in sidebar + console window opens.

## Deferred to follow-ups

- AvatarSource.Url wiring (needs PackInstance to carry icon_url -- ties to `[[project_pack_rich_metadata]]`).
- IndicationGlow overlay on PackCard (data already flowing; just needs the visual hookup).
- "+N more" drawer (v0 truncates; v1 will expand inline).
- DoNotDisturb settings toggle.
- Position prefs (top-right hardcoded for now).
- Notification history persistence (in-memory only; restart wipes).