### PR TITLE
fix(i18n): drop deprecated Locale(String, String) constructor

### DIFF
--- a/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
+++ b/client-ui/src/desktopMain/kotlin/hivens/ui/i18n/RussianStrings.kt
@@ -641,7 +641,7 @@ object RussianStrings : AppStrings {
     override fun notificationShowMore(count: Int)               = "ещё $count"
     override fun notificationAbsoluteTime(instant: java.time.Instant): String =
         java.time.format.DateTimeFormatter
-            .ofPattern("d MMMM yyyy, HH:mm:ss", java.util.Locale("ru", "RU"))
+            .ofPattern("d MMMM yyyy, HH:mm:ss", java.util.Locale.of("ru", "RU"))
             .withZone(java.time.ZoneId.systemDefault())
             .format(instant)
 


### PR DESCRIPTION
One-line cleanup of the kotlinc warning surfaced by manual smoke on stable:

\`\`\`
w: RussianStrings.kt:644 'constructor(p0: String!, p1: String!): Locale' is deprecated.
\`\`\`

\`Locale.of(...)\` (JDK 19+) replaces the deprecated two-arg constructor. Project JDK floor is 25 per the root build, so the static factory is always available.

## Test plan

- [x] \`:client-ui:compileKotlinDesktop\` -- no Locale deprecation in output