### PR TITLE
feat(notifications): a11y + theme tokens + severity/kind split + i18n (batches A-E)

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/Main.kt
@@ -1,7 +1,10 @@
 package hivens.ui
 
 import androidx.compose.ui.window.application
+import hivens.core.api.interfaces.ISettingsService
 import hivens.launcher.bootstrap.LauncherBootstrap
+import hivens.ui.i18n.AppLocale
+import hivens.ui.i18n.stringsFor
 import hivens.ui.identity.SkinManager
 import hivens.ui.notifications.IndicationCenter
 import hivens.ui.notifications.NotificationCenter
@@ -32,13 +35,15 @@ val uiModule = module {
     single { IndicationCenter() }
     single { SessionRegistry(appScope = get()) }
     single {
+        val settingsService: ISettingsService = get()
         PackLaunchDriver(
-            controller    = get(),
-            notifications = get(),
-            indications   = get(),
-            sessions      = get(),
-            gameConsole   = get(),
-            appScope      = get(),
+            controller      = get(),
+            notifications   = get(),
+            indications     = get(),
+            sessions        = get(),
+            gameConsole     = get(),
+            appScope        = get(),
+            stringsProvider = { stringsFor(AppLocale.fromTag(settingsService.getSettings().locale)) },
         )
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -681,4 +681,33 @@ interface AppStrings {
     fun notificationShowMore(count: Int): String
     /** Absolute timestamp shown on hover tooltip over the relative-time label. */
     fun notificationAbsoluteTime(instant: java.time.Instant): String
+
+    // --- Notification driver templates (pack launch lifecycle) ---
+    fun notifPackPreparing(packName: String): String
+    fun notifPackStage(stage: String): String
+    fun notifPackSyncing(packName: String): String
+    /** "{current}/{total} files, 47%" or "...downloading...". `pctLabel` carries either. */
+    fun notifPackSyncBody(current: Int, total: Int, pctLabel: String): String
+    val notifPackSyncIndeterminate: String
+    fun notifPackSyncPercent(pct: Int): String
+    fun notifPackRunning(packName: String): String
+    fun notifPackFailed(packName: String): String
+    fun notifPackSessionEnded(packName: String): String
+    val notifActionShowConsole: String
+    val notifActionStop: String
+    fun notifReasonExitCode(code: Int): String
+    val notifReasonInternal: String
+    fun notifReasonInternalDetail(detail: String): String
+    val notifReasonAuthFail: String
+    fun notifReasonAuthFailDetail(detail: String): String
+    val notifReasonOfflineNoClient: String
+    val notifReasonOfflineNoManifest: String
+    val notifReasonTwoFactorExpired: String
+
+    // --- Notification relative-time formatter (header label) ---
+    val notifTimeNow: String
+    fun notifTimeSeconds(seconds: Long): String
+    fun notifTimeMinutes(minutes: Long): String
+    fun notifTimeHours(hours: Long): String
+    fun notifTimeDays(days: Long): String
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/AppStrings.kt
@@ -672,4 +672,13 @@ interface AppStrings {
     val packDetailNotFoundTitle: String
     val packDetailNotFoundHint: String
     val packDetailNotFoundBack: String
+
+    // --- Notification subsystem (a11y + minimal labels) ---
+    val notificationExpandHistory: String
+    val notificationCollapseHistory: String
+    val notificationDismiss: String
+    /** "+N more" footer text + screen-reader label. Receives the overflow count. */
+    fun notificationShowMore(count: Int): String
+    /** Absolute timestamp shown on hover tooltip over the relative-time label. */
+    fun notificationAbsoluteTime(instant: java.time.Instant): String
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -632,4 +632,20 @@ object EnglishStrings : AppStrings {
     override val packDetailNotFoundTitle        = "Instance not found"
     override val packDetailNotFoundHint         = "It may have been removed from another window."
     override val packDetailNotFoundBack         = "Back to Library"
+
+    // --- Notification subsystem ---
+    override val notificationExpandHistory   = "Expand notification history"
+    override val notificationCollapseHistory = "Collapse notification history"
+    override val notificationDismiss         = "Dismiss notification"
+    override fun notificationShowMore(count: Int)               = "+$count more"
+    override fun notificationAbsoluteTime(instant: java.time.Instant): String =
+        notificationTimeFormatter(java.util.Locale.ENGLISH).format(instant)
 }
+
+private val notificationTimeFormatterCache = java.util.concurrent.ConcurrentHashMap<java.util.Locale, java.time.format.DateTimeFormatter>()
+private fun notificationTimeFormatter(locale: java.util.Locale): java.time.format.DateTimeFormatter =
+    notificationTimeFormatterCache.computeIfAbsent(locale) {
+        java.time.format.DateTimeFormatter
+            .ofPattern("d MMM yyyy, HH:mm:ss", it)
+            .withZone(java.time.ZoneId.systemDefault())
+    }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/EnglishStrings.kt
@@ -640,6 +640,33 @@ object EnglishStrings : AppStrings {
     override fun notificationShowMore(count: Int)               = "+$count more"
     override fun notificationAbsoluteTime(instant: java.time.Instant): String =
         notificationTimeFormatter(java.util.Locale.ENGLISH).format(instant)
+
+    override fun notifPackPreparing(packName: String)   = "Preparing $packName"
+    override fun notifPackStage(stage: String)          = "Stage: $stage"
+    override fun notifPackSyncing(packName: String)     = "Syncing $packName"
+    override fun notifPackSyncBody(current: Int, total: Int, pctLabel: String) =
+        "$current/$total files, $pctLabel"
+    override val notifPackSyncIndeterminate             = "downloading..."
+    override fun notifPackSyncPercent(pct: Int)         = "$pct%"
+    override fun notifPackRunning(packName: String)     = "$packName is running"
+    override fun notifPackFailed(packName: String)      = "$packName failed to launch"
+    override fun notifPackSessionEnded(packName: String) = "$packName session ended"
+    override val notifActionShowConsole                 = "Show console"
+    override val notifActionStop                        = "Stop"
+    override fun notifReasonExitCode(code: Int)         = "Game exited with code $code"
+    override val notifReasonInternal                    = "Internal error"
+    override fun notifReasonInternalDetail(detail: String) = detail
+    override val notifReasonAuthFail                    = "Authentication failed"
+    override fun notifReasonAuthFailDetail(detail: String) = detail
+    override val notifReasonOfflineNoClient             = "Pack files missing on disk"
+    override val notifReasonOfflineNoManifest           = "No cached manifest; go online once to sync"
+    override val notifReasonTwoFactorExpired            = "Sign in again to refresh credentials"
+
+    override val notifTimeNow                           = "Now"
+    override fun notifTimeSeconds(seconds: Long)        = "${seconds}s"
+    override fun notifTimeMinutes(minutes: Long)        = "${minutes}m"
+    override fun notifTimeHours(hours: Long)            = "${hours}h"
+    override fun notifTimeDays(days: Long)              = "${days}d"
 }
 
 private val notificationTimeFormatterCache = java.util.concurrent.ConcurrentHashMap<java.util.Locale, java.time.format.DateTimeFormatter>()

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -632,4 +632,15 @@ object GermanStrings : AppStrings {
     override val packDetailNotFoundTitle        = "Instanz nicht gefunden"
     override val packDetailNotFoundHint         = "Möglicherweise in einem anderen Fenster entfernt."
     override val packDetailNotFoundBack         = "Zurück zur Library"
+
+    // --- Notification subsystem ---
+    override val notificationExpandHistory   = "Benachrichtigungsverlauf einblenden"
+    override val notificationCollapseHistory = "Benachrichtigungsverlauf ausblenden"
+    override val notificationDismiss         = "Benachrichtigung schliessen"
+    override fun notificationShowMore(count: Int)               = "+$count weitere"
+    override fun notificationAbsoluteTime(instant: java.time.Instant): String =
+        java.time.format.DateTimeFormatter
+            .ofPattern("d. MMMM yyyy, HH:mm:ss", java.util.Locale.GERMAN)
+            .withZone(java.time.ZoneId.systemDefault())
+            .format(instant)
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/GermanStrings.kt
@@ -643,4 +643,31 @@ object GermanStrings : AppStrings {
             .ofPattern("d. MMMM yyyy, HH:mm:ss", java.util.Locale.GERMAN)
             .withZone(java.time.ZoneId.systemDefault())
             .format(instant)
+
+    override fun notifPackPreparing(packName: String)   = "Vorbereitung: $packName"
+    override fun notifPackStage(stage: String)          = "Phase: $stage"
+    override fun notifPackSyncing(packName: String)     = "Synchronisiere $packName"
+    override fun notifPackSyncBody(current: Int, total: Int, pctLabel: String) =
+        "$current/$total Dateien, $pctLabel"
+    override val notifPackSyncIndeterminate             = "wird heruntergeladen..."
+    override fun notifPackSyncPercent(pct: Int)         = "$pct %"
+    override fun notifPackRunning(packName: String)     = "$packName laeuft"
+    override fun notifPackFailed(packName: String)      = "$packName konnte nicht gestartet werden"
+    override fun notifPackSessionEnded(packName: String) = "Sitzung $packName beendet"
+    override val notifActionShowConsole                 = "Konsole anzeigen"
+    override val notifActionStop                        = "Stoppen"
+    override fun notifReasonExitCode(code: Int)         = "Spiel mit Code $code beendet"
+    override val notifReasonInternal                    = "Interner Fehler"
+    override fun notifReasonInternalDetail(detail: String) = detail
+    override val notifReasonAuthFail                    = "Anmeldung fehlgeschlagen"
+    override fun notifReasonAuthFailDetail(detail: String) = detail
+    override val notifReasonOfflineNoClient             = "Pack-Dateien fehlen auf der Platte"
+    override val notifReasonOfflineNoManifest           = "Kein Manifest im Cache; einmal online gehen, um zu synchronisieren"
+    override val notifReasonTwoFactorExpired            = "Bitte erneut anmelden, um die Anmeldedaten zu aktualisieren"
+
+    override val notifTimeNow                           = "Jetzt"
+    override fun notifTimeSeconds(seconds: Long)        = "${seconds} s"
+    override fun notifTimeMinutes(minutes: Long)        = "${minutes} min"
+    override fun notifTimeHours(hours: Long)            = "${hours} h"
+    override fun notifTimeDays(days: Long)              = "${days} T"
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -633,4 +633,15 @@ object RussianStrings : AppStrings {
     override val packDetailNotFoundTitle        = "Экземпляр не найден"
     override val packDetailNotFoundHint         = "Возможно, удалён в другом окне."
     override val packDetailNotFoundBack         = "Назад в Library"
+
+    // --- Notification subsystem ---
+    override val notificationExpandHistory   = "Раскрыть историю уведомления"
+    override val notificationCollapseHistory = "Свернуть историю уведомления"
+    override val notificationDismiss         = "Закрыть уведомление"
+    override fun notificationShowMore(count: Int)               = "ещё $count"
+    override fun notificationAbsoluteTime(instant: java.time.Instant): String =
+        java.time.format.DateTimeFormatter
+            .ofPattern("d MMMM yyyy, HH:mm:ss", java.util.Locale("ru", "RU"))
+            .withZone(java.time.ZoneId.systemDefault())
+            .format(instant)
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -644,4 +644,31 @@ object RussianStrings : AppStrings {
             .ofPattern("d MMMM yyyy, HH:mm:ss", java.util.Locale("ru", "RU"))
             .withZone(java.time.ZoneId.systemDefault())
             .format(instant)
+
+    override fun notifPackPreparing(packName: String)   = "Подготовка $packName"
+    override fun notifPackStage(stage: String)          = "Этап: $stage"
+    override fun notifPackSyncing(packName: String)     = "Синхронизация $packName"
+    override fun notifPackSyncBody(current: Int, total: Int, pctLabel: String) =
+        "$current/$total файлов, $pctLabel"
+    override val notifPackSyncIndeterminate             = "загрузка..."
+    override fun notifPackSyncPercent(pct: Int)         = "$pct%"
+    override fun notifPackRunning(packName: String)     = "$packName запущен"
+    override fun notifPackFailed(packName: String)      = "$packName не удалось запустить"
+    override fun notifPackSessionEnded(packName: String) = "Сессия $packName завершена"
+    override val notifActionShowConsole                 = "Открыть консоль"
+    override val notifActionStop                        = "Остановить"
+    override fun notifReasonExitCode(code: Int)         = "Игра завершилась с кодом $code"
+    override val notifReasonInternal                    = "Внутренняя ошибка"
+    override fun notifReasonInternalDetail(detail: String) = detail
+    override val notifReasonAuthFail                    = "Не удалось войти"
+    override fun notifReasonAuthFailDetail(detail: String) = detail
+    override val notifReasonOfflineNoClient             = "Файлы сборки отсутствуют на диске"
+    override val notifReasonOfflineNoManifest           = "Нет кэша манифеста; выйди в сеть один раз для синхронизации"
+    override val notifReasonTwoFactorExpired            = "Войди ещё раз, чтобы обновить учётные данные"
+
+    override val notifTimeNow                           = "сейчас"
+    override fun notifTimeSeconds(seconds: Long)        = "${seconds} с"
+    override fun notifTimeMinutes(minutes: Long)        = "${minutes} мин"
+    override fun notifTimeHours(hours: Long)            = "${hours} ч"
+    override fun notifTimeDays(days: Long)              = "${days} дн"
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Kind.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Kind.kt
@@ -1,0 +1,19 @@
+package hivens.ui.notifications
+
+import kotlin.time.Duration
+
+// Lifecycle band. Orthogonal to Severity. Decides whether the
+// notification auto-dismisses and roughly how the renderer should treat
+// it (Progress -> show indeterminate/animated UI, ActionRequired ->
+// expect actions, Sticky -> stays until the user dismisses).
+enum class Kind {
+    OneShot,
+    Progress,
+    Sticky,
+    ActionRequired;
+
+    fun autoDismissAfter(severity: Severity): Duration? = when (this) {
+        OneShot                              -> severity.defaultDuration
+        Progress, Sticky, ActionRequired     -> null
+    }
+}

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Notification.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Notification.kt
@@ -3,12 +3,6 @@ package hivens.ui.notifications
 import java.time.Instant
 import java.util.UUID
 
-sealed class AvatarSource {
-    data class Url(val url: String) : AvatarSource()
-    data class Glyph(val name: String) : AvatarSource()
-    data object Generic : AvatarSource()
-}
-
 // `id` is stable across i18n rebrands; tests + puppet observers key on it.
 data class NotifAction(
     val id: String,
@@ -31,7 +25,11 @@ data class NotificationEvent(
 data class NotificationGroup(
     val sourceKey: String,
     val sender: String,
-    val avatar: AvatarSource,
+    // Direct URL string; null = renderer falls back to a neutral
+    // placeholder. The previous sealed Url/Glyph/Generic carried
+    // future-extension shape without a real consumer; recover the
+    // indirection only when a second source type is needed.
+    val iconUrl: String?,
     val events: List<NotificationEvent>,
 ) {
     init {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Notification.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Notification.kt
@@ -15,6 +15,7 @@ data class NotifAction(
 data class NotificationEvent(
     val id: UUID,
     val severity: Severity,
+    val kind: Kind,
     val title: String,
     val body: String? = null,
     val progress: Float? = null,
@@ -43,6 +44,12 @@ data class NotificationGroup(
     // max across events, not events.first.severity -- a past Critical
     // must keep the group visually marked even after a later Info.
     val severity: Severity get() = events.maxOf { it.severity }
+
+    // Kind tracks the current lifecycle, so it follows the latest event.
+    // The auto-dismiss decision still consults `severity` (max across) so
+    // a group that ever held Critical keeps the longer window once it
+    // transitions to OneShot.
+    val kind: Kind get() = latest.kind
 
     val count: Int get() = events.size
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/NotificationCenter.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/NotificationCenter.kt
@@ -19,7 +19,7 @@ class NotificationCenter(
     fun push(
         sourceKey: String,
         sender: String,
-        avatar: AvatarSource,
+        iconUrl: String?,
         severity: Severity,
         title: String,
         body: String? = null,
@@ -42,16 +42,16 @@ class NotificationCenter(
                     NotificationGroup(
                         sourceKey = sourceKey,
                         sender    = sender,
-                        avatar    = avatar,
+                        iconUrl   = iconUrl,
                         events    = listOf(event),
                     )
                 ) + current
             } else {
                 val existing = current[existingIndex]
                 val merged = existing.copy(
-                    sender = sender,
-                    avatar = avatar,
-                    events = (listOf(event) + existing.events).take(historyPerGroup),
+                    sender  = sender,
+                    iconUrl = iconUrl,
+                    events  = (listOf(event) + existing.events).take(historyPerGroup),
                 )
                 val others = current.toMutableList().also { it.removeAt(existingIndex) }
                 listOf(merged) + others

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/NotificationCenter.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/NotificationCenter.kt
@@ -21,6 +21,7 @@ class NotificationCenter(
         sender: String,
         iconUrl: String?,
         severity: Severity,
+        kind: Kind,
         title: String,
         body: String? = null,
         progress: Float? = null,
@@ -29,6 +30,7 @@ class NotificationCenter(
         val event = NotificationEvent(
             id        = UUID.randomUUID(),
             severity  = severity,
+            kind      = kind,
             title     = title,
             body      = body,
             progress  = progress,

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Severity.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/Severity.kt
@@ -3,23 +3,23 @@ package hivens.ui.notifications
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+// Color/urgency band. Orthogonal to Kind, which controls lifecycle.
 // Ordering matters: NotificationGroup.severity is `events.maxOf { it.severity }`,
-// so a past Critical event stays visually marked as Critical even after a later
-// Info arrives -- prevents accidentally hiding hard failures that scrolled past.
+// so a past Critical stays visually marked even after a later Info -- the
+// loud severity never silently drops out of the user's view.
 enum class Severity {
     Info,
-    Progress,
     Success,
     Warn,
     Critical;
 
-    /** Null = sticky until manually dismissed or the next event in the group supersedes. */
-    val autoDismissAfter: Duration?
+    // Default OneShot window. Kind.OneShot consults this; sticky kinds
+    // (Progress, Sticky, ActionRequired) ignore it entirely.
+    val defaultDuration: Duration
         get() = when (this) {
             Info     -> 5.seconds
             Success  -> 4.seconds
-            Progress -> null
             Warn     -> 30.seconds
-            Critical -> null
+            Critical -> 30.seconds
         }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
@@ -6,6 +6,7 @@ import hivens.launcher.launch.LaunchState
 import hivens.launcher.launch.LauncherController
 import hivens.ui.notifications.IndicationCenter
 import hivens.ui.notifications.IndicationCenter.LaunchIndication
+import hivens.ui.notifications.Kind
 import hivens.ui.notifications.NotifAction
 import hivens.ui.notifications.NotificationCenter
 import hivens.ui.notifications.SessionRegistry
@@ -86,7 +87,8 @@ class PackLaunchDriver(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
             iconUrl   = iconUrlFor(pack),
-            severity  = Severity.Progress,
+            severity  = Severity.Info,
+            kind      = Kind.Progress,
             title     = "Preparing ${pack.displayName}",
             body      = "Stage: ${state.stage.name.lowercase()}",
             progress  = state.progress.coerceIn(0f, 1f),
@@ -111,7 +113,8 @@ class PackLaunchDriver(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
             iconUrl   = iconUrlFor(pack),
-            severity  = Severity.Progress,
+            severity  = Severity.Info,
+            kind      = Kind.Progress,
             title     = "Syncing ${pack.displayName}",
             body      = "${state.currentFileIdx}/${state.totalFiles} files, $displayPct",
             progress  = notifProgress,
@@ -132,6 +135,7 @@ class PackLaunchDriver(
             sender    = pack.displayName,
             iconUrl   = iconUrlFor(pack),
             severity  = Severity.Success,
+            kind      = Kind.ActionRequired,
             title     = "${pack.displayName} is running",
             body      = null,
             actions   = listOf(
@@ -149,6 +153,7 @@ class PackLaunchDriver(
             sender    = pack.displayName,
             iconUrl   = iconUrlFor(pack),
             severity  = Severity.Critical,
+            kind      = Kind.Sticky,
             title     = "${pack.displayName} failed to launch",
             body      = humanReason(reason),
             actions   = listOf(
@@ -167,6 +172,7 @@ class PackLaunchDriver(
             sender    = pack.displayName,
             iconUrl   = iconUrlFor(pack),
             severity  = Severity.Success,
+            kind      = Kind.OneShot,
             title     = "${pack.displayName} session ended",
             body      = null,
         )

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
@@ -4,7 +4,6 @@ import hivens.core.data.PackInstance
 import hivens.launcher.launch.LaunchError
 import hivens.launcher.launch.LaunchState
 import hivens.launcher.launch.LauncherController
-import hivens.ui.notifications.AvatarSource
 import hivens.ui.notifications.IndicationCenter
 import hivens.ui.notifications.IndicationCenter.LaunchIndication
 import hivens.ui.notifications.NotifAction
@@ -86,7 +85,7 @@ class PackLaunchDriver(
         notifications.push(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
-            avatar    = avatarFor(pack),
+            iconUrl   = iconUrlFor(pack),
             severity  = Severity.Progress,
             title     = "Preparing ${pack.displayName}",
             body      = "Stage: ${state.stage.name.lowercase()}",
@@ -111,7 +110,7 @@ class PackLaunchDriver(
         notifications.push(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
-            avatar    = avatarFor(pack),
+            iconUrl   = iconUrlFor(pack),
             severity  = Severity.Progress,
             title     = "Syncing ${pack.displayName}",
             body      = "${state.currentFileIdx}/${state.totalFiles} files, $displayPct",
@@ -131,7 +130,7 @@ class PackLaunchDriver(
         notifications.push(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
-            avatar    = avatarFor(pack),
+            iconUrl   = iconUrlFor(pack),
             severity  = Severity.Success,
             title     = "${pack.displayName} is running",
             body      = null,
@@ -148,7 +147,7 @@ class PackLaunchDriver(
         notifications.push(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
-            avatar    = avatarFor(pack),
+            iconUrl   = iconUrlFor(pack),
             severity  = Severity.Critical,
             title     = "${pack.displayName} failed to launch",
             body      = humanReason(reason),
@@ -166,7 +165,7 @@ class PackLaunchDriver(
         notifications.push(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
-            avatar    = avatarFor(pack),
+            iconUrl   = iconUrlFor(pack),
             severity  = Severity.Success,
             title     = "${pack.displayName} session ended",
             body      = null,
@@ -175,8 +174,9 @@ class PackLaunchDriver(
 
     private fun sourceKeyFor(pack: PackInstance): String = "pack:${pack.id}:launch"
 
-    // PackInstance does not carry icon_url yet; swap to Url when it does.
-    private fun avatarFor(pack: PackInstance): AvatarSource = AvatarSource.Generic
+    // PackInstance does not carry icon_url yet; returns null until
+    // project_pack_rich_metadata propagates summary.icon_url.
+    private fun iconUrlFor(pack: PackInstance): String? = null
 
     private fun humanReason(reason: LaunchError): String = when (reason) {
         is LaunchError.ExitCode       -> "Game exited with code ${reason.code}"

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/drivers/PackLaunchDriver.kt
@@ -4,6 +4,7 @@ import hivens.core.data.PackInstance
 import hivens.launcher.launch.LaunchError
 import hivens.launcher.launch.LaunchState
 import hivens.launcher.launch.LauncherController
+import hivens.ui.i18n.AppStrings
 import hivens.ui.notifications.IndicationCenter
 import hivens.ui.notifications.IndicationCenter.LaunchIndication
 import hivens.ui.notifications.Kind
@@ -34,6 +35,9 @@ class PackLaunchDriver(
     private val sessions: SessionRegistry,
     private val gameConsole: GameConsoleService,
     private val appScope: CoroutineScope,
+    // Read on each push so a locale change in Settings is picked up
+    // mid-launch without restarting the driver.
+    private val stringsProvider: () -> AppStrings,
 ) {
     private val log = LoggerFactory.getLogger(PackLaunchDriver::class.java)
 
@@ -82,6 +86,7 @@ class PackLaunchDriver(
     }
 
     private fun onPrepare(pack: PackInstance, state: LaunchState.Prepare) {
+        val s = stringsProvider()
         indications.setLaunchIndication(pack.id, LaunchIndication.Preparing)
         notifications.push(
             sourceKey = sourceKeyFor(pack),
@@ -89,8 +94,8 @@ class PackLaunchDriver(
             iconUrl   = iconUrlFor(pack),
             severity  = Severity.Info,
             kind      = Kind.Progress,
-            title     = "Preparing ${pack.displayName}",
-            body      = "Stage: ${state.stage.name.lowercase()}",
+            title     = s.notifPackPreparing(pack.displayName),
+            body      = s.notifPackStage(state.stage.name.lowercase()),
             progress  = state.progress.coerceIn(0f, 1f),
         )
     }
@@ -106,22 +111,25 @@ class PackLaunchDriver(
         }
         indications.setLaunchIndication(pack.id, LaunchIndication.Downloading(fraction))
 
+        val s = stringsProvider()
         val notifProgress: Float = fraction ?: Float.NaN
         val displayPct =
-            if (fraction == null) "downloading..." else "${(fraction * 100).toInt()}%"
+            if (fraction == null) s.notifPackSyncIndeterminate
+            else s.notifPackSyncPercent((fraction * 100).toInt())
         notifications.push(
             sourceKey = sourceKeyFor(pack),
             sender    = pack.displayName,
             iconUrl   = iconUrlFor(pack),
             severity  = Severity.Info,
             kind      = Kind.Progress,
-            title     = "Syncing ${pack.displayName}",
-            body      = "${state.currentFileIdx}/${state.totalFiles} files, $displayPct",
+            title     = s.notifPackSyncing(pack.displayName),
+            body      = s.notifPackSyncBody(state.currentFileIdx, state.totalFiles, displayPct),
             progress  = notifProgress,
         )
     }
 
     private fun onRunning(pack: PackInstance, state: LaunchState.GameRunning) {
+        val s = stringsProvider()
         indications.setLaunchIndication(pack.id, LaunchIndication.Running)
         sessions.register(
             packInstanceId  = pack.id,
@@ -136,16 +144,17 @@ class PackLaunchDriver(
             iconUrl   = iconUrlFor(pack),
             severity  = Severity.Success,
             kind      = Kind.ActionRequired,
-            title     = "${pack.displayName} is running",
+            title     = s.notifPackRunning(pack.displayName),
             body      = null,
             actions   = listOf(
-                NotifAction("show_console", "Show console") { gameConsole.show() },
-                NotifAction("abort", "Stop") { controller.abort() },
+                NotifAction("show_console", s.notifActionShowConsole) { gameConsole.show() },
+                NotifAction("abort",        s.notifActionStop)        { controller.abort() },
             ),
         )
     }
 
     private fun onError(pack: PackInstance, reason: LaunchError) {
+        val s = stringsProvider()
         indications.setLaunchIndication(pack.id, LaunchIndication.Failed)
         sessions.unregister(pack.id)
         notifications.push(
@@ -154,15 +163,16 @@ class PackLaunchDriver(
             iconUrl   = iconUrlFor(pack),
             severity  = Severity.Critical,
             kind      = Kind.Sticky,
-            title     = "${pack.displayName} failed to launch",
-            body      = humanReason(reason),
+            title     = s.notifPackFailed(pack.displayName),
+            body      = humanReason(reason, s),
             actions   = listOf(
-                NotifAction("show_console", "Show console") { gameConsole.show() },
+                NotifAction("show_console", s.notifActionShowConsole) { gameConsole.show() },
             ),
         )
     }
 
     private fun onIdle(pack: PackInstance) {
+        val s = stringsProvider()
         // Idle after non-Idle = clean exit (code 0). Group history stays
         // so the user can scroll back through the run.
         indications.setLaunchIndication(pack.id, null)
@@ -173,7 +183,7 @@ class PackLaunchDriver(
             iconUrl   = iconUrlFor(pack),
             severity  = Severity.Success,
             kind      = Kind.OneShot,
-            title     = "${pack.displayName} session ended",
+            title     = s.notifPackSessionEnded(pack.displayName),
             body      = null,
         )
     }
@@ -184,12 +194,16 @@ class PackLaunchDriver(
     // project_pack_rich_metadata propagates summary.icon_url.
     private fun iconUrlFor(pack: PackInstance): String? = null
 
-    private fun humanReason(reason: LaunchError): String = when (reason) {
-        is LaunchError.ExitCode       -> "Game exited with code ${reason.code}"
-        is LaunchError.Internal       -> reason.message.ifBlank { "Internal error" }
-        is LaunchError.AuthFail       -> reason.cause?.ifBlank { null } ?: "Authentication failed"
-        LaunchError.OfflineNoClient   -> "Pack files missing on disk"
-        LaunchError.OfflineNoManifest -> "No cached manifest; go online once to sync"
-        LaunchError.TwoFactorExpired  -> "Sign in again to refresh credentials"
+    private fun humanReason(reason: LaunchError, s: AppStrings): String = when (reason) {
+        is LaunchError.ExitCode       -> s.notifReasonExitCode(reason.code)
+        is LaunchError.Internal       -> reason.message.ifBlank { null }
+                                            ?.let { s.notifReasonInternalDetail(it) }
+                                            ?: s.notifReasonInternal
+        is LaunchError.AuthFail       -> reason.cause?.ifBlank { null }
+                                            ?.let { s.notifReasonAuthFailDetail(it) }
+                                            ?: s.notifReasonAuthFail
+        LaunchError.OfflineNoClient   -> s.notifReasonOfflineNoClient
+        LaunchError.OfflineNoManifest -> s.notifReasonOfflineNoManifest
+        LaunchError.TwoFactorExpired  -> s.notifReasonTwoFactorExpired
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import hivens.ui.i18n.AppStrings
 import hivens.ui.i18n.LocalStrings
 import hivens.ui.notifications.Kind
 import hivens.ui.notifications.NotifAction
@@ -167,7 +168,7 @@ private fun HeaderRow(
             tooltipPlacement = TooltipPlacement.CursorPoint(offset = DpOffset(0.dp, 12.dp)),
         ) {
             Text(
-                text  = relativeTime(group.latest.createdAt, now),
+                text  = relativeTime(group.latest.createdAt, now, strings),
                 style = MaterialTheme.typography.labelSmall,
                 color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
             )
@@ -267,6 +268,7 @@ private fun ActionsRow(actions: List<NotifAction>, onDismiss: () -> Unit) {
 
 @Composable
 private fun HistoryRow(event: NotificationEvent, now: Instant) {
+    val strings = LocalStrings.current
     Row(
         modifier          = Modifier.fillMaxWidth().padding(vertical = 3.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -279,7 +281,7 @@ private fun HistoryRow(event: NotificationEvent, now: Instant) {
         )
         Spacer(Modifier.width(6.dp))
         Text(
-            text  = relativeTime(event.createdAt, now),
+            text  = relativeTime(event.createdAt, now, strings),
             style = MaterialTheme.typography.labelSmall,
             color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.55f),
         )
@@ -323,13 +325,13 @@ private fun severityAccent(severity: Severity, kind: Kind, colors: CelestiaColor
     Severity.Critical -> colors.criticalAccent
 }
 
-private fun relativeTime(created: Instant, now: Instant): String {
+private fun relativeTime(created: Instant, now: Instant, strings: AppStrings): String {
     val seconds = Duration.between(created, now).seconds
     return when {
-        seconds < 5         -> "Now"
-        seconds < 60        -> "${seconds}s"
-        seconds < 3600      -> "${seconds / 60}m"
-        seconds < 86_400    -> "${seconds / 3600}h"
-        else                -> "${seconds / 86_400}d"
+        seconds < 5      -> strings.notifTimeNow
+        seconds < 60     -> strings.notifTimeSeconds(seconds)
+        seconds < 3600   -> strings.notifTimeMinutes(seconds / 60)
+        seconds < 86_400 -> strings.notifTimeHours(seconds / 3600)
+        else             -> strings.notifTimeDays(seconds / 86_400)
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
@@ -54,6 +54,7 @@ import hivens.ui.notifications.NotifAction
 import hivens.ui.notifications.NotificationEvent
 import hivens.ui.notifications.NotificationGroup
 import hivens.ui.notifications.Severity
+import hivens.ui.theme.CelestiaColors
 import hivens.ui.theme.CelestiaTheme
 import java.time.Duration
 import java.time.Instant
@@ -69,7 +70,8 @@ fun NotificationCard(
     // pushed Critical inherits the user's prior expanded=true and
     // appears already opened into stale history.
     var expanded by remember(group.sourceKey, group.count) { mutableStateOf(false) }
-    val accentColor = severityAccent(group.severity)
+    val palette = CelestiaTheme.colors
+    val accentColor = severityAccent(group.severity, palette)
     val accentAlpha = if (group.severity == Severity.Critical) criticalPulse() else 1f
 
     Box(
@@ -309,12 +311,14 @@ private fun criticalPulse(): Float {
     return v
 }
 
-private fun severityAccent(severity: Severity): Color = when (severity) {
+// Routes Severity onto the active palette. Info has no stripe -- caller
+// elides the side-bar -- so Color.Transparent is the safe sentinel.
+private fun severityAccent(severity: Severity, colors: CelestiaColors): Color = when (severity) {
     Severity.Info     -> Color.Transparent
-    Severity.Progress -> Color(0xFF6A84FF)
-    Severity.Success  -> Color(0xFF4FC76E)
-    Severity.Warn     -> Color(0xFFE0B341)
-    Severity.Critical -> Color(0xFFD8484A)
+    Severity.Progress -> colors.progressAccent
+    Severity.Success  -> colors.success
+    Severity.Warn     -> colors.warnAccent
+    Severity.Critical -> colors.criticalAccent
 }
 
 private fun relativeTime(created: Instant, now: Instant): String {

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import hivens.ui.i18n.LocalStrings
+import hivens.ui.notifications.Kind
 import hivens.ui.notifications.NotifAction
 import hivens.ui.notifications.NotificationEvent
 import hivens.ui.notifications.NotificationGroup
@@ -71,7 +72,7 @@ fun NotificationCard(
     // appears already opened into stale history.
     var expanded by remember(group.sourceKey, group.count) { mutableStateOf(false) }
     val palette = CelestiaTheme.colors
-    val accentColor = severityAccent(group.severity, palette)
+    val accentColor = severityAccent(group.severity, group.kind, palette)
     val accentAlpha = if (group.severity == Severity.Critical) criticalPulse() else 1f
 
     Box(
@@ -81,7 +82,7 @@ fun NotificationCard(
             .background(CelestiaTheme.colors.surface)
     ) {
         Row(modifier = Modifier.fillMaxWidth()) {
-            if (group.severity != Severity.Info) {
+            if (accentColor != Color.Transparent) {
                 Box(
                     modifier = Modifier
                         .width(if (group.severity == Severity.Critical) 4.dp else 3.dp)
@@ -311,11 +312,12 @@ private fun criticalPulse(): Float {
     return v
 }
 
-// Routes Severity onto the active palette. Info has no stripe -- caller
-// elides the side-bar -- so Color.Transparent is the safe sentinel.
-private fun severityAccent(severity: Severity, colors: CelestiaColors): Color = when (severity) {
-    Severity.Info     -> Color.Transparent
-    Severity.Progress -> colors.progressAccent
+// Routes (Severity, Kind) onto the active palette. Severity drives the
+// color band; Kind.Progress promotes Info to the progress accent so the
+// card visibly tracks in-flight work. Info+non-Progress has no stripe --
+// caller elides the side-bar -- so Color.Transparent is the safe sentinel.
+private fun severityAccent(severity: Severity, kind: Kind, colors: CelestiaColors): Color = when (severity) {
+    Severity.Info     -> if (kind == Kind.Progress) colors.progressAccent else Color.Transparent
     Severity.Success  -> colors.success
     Severity.Warn     -> colors.warnAccent
     Severity.Critical -> colors.criticalAccent

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
@@ -173,6 +173,10 @@ private fun HeaderRow(
                 color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
             )
         }
+        // Chevron is conditional on count; close is unconditional. Sticky
+        // kinds (Sticky, ActionRequired) never auto-dismiss, so grouped
+        // cards without a close leave the user trapped -- the action
+        // buttons all have side effects, none of them just "close this".
         if (group.count > 1) {
             Spacer(Modifier.width(6.dp))
             // IconButton wraps the row so screen readers / keyboards see a
@@ -194,16 +198,15 @@ private fun HeaderRow(
                     )
                 }
             }
-        } else {
-            Spacer(Modifier.width(2.dp))
-            IconButton(onClick = onDismiss, modifier = Modifier.size(20.dp)) {
-                Icon(
-                    imageVector       = Icons.Default.Close,
-                    contentDescription = strings.notificationDismiss,
-                    modifier          = Modifier.size(14.dp),
-                    tint              = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
-                )
-            }
+        }
+        Spacer(Modifier.width(2.dp))
+        IconButton(onClick = onDismiss, modifier = Modifier.size(20.dp)) {
+            Icon(
+                imageVector       = Icons.Default.Close,
+                contentDescription = strings.notificationDismiss,
+                modifier          = Modifier.size(14.dp),
+                tint              = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
+            )
         }
     }
 }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationCard.kt
@@ -8,16 +8,18 @@ import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.TooltipArea
+import androidx.compose.foundation.TooltipPlacement
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -32,6 +34,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -44,7 +47,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import hivens.ui.i18n.LocalStrings
 import hivens.ui.notifications.NotifAction
 import hivens.ui.notifications.NotificationEvent
 import hivens.ui.notifications.NotificationGroup
@@ -118,6 +123,7 @@ fun NotificationCard(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun HeaderRow(
     group: NotificationGroup,
@@ -126,6 +132,7 @@ private fun HeaderRow(
     onToggle: () -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val strings = LocalStrings.current
     Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
         AvatarSlot(group)
         Spacer(Modifier.width(10.dp))
@@ -136,35 +143,59 @@ private fun HeaderRow(
             fontWeight = FontWeight.Medium,
             modifier   = Modifier.weight(1f),
         )
-        Text(
-            text  = relativeTime(group.latest.createdAt, now),
-            style = MaterialTheme.typography.labelSmall,
-            color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
-        )
+        // Hover-tooltip with absolute date; the inline label stays relative
+        // ("Now" / "5s" / "1d") so the card reads quickly. A 1d label loses
+        // the exact "yesterday at HH:mm" detail; the tooltip recovers it.
+        TooltipArea(
+            tooltip = {
+                Surface(
+                    color = CelestiaTheme.colors.surface,
+                    shape = RoundedCornerShape(4.dp),
+                ) {
+                    Text(
+                        text     = strings.notificationAbsoluteTime(group.latest.createdAt),
+                        style    = MaterialTheme.typography.labelSmall,
+                        color    = CelestiaTheme.colors.textPrimary,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+                    )
+                }
+            },
+            delayMillis = 400,
+            tooltipPlacement = TooltipPlacement.CursorPoint(offset = DpOffset(0.dp, 12.dp)),
+        ) {
+            Text(
+                text  = relativeTime(group.latest.createdAt, now),
+                style = MaterialTheme.typography.labelSmall,
+                color = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
+            )
+        }
         if (group.count > 1) {
             Spacer(Modifier.width(6.dp))
-            Row(
-                modifier = Modifier.clickable(onClick = onToggle),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text  = group.count.toString(),
-                    style = MaterialTheme.typography.labelSmall,
-                    color = CelestiaTheme.colors.textSecondary,
-                )
-                Icon(
-                    imageVector       = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                    contentDescription = null,
-                    modifier          = Modifier.size(16.dp),
-                    tint              = CelestiaTheme.colors.textSecondary,
-                )
+            // IconButton wraps the row so screen readers / keyboards see a
+            // single focusable target with a stable contentDescription; the
+            // expanded label flips so screen-reader output reflects state.
+            IconButton(onClick = onToggle, modifier = Modifier.size(28.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text  = group.count.toString(),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = CelestiaTheme.colors.textSecondary,
+                    )
+                    Icon(
+                        imageVector       = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
+                        contentDescription = if (expanded) strings.notificationCollapseHistory
+                                             else strings.notificationExpandHistory,
+                        modifier          = Modifier.size(16.dp),
+                        tint              = CelestiaTheme.colors.textSecondary,
+                    )
+                }
             }
         } else {
             Spacer(Modifier.width(2.dp))
             IconButton(onClick = onDismiss, modifier = Modifier.size(20.dp)) {
                 Icon(
                     imageVector       = Icons.Default.Close,
-                    contentDescription = null,
+                    contentDescription = strings.notificationDismiss,
                     modifier          = Modifier.size(14.dp),
                     tint              = CelestiaTheme.colors.textSecondary.copy(alpha = 0.6f),
                 )

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationStack.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationStack.kt
@@ -59,7 +59,7 @@ fun NotificationStack(center: NotificationCenter = koinInject()) {
 
     LaunchedEffect(clockTick, groups) {
         groups.forEach { group ->
-            val window = group.severity.autoDismissAfter ?: return@forEach
+            val window = group.kind.autoDismissAfter(group.severity) ?: return@forEach
             val age = java.time.Duration.between(group.latest.createdAt, clockTick)
             if (age.toMillis() >= window.inWholeMilliseconds) {
                 center.dismiss(group.sourceKey)

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationStack.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/notifications/render/NotificationStack.kt
@@ -3,12 +3,20 @@ package hivens.ui.notifications.render
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.material3.Text
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -20,7 +28,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import hivens.ui.i18n.LocalStrings
 import hivens.ui.notifications.NotificationCenter
 import hivens.ui.theme.CelestiaTheme
 import kotlinx.coroutines.delay
@@ -58,12 +69,27 @@ fun NotificationStack(center: NotificationCenter = koinInject()) {
 
     if (!hasGroups) return
 
+    val strings = LocalStrings.current
+    // Overflow expansion: click "+N more" to show every group instead of
+    // just the first MAX_VISIBLE. Stays scoped to this composition --
+    // dismissing past the cap rolls back to the collapsed view.
+    var overflowExpanded by remember { mutableStateOf(false) }
+    val overflow = (groups.size - MAX_VISIBLE).coerceAtLeast(0)
+    if (overflow == 0 && overflowExpanded) overflowExpanded = false
+
     Box(modifier = Modifier.fillMaxSize().padding(top = 16.dp, end = 16.dp)) {
+        // heightIn cap + verticalScroll let the expanded list breathe up to
+        // half the screen without pushing the stack off the bottom edge.
+        val outerModifier = Modifier
+            .align(Alignment.TopEnd)
+            .widthIn(max = 440.dp)
+            .heightIn(max = 720.dp)
+            .verticalScroll(rememberScrollState())
         Column(
-            modifier              = Modifier.align(Alignment.TopEnd).widthIn(max = 440.dp),
-            verticalArrangement   = Arrangement.spacedBy(8.dp),
+            modifier            = outerModifier,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
-            val visible = groups.take(MAX_VISIBLE)
+            val visible = if (overflowExpanded) groups else groups.take(MAX_VISIBLE)
             visible.forEach { group ->
                 AnimatedVisibility(
                     visible = true,
@@ -77,12 +103,24 @@ fun NotificationStack(center: NotificationCenter = koinInject()) {
                     )
                 }
             }
-            if (groups.size > MAX_VISIBLE) {
+            if (overflow > 0) {
+                val label =
+                    if (overflowExpanded) strings.notificationCollapseHistory
+                    else strings.notificationShowMore(overflow)
                 Text(
-                    text     = "+${groups.size - MAX_VISIBLE} more",
-                    style    = MaterialTheme.typography.labelSmall,
-                    color    = CelestiaTheme.colors.textSecondary,
-                    modifier = Modifier.padding(top = 4.dp, end = 4.dp).align(Alignment.End),
+                    text       = label,
+                    style      = MaterialTheme.typography.labelSmall,
+                    color      = CelestiaTheme.colors.textSecondary,
+                    fontWeight = FontWeight.Medium,
+                    textDecoration = TextDecoration.Underline,
+                    modifier   = Modifier
+                        .align(Alignment.End)
+                        .clickable { overflowExpanded = !overflowExpanded }
+                        .semantics {
+                            role = Role.Button
+                            contentDescription = label
+                        }
+                        .padding(top = 4.dp, end = 4.dp),
                 )
             }
         }

--- a/client-ui/src/desktopMain/kotlin/hivens/ui/theme/CelestiaTheme.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/theme/CelestiaTheme.kt
@@ -29,7 +29,13 @@ data class CelestiaColors(
     val glassBackground: Color,
     val glassAlpha: Float,
     val success: Color,
-    val outline: Color
+    val outline: Color,
+    // Severity accents for notifications. `success` already doubles as
+    // Severity.Success; the other three are new tokens so each accent can
+    // drift per palette without dragging unrelated UI.
+    val progressAccent: Color,
+    val warnAccent: Color,
+    val criticalAccent: Color,
 )
 
 private val DarkColorPalette = CelestiaColors(
@@ -49,7 +55,10 @@ private val DarkColorPalette = CelestiaColors(
     glassBackground = Color(0xFF000000), // Base for glass
     glassAlpha = 0.60f, // Glass transparency (dark)
     success = Color(0xFF4CAF50),
-    outline = Color(0xFF444444)
+    outline = Color(0xFF444444),
+    progressAccent = Color(0xFF6A84FF),
+    warnAccent     = Color(0xFFE0B341),
+    criticalAccent = Color(0xFFD8484A),
 )
 
 private val LightColorPalette = CelestiaColors(
@@ -69,7 +78,10 @@ private val LightColorPalette = CelestiaColors(
     glassBackground = Color(0xFFFFFFFF),
     glassAlpha = 0.65f,                // Slightly more opacity for readability
     success = Color(0xFF66BB6A),
-    outline = Color(0xFFCCCCCC)
+    outline = Color(0xFFCCCCCC),
+    progressAccent = Color(0xFF3C5BD9),
+    warnAccent     = Color(0xFFB37A0E),
+    criticalAccent = Color(0xFFB3262A),
 )
 
 val LocalCelestiaColors = staticCompositionLocalOf<CelestiaColors> {
@@ -145,6 +157,9 @@ fun CelestiaTheme(
     val animatedOutline by animateColorAsState(targetColors.outline, colorAnimSpec)
     val animatedGlassBg by animateColorAsState(targetColors.glassBackground, colorAnimSpec)
     val animatedGlassAlpha by animateFloatAsState(targetColors.glassAlpha, TweenSpec(animDurationMs))
+    val animatedProgressAccent by animateColorAsState(targetColors.progressAccent, colorAnimSpec)
+    val animatedWarnAccent by animateColorAsState(targetColors.warnAccent, colorAnimSpec)
+    val animatedCriticalAccent by animateColorAsState(targetColors.criticalAccent, colorAnimSpec)
 
     // Assembling an animated palette
     val animatedPalette = targetColors.copy(
@@ -159,7 +174,10 @@ fun CelestiaTheme(
         textSecondary = animatedTextSecondary,
         outline = animatedOutline,
         glassBackground = animatedGlassBg,
-        glassAlpha = animatedGlassAlpha
+        glassAlpha = animatedGlassAlpha,
+        progressAccent = animatedProgressAccent,
+        warnAccent = animatedWarnAccent,
+        criticalAccent = animatedCriticalAccent,
     )
 
     // M3 ColorScheme

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/NotificationCenterTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/NotificationCenterTest.kt
@@ -21,7 +21,8 @@ class NotificationCenterTest {
             sourceKey = "pack:Industrial:launch",
             sender    = "Industrial",
             iconUrl   = null,
-            severity  = Severity.Progress,
+            severity  = Severity.Info,
+            kind      = Kind.Progress,
             title     = "Preparing",
         )
 
@@ -32,17 +33,18 @@ class NotificationCenterTest {
         assertEquals("Industrial", g.sender)
         assertEquals(1, g.count)
         assertEquals("Preparing", g.latest.title)
-        assertEquals(Severity.Progress, g.latest.severity)
+        assertEquals(Severity.Info, g.latest.severity)
+        assertEquals(Kind.Progress, g.latest.kind)
     }
 
     @Test
     fun `re-push with same sourceKey appends event to existing group`() = runTest {
         val center = newCenter()
-        center.push("pack:X", "X", null, Severity.Progress, "Preparing")
+        center.push("pack:X", "X", null, Severity.Info, Kind.Progress, "Preparing")
         clock.advance(seconds = 2)
-        center.push("pack:X", "X", null, Severity.Progress, "Downloading 47%")
+        center.push("pack:X", "X", null, Severity.Info, Kind.Progress, "Downloading 47%")
         clock.advance(seconds = 5)
-        center.push("pack:X", "X", null, Severity.Success, "Done")
+        center.push("pack:X", "X", null, Severity.Success, Kind.OneShot, "Done")
 
         val g = center.groups.first().single()
         assertEquals(3, g.count)
@@ -53,9 +55,9 @@ class NotificationCenterTest {
     @Test
     fun `group history is capped at historyPerGroup`() = runTest {
         val center = NotificationCenter(historyPerGroup = 2, clock = clock::now)
-        center.push("k", "X", null, Severity.Info, "e1")
-        center.push("k", "X", null, Severity.Info, "e2")
-        center.push("k", "X", null, Severity.Info, "e3")
+        center.push("k", "X", null, Severity.Info, Kind.OneShot, "e1")
+        center.push("k", "X", null, Severity.Info, Kind.OneShot, "e2")
+        center.push("k", "X", null, Severity.Info, Kind.OneShot, "e3")
 
         val g = center.groups.first().single()
         assertEquals(2, g.count, "oldest event dropped at the cap")
@@ -66,25 +68,35 @@ class NotificationCenterTest {
     @Test
     fun `severity is max across events`() = runTest {
         val center = newCenter()
-        center.push("k", "X", null, Severity.Info, "info")
-        center.push("k", "X", null, Severity.Critical, "boom")
+        center.push("k", "X", null, Severity.Info,     Kind.OneShot, "info")
+        center.push("k", "X", null, Severity.Critical, Kind.Sticky,  "boom")
         // A later non-critical event must NOT visually downgrade the
         // group -- max wins so the user does not lose track of the
         // earlier critical when scanning the stack.
-        center.push("k", "X", null, Severity.Info, "muted recovery")
+        center.push("k", "X", null, Severity.Info,     Kind.OneShot, "muted recovery")
 
         val g = center.groups.first().single()
         assertEquals(Severity.Critical, g.severity)
     }
 
     @Test
+    fun `kind follows the latest event, not the max`() = runTest {
+        val center = newCenter()
+        center.push("k", "X", null, Severity.Info,    Kind.Progress, "downloading")
+        center.push("k", "X", null, Severity.Success, Kind.OneShot,  "done")
+
+        val g = center.groups.first().single()
+        assertEquals(Kind.OneShot, g.kind, "lifecycle tracks current state")
+    }
+
+    @Test
     fun `touched group floats to the front of the stack`() = runTest {
         val center = newCenter()
-        center.push("k1", "First",  null, Severity.Info, "1")
-        center.push("k2", "Second", null, Severity.Info, "2")
-        center.push("k3", "Third",  null, Severity.Info, "3")
+        center.push("k1", "First",  null, Severity.Info, Kind.OneShot, "1")
+        center.push("k2", "Second", null, Severity.Info, Kind.OneShot, "2")
+        center.push("k3", "Third",  null, Severity.Info, Kind.OneShot, "3")
         // Touch k1 -- it should float to the top, k3 / k2 follow.
-        center.push("k1", "First",  null, Severity.Info, "1 again")
+        center.push("k1", "First",  null, Severity.Info, Kind.OneShot, "1 again")
 
         val keys = center.groups.first().map { it.sourceKey }
         assertEquals(listOf("k1", "k3", "k2"), keys)
@@ -93,7 +105,7 @@ class NotificationCenterTest {
     @Test
     fun `dismiss removes the group and is idempotent on unknown key`() = runTest {
         val center = newCenter()
-        center.push("k", "X", null, Severity.Info, "hi")
+        center.push("k", "X", null, Severity.Info, Kind.OneShot, "hi")
         center.dismiss("k")
         assertTrue(center.groups.first().isEmpty())
 
@@ -105,20 +117,22 @@ class NotificationCenterTest {
     @Test
     fun `clear wipes the stack`() = runTest {
         val center = newCenter()
-        center.push("a", "A", null, Severity.Info, "1")
-        center.push("b", "B", null, Severity.Info, "2")
+        center.push("a", "A", null, Severity.Info, Kind.OneShot, "1")
+        center.push("b", "B", null, Severity.Info, Kind.OneShot, "2")
         center.clear()
         assertTrue(center.groups.first().isEmpty())
     }
 
     @Test
-    fun `severity auto-dismiss policy is consistent with the docs`() {
+    fun `kind auto-dismiss policy is consistent with the docs`() {
         // The renderer + driver depend on these values; lock them in.
-        assertNull(Severity.Progress.autoDismissAfter)
-        assertNull(Severity.Critical.autoDismissAfter)
-        assertEquals(5, Severity.Info.autoDismissAfter?.inWholeSeconds)
-        assertEquals(4, Severity.Success.autoDismissAfter?.inWholeSeconds)
-        assertEquals(30, Severity.Warn.autoDismissAfter?.inWholeSeconds)
+        assertNull(Kind.Progress.autoDismissAfter(Severity.Info))
+        assertNull(Kind.Sticky.autoDismissAfter(Severity.Critical))
+        assertNull(Kind.ActionRequired.autoDismissAfter(Severity.Success))
+        assertEquals(5,  Kind.OneShot.autoDismissAfter(Severity.Info)?.inWholeSeconds)
+        assertEquals(4,  Kind.OneShot.autoDismissAfter(Severity.Success)?.inWholeSeconds)
+        assertEquals(30, Kind.OneShot.autoDismissAfter(Severity.Warn)?.inWholeSeconds)
+        assertEquals(30, Kind.OneShot.autoDismissAfter(Severity.Critical)?.inWholeSeconds)
     }
 
     private class FixedClock(start: Instant = Instant.parse("2026-05-26T00:00:00Z")) {

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/NotificationCenterTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/NotificationCenterTest.kt
@@ -20,7 +20,7 @@ class NotificationCenterTest {
         center.push(
             sourceKey = "pack:Industrial:launch",
             sender    = "Industrial",
-            avatar    = AvatarSource.Generic,
+            iconUrl   = null,
             severity  = Severity.Progress,
             title     = "Preparing",
         )
@@ -38,11 +38,11 @@ class NotificationCenterTest {
     @Test
     fun `re-push with same sourceKey appends event to existing group`() = runTest {
         val center = newCenter()
-        center.push("pack:X", "X", AvatarSource.Generic, Severity.Progress, "Preparing")
+        center.push("pack:X", "X", null, Severity.Progress, "Preparing")
         clock.advance(seconds = 2)
-        center.push("pack:X", "X", AvatarSource.Generic, Severity.Progress, "Downloading 47%")
+        center.push("pack:X", "X", null, Severity.Progress, "Downloading 47%")
         clock.advance(seconds = 5)
-        center.push("pack:X", "X", AvatarSource.Generic, Severity.Success, "Done")
+        center.push("pack:X", "X", null, Severity.Success, "Done")
 
         val g = center.groups.first().single()
         assertEquals(3, g.count)
@@ -53,9 +53,9 @@ class NotificationCenterTest {
     @Test
     fun `group history is capped at historyPerGroup`() = runTest {
         val center = NotificationCenter(historyPerGroup = 2, clock = clock::now)
-        center.push("k", "X", AvatarSource.Generic, Severity.Info, "e1")
-        center.push("k", "X", AvatarSource.Generic, Severity.Info, "e2")
-        center.push("k", "X", AvatarSource.Generic, Severity.Info, "e3")
+        center.push("k", "X", null, Severity.Info, "e1")
+        center.push("k", "X", null, Severity.Info, "e2")
+        center.push("k", "X", null, Severity.Info, "e3")
 
         val g = center.groups.first().single()
         assertEquals(2, g.count, "oldest event dropped at the cap")
@@ -66,12 +66,12 @@ class NotificationCenterTest {
     @Test
     fun `severity is max across events`() = runTest {
         val center = newCenter()
-        center.push("k", "X", AvatarSource.Generic, Severity.Info, "info")
-        center.push("k", "X", AvatarSource.Generic, Severity.Critical, "boom")
+        center.push("k", "X", null, Severity.Info, "info")
+        center.push("k", "X", null, Severity.Critical, "boom")
         // A later non-critical event must NOT visually downgrade the
         // group -- max wins so the user does not lose track of the
         // earlier critical when scanning the stack.
-        center.push("k", "X", AvatarSource.Generic, Severity.Info, "muted recovery")
+        center.push("k", "X", null, Severity.Info, "muted recovery")
 
         val g = center.groups.first().single()
         assertEquals(Severity.Critical, g.severity)
@@ -80,11 +80,11 @@ class NotificationCenterTest {
     @Test
     fun `touched group floats to the front of the stack`() = runTest {
         val center = newCenter()
-        center.push("k1", "First",  AvatarSource.Generic, Severity.Info, "1")
-        center.push("k2", "Second", AvatarSource.Generic, Severity.Info, "2")
-        center.push("k3", "Third",  AvatarSource.Generic, Severity.Info, "3")
+        center.push("k1", "First",  null, Severity.Info, "1")
+        center.push("k2", "Second", null, Severity.Info, "2")
+        center.push("k3", "Third",  null, Severity.Info, "3")
         // Touch k1 -- it should float to the top, k3 / k2 follow.
-        center.push("k1", "First",  AvatarSource.Generic, Severity.Info, "1 again")
+        center.push("k1", "First",  null, Severity.Info, "1 again")
 
         val keys = center.groups.first().map { it.sourceKey }
         assertEquals(listOf("k1", "k3", "k2"), keys)
@@ -93,11 +93,10 @@ class NotificationCenterTest {
     @Test
     fun `dismiss removes the group and is idempotent on unknown key`() = runTest {
         val center = newCenter()
-        center.push("k", "X", AvatarSource.Generic, Severity.Info, "hi")
+        center.push("k", "X", null, Severity.Info, "hi")
         center.dismiss("k")
         assertTrue(center.groups.first().isEmpty())
 
-        // Second dismiss of the same (now-absent) key is a no-op.
         center.dismiss("k")
         center.dismiss("never-existed")
         assertTrue(center.groups.first().isEmpty())
@@ -106,8 +105,8 @@ class NotificationCenterTest {
     @Test
     fun `clear wipes the stack`() = runTest {
         val center = newCenter()
-        center.push("a", "A", AvatarSource.Generic, Severity.Info, "1")
-        center.push("b", "B", AvatarSource.Generic, Severity.Info, "2")
+        center.push("a", "A", null, Severity.Info, "1")
+        center.push("b", "B", null, Severity.Info, "2")
         center.clear()
         assertTrue(center.groups.first().isEmpty())
     }

--- a/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/drivers/PackLaunchDriverTest.kt
+++ b/client-ui/src/desktopTest/kotlin/hivens/ui/notifications/drivers/PackLaunchDriverTest.kt
@@ -84,6 +84,6 @@ class PackLaunchDriverTest {
         // after subsequent Info/Success arrivals.
         assertTrue(Severity.Critical.ordinal > Severity.Warn.ordinal)
         assertTrue(Severity.Critical.ordinal > Severity.Success.ordinal)
-        assertTrue(Severity.Critical.ordinal > Severity.Progress.ordinal)
+        assertTrue(Severity.Critical.ordinal > Severity.Info.ordinal)
     }
 }


### PR DESCRIPTION
## Summary

Five batches on top of the notification subsystem MVP (#253). Each is a separate commit on the branch so the diff is easy to bisect.

- **A** a11y + UX micro-fixes: contentDescription on chevron/close, hover-tooltip with absolute date, clickable "+N more" overflow with scroll cap.
- **B** AvatarSource rollback. The sealed Url/Glyph/Generic shape was speculative -- only Generic was wired. Reverted to `iconUrl: String?`; recover the indirection when pack rich-metadata actually carries icons.
- **C** Severity color tokens. `progressAccent` / `warnAccent` / `criticalAccent` added to CelestiaColors, plumbed through the animateColorAsState pipeline. Light + Dark palettes calibrated for contrast. NotificationCard reads from the palette, no more hard-coded hex.
- **D** Severity vs Kind split. Severity collapses to color bands (Info, Success, Warn, Critical); new Kind enum carries lifecycle (OneShot, Progress, Sticky, ActionRequired). Auto-dismiss moves to `Kind.autoDismissAfter(severity)`. Group severity stays max-wins; group kind tracks the latest event.
- **E** i18n. PackLaunchDriver no longer emits English literals; new `notifPack*` / `notifAction*` / `notifReason*` / `notifTime*` keys land in en/ru/de. `stringsProvider` lambda injected via Koin reads settings live so a locale change in Settings propagates mid-launch.

## Test plan

- [x] :client-ui:compileKotlinDesktop green
- [x] :client-ui:desktopTest green
- [ ] Smoke: launch a pack under each locale (ru/en/de), confirm Prepare -> Sync -> Running -> Idle strings match
- [ ] Smoke: trigger a failed launch, confirm Critical stays sticky and reason text is localized
- [ ] Visual: confirm progress bar / stripe color matches palette under Celestia, Brut, and a Custom theme